### PR TITLE
Fix force move

### DIFF
--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -69,8 +69,14 @@ contract ForceMove {
         // REQUIREMENTS
         // ------------
 
-        _requireNonDecreasedTurnNumber(channelId, largestTurnNum);
-        _requireChannelNotFinalized(channelId);
+        if (_mode(channelId) == ChannelMode.Open) {
+            _requireNonDecreasedTurnNumber(channelId, largestTurnNum);
+        } else if (_mode(channelId) == ChannelMode.Challenge) {
+            _requireIncreasedTurnNumber(channelId, largestTurnNum);
+        } else {
+            // This should revert.
+            _requireChannelNotFinalized(channelId);
+        }
         bytes32 supportedStateHash = _requireStateSupportedBy(
             largestTurnNum,
             variableParts,

--- a/packages/nitro-protocol/test/contracts/ForceMove/forceMove.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/forceMove.test.ts
@@ -1,11 +1,11 @@
-import { ethers } from 'ethers';
-import { expectRevert } from '@statechannels/devtools';
+import {ethers} from 'ethers';
+import {expectRevert} from '@statechannels/devtools';
 // @ts-ignore
 import ForceMoveArtifact from '../../../build/contracts/TESTForceMove.json';
 // @ts-ignore
 import countingAppArtifact from '../../../build/contracts/CountingApp.json';
-import { defaultAbiCoder, hexlify } from 'ethers/utils';
-import { HashZero } from 'ethers/constants';
+import {defaultAbiCoder, hexlify} from 'ethers/utils';
+import {HashZero} from 'ethers/constants';
 import {
   setupContracts,
   clearedChallengeHash,
@@ -14,18 +14,18 @@ import {
   signStates,
   finalizedOutcomeHash,
 } from '../../test-helpers';
-import { Channel, getChannelId } from '../../../src/contract/channel';
-import { State, getVariablePart, getFixedPart } from '../../../src/contract/state';
-import { hashChannelStorage, ChannelStorage } from '../../../src/contract/channel-storage';
+import {Channel, getChannelId} from '../../../src/contract/channel';
+import {State, getVariablePart, getFixedPart} from '../../../src/contract/state';
+import {hashChannelStorage, ChannelStorage} from '../../../src/contract/channel-storage';
 import {
   CHALLENGER_NON_PARTICIPANT,
   CHANNEL_FINALIZED,
   TURN_NUM_RECORD_DECREASED,
   TURN_NUM_RECORD_NOT_INCREASED,
 } from '../../../src/contract/transaction-creators/revert-reasons';
-import { signChallengeMessage } from '../../../src/signatures';
-import { SignedState } from '../../../src/index';
-import { COUNTING_APP_INVALID_TRANSITION } from '../../revert-reasons';
+import {signChallengeMessage} from '../../../src/signatures';
+import {SignedState} from '../../../src/index';
+import {COUNTING_APP_INVALID_TRANSITION} from '../../revert-reasons';
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.GANACHE_PORT}`,
 );
@@ -36,7 +36,7 @@ const chainId = '0x1234';
 const participants = ['', '', ''];
 const wallets = new Array(3);
 const challengeDuration = 0x1;
-const outcome = [{ allocation: [], assetHolderAddress: ethers.Wallet.createRandom().address }];
+const outcome = [{allocation: [], assetHolderAddress: ethers.Wallet.createRandom().address}];
 
 let appDefinition;
 
@@ -76,13 +76,13 @@ const reverts4 = 'It reverts when a challenge is present if the turnNumRecord do
 const reverts5 = 'It reverts when the channel is finalized';
 
 describe('forceMove', () => {
-  const threeStates = { appDatas: [0, 1, 2], whoSignedWhat: [0, 1, 2] };
-  const oneState = { appDatas: [2], whoSignedWhat: [0, 0, 0] };
-  const invalid = { appDatas: [0, 2, 1], whoSignedWhat: [0, 1, 2] };
+  const threeStates = {appDatas: [0, 1, 2], whoSignedWhat: [0, 1, 2]};
+  const oneState = {appDatas: [2], whoSignedWhat: [0, 0, 0]};
+  const invalid = {appDatas: [0, 2, 1], whoSignedWhat: [0, 1, 2]};
   const largestTurnNum = 8;
   const isFinalCount = 0;
   const challenger = wallets[2];
-  const wrongSig = { v: 1, s: HashZero, r: HashZero };
+  const wrongSig = {v: 1, s: HashZero, r: HashZero};
 
   const empty = HashZero; // equivalent to openAtZero
   const openAtFive = clearedChallengeHash(5);
@@ -113,8 +113,8 @@ describe('forceMove', () => {
   `(
     '$description', // for the purposes of this test, chainId and participants are fixed, making channelId 1-1 with channelNonce
 
-    async ({ initialChannelStorageHash, stateData, challengeSignature, reasonString }) => {
-      const { appDatas, whoSignedWhat } = stateData;
+    async ({initialChannelStorageHash, stateData, challengeSignature, reasonString}) => {
+      const {appDatas, whoSignedWhat} = stateData;
       const channel: Channel = {
         chainId,
         participants,
@@ -138,7 +138,7 @@ describe('forceMove', () => {
       const signatures = await signStates(states, wallets, whoSignedWhat);
       const challengeState: SignedState = {
         state: states[states.length - 1],
-        signature: { v: 0, r: '', s: '' },
+        signature: {v: 0, r: '', s: ''},
       };
       challengeSignature =
         challengeSignature || signChallengeMessage([challengeState], challenger.privateKey);

--- a/packages/nitro-protocol/test/contracts/ForceMove/forceMove.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/forceMove.test.ts
@@ -1,11 +1,11 @@
-import {ethers} from 'ethers';
-import {expectRevert} from '@statechannels/devtools';
+import { ethers } from 'ethers';
+import { expectRevert } from '@statechannels/devtools';
 // @ts-ignore
 import ForceMoveArtifact from '../../../build/contracts/TESTForceMove.json';
 // @ts-ignore
 import countingAppArtifact from '../../../build/contracts/CountingApp.json';
-import {defaultAbiCoder, hexlify} from 'ethers/utils';
-import {HashZero} from 'ethers/constants';
+import { defaultAbiCoder, hexlify } from 'ethers/utils';
+import { HashZero } from 'ethers/constants';
 import {
   setupContracts,
   clearedChallengeHash,
@@ -14,17 +14,18 @@ import {
   signStates,
   finalizedOutcomeHash,
 } from '../../test-helpers';
-import {Channel, getChannelId} from '../../../src/contract/channel';
-import {State, getVariablePart, getFixedPart} from '../../../src/contract/state';
-import {hashChannelStorage, ChannelStorage} from '../../../src/contract/channel-storage';
+import { Channel, getChannelId } from '../../../src/contract/channel';
+import { State, getVariablePart, getFixedPart } from '../../../src/contract/state';
+import { hashChannelStorage, ChannelStorage } from '../../../src/contract/channel-storage';
 import {
   CHALLENGER_NON_PARTICIPANT,
   CHANNEL_FINALIZED,
   TURN_NUM_RECORD_DECREASED,
+  TURN_NUM_RECORD_NOT_INCREASED,
 } from '../../../src/contract/transaction-creators/revert-reasons';
-import {signChallengeMessage} from '../../../src/signatures';
-import {SignedState} from '../../../src/index';
-import {COUNTING_APP_INVALID_TRANSITION} from '../../revert-reasons';
+import { signChallengeMessage } from '../../../src/signatures';
+import { SignedState } from '../../../src/index';
+import { COUNTING_APP_INVALID_TRANSITION } from '../../revert-reasons';
 const provider = new ethers.providers.JsonRpcProvider(
   `http://localhost:${process.env.GANACHE_PORT}`,
 );
@@ -35,7 +36,7 @@ const chainId = '0x1234';
 const participants = ['', '', ''];
 const wallets = new Array(3);
 const challengeDuration = 0x1;
-const outcome = [{allocation: [], assetHolderAddress: ethers.Wallet.createRandom().address}];
+const outcome = [{ allocation: [], assetHolderAddress: ethers.Wallet.createRandom().address }];
 
 let appDefinition;
 
@@ -75,43 +76,45 @@ const reverts4 = 'It reverts when a challenge is present if the turnNumRecord do
 const reverts5 = 'It reverts when the channel is finalized';
 
 describe('forceMove', () => {
-  const threeStates = {appDatas: [0, 1, 2], whoSignedWhat: [0, 1, 2]};
-  const oneState = {appDatas: [2], whoSignedWhat: [0, 0, 0]};
-  const invalid = {appDatas: [0, 2, 1], whoSignedWhat: [0, 1, 2]};
+  const threeStates = { appDatas: [0, 1, 2], whoSignedWhat: [0, 1, 2] };
+  const oneState = { appDatas: [2], whoSignedWhat: [0, 0, 0] };
+  const invalid = { appDatas: [0, 2, 1], whoSignedWhat: [0, 1, 2] };
   const largestTurnNum = 8;
   const isFinalCount = 0;
   const challenger = wallets[2];
-  const wrongSig = {v: 1, s: HashZero, r: HashZero};
+  const wrongSig = { v: 1, s: HashZero, r: HashZero };
 
   const empty = HashZero; // equivalent to openAtZero
   const openAtFive = clearedChallengeHash(5);
   const openAtLargestTurnNum = clearedChallengeHash(largestTurnNum);
   const openAtTwenty = clearedChallengeHash(20);
   const challengeAtFive = ongoingChallengeHash(5);
+  const challengeAtLargestTurnNum = ongoingChallengeHash(largestTurnNum);
   const challengeAtTwenty = ongoingChallengeHash(20);
   const finalizedAtFive = finalizedOutcomeHash(5);
 
   let channelNonce = 200;
   beforeEach(() => (channelNonce += 1));
   it.each`
-    description | initialChannelStorageHash | stateData      | challengeSignature | reasonString
-    ${accepts1} | ${empty}                  | ${oneState}    | ${undefined}       | ${undefined}
-    ${accepts2} | ${empty}                  | ${threeStates} | ${undefined}       | ${undefined}
-    ${accepts3} | ${openAtFive}             | ${oneState}    | ${undefined}       | ${undefined}
-    ${accepts3} | ${openAtLargestTurnNum}   | ${oneState}    | ${undefined}       | ${undefined}
-    ${accepts4} | ${openAtFive}             | ${threeStates} | ${undefined}       | ${undefined}
-    ${accepts5} | ${challengeAtFive}        | ${oneState}    | ${undefined}       | ${undefined}
-    ${accepts6} | ${challengeAtFive}        | ${threeStates} | ${undefined}       | ${undefined}
-    ${reverts1} | ${openAtTwenty}           | ${oneState}    | ${undefined}       | ${TURN_NUM_RECORD_DECREASED}
-    ${reverts2} | ${empty}                  | ${oneState}    | ${wrongSig}        | ${CHALLENGER_NON_PARTICIPANT}
-    ${reverts3} | ${empty}                  | ${invalid}     | ${undefined}       | ${COUNTING_APP_INVALID_TRANSITION}
-    ${reverts4} | ${challengeAtTwenty}      | ${oneState}    | ${undefined}       | ${TURN_NUM_RECORD_DECREASED}
-    ${reverts5} | ${finalizedAtFive}        | ${oneState}    | ${undefined}       | ${CHANNEL_FINALIZED}
+    description | initialChannelStorageHash    | stateData      | challengeSignature | reasonString
+    ${accepts1} | ${empty}                     | ${oneState}    | ${undefined}       | ${undefined}
+    ${accepts2} | ${empty}                     | ${threeStates} | ${undefined}       | ${undefined}
+    ${accepts3} | ${openAtFive}                | ${oneState}    | ${undefined}       | ${undefined}
+    ${accepts3} | ${openAtLargestTurnNum}      | ${oneState}    | ${undefined}       | ${undefined}
+    ${accepts4} | ${openAtFive}                | ${threeStates} | ${undefined}       | ${undefined}
+    ${accepts5} | ${challengeAtFive}           | ${oneState}    | ${undefined}       | ${undefined}
+    ${accepts6} | ${challengeAtFive}           | ${threeStates} | ${undefined}       | ${undefined}
+    ${reverts1} | ${openAtTwenty}              | ${oneState}    | ${undefined}       | ${TURN_NUM_RECORD_DECREASED}
+    ${reverts2} | ${empty}                     | ${oneState}    | ${wrongSig}        | ${CHALLENGER_NON_PARTICIPANT}
+    ${reverts3} | ${empty}                     | ${invalid}     | ${undefined}       | ${COUNTING_APP_INVALID_TRANSITION}
+    ${reverts4} | ${challengeAtTwenty}         | ${oneState}    | ${undefined}       | ${TURN_NUM_RECORD_NOT_INCREASED}
+    ${reverts4} | ${challengeAtLargestTurnNum} | ${oneState}    | ${undefined}       | ${TURN_NUM_RECORD_NOT_INCREASED}
+    ${reverts5} | ${finalizedAtFive}           | ${oneState}    | ${undefined}       | ${CHANNEL_FINALIZED}
   `(
     '$description', // for the purposes of this test, chainId and participants are fixed, making channelId 1-1 with channelNonce
 
-    async ({initialChannelStorageHash, stateData, challengeSignature, reasonString}) => {
-      const {appDatas, whoSignedWhat} = stateData;
+    async ({ initialChannelStorageHash, stateData, challengeSignature, reasonString }) => {
+      const { appDatas, whoSignedWhat } = stateData;
       const channel: Channel = {
         chainId,
         participants,
@@ -135,7 +138,7 @@ describe('forceMove', () => {
       const signatures = await signStates(states, wallets, whoSignedWhat);
       const challengeState: SignedState = {
         state: states[states.length - 1],
-        signature: {v: 0, r: '', s: ''},
+        signature: { v: 0, r: '', s: '' },
       };
       challengeSignature =
         challengeSignature || signChallengeMessage([challengeState], challenger.privateKey);


### PR DESCRIPTION
While writing the TLA+ spec for the new protocol, I discovered that `forceMove` currently lets you overwrite existing challenges with the same turn number.