### PR TITLE
Reorder jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
             - packages/*/build
             - packages/*/lib
 
-  run-tests:
+  a-run-tests:
     <<: *defaults
     steps:
       - <<: *restore_code
@@ -65,7 +65,7 @@ jobs:
           name: Run State Channels tests
           command: yarn test
 
-  run-tslint:
+  b-run-tslint:
     <<: *defaults
     steps:
       - <<: *restore_code
@@ -77,7 +77,7 @@ jobs:
 
       - run: yarn lint
 
-  ensure-updated-lockfiles:
+  c-ensure-updated-lockfiles:
     <<: *defaults
     steps:
       - <<: *restore_code
@@ -112,15 +112,15 @@ workflows:
     jobs:
       - build
 
-      - run-tests:
+      - a-run-tests:
           requires:
             - build
 
-      - run-tslint:
+      - b-run-tslint:
           requires:
             - build
 
-      - ensure-updated-lockfiles:
+      - c-ensure-updated-lockfiles:
           requires:
             - build
       # - publish-to-npm:


### PR DESCRIPTION
It seems like circleci runs all "prepared" jobs in alphabetical order,
where a job is "prepared" if its requirements are satisfied.

The workflow is currently defined here https://github.com/statechannels/monorepo/blob/96e3ac8bf6eedc5b58fc704f25e2273774ee1fa2/.circleci/config.yml#L110-L125

By pre-pending the job titles with letters, we force tests to run first,
accomplishing the goal of b693452