### PR TITLE
Faster circle runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ restore_dep: &restore_dep
     key: dependency-cache-{{ checksum "yarn.lock" }}
 
 jobs:
-  build:
+  test:
     <<: *defaults
     steps:
       - <<: *restore_code
@@ -38,7 +38,11 @@ jobs:
           name: "yarn --frozen-lockfile"
           command: yarn --frozen-lockfile
 
+      - run: yarn lint
       - run: yarn build:ci
+      - run:
+          name: Run State Channels tests
+          command: yarn test
 
       - <<: *save_dep
 
@@ -49,86 +53,7 @@ jobs:
             - packages/*/build
             - packages/*/lib
 
-  run-tests:
-    <<: *defaults
-    steps:
-      - <<: *restore_code
-      - checkout
-      - <<: *restore_dep
-
-      - run: yarn --frozen-lockfile # symlink packages' node_modules
-
-      - attach_workspace:
-          at: /home/circleci/project
-
-      - run:
-          name: Run State Channels tests
-          command: yarn test
-
-  run-tslint:
-    <<: *defaults
-    steps:
-      - <<: *restore_code
-      - checkout
-      - <<: *restore_dep
-
-      - attach_workspace:
-          at: /home/circleci/project
-
-      - run: yarn lint
-
-  ensure-updated-lockfiles:
-    <<: *defaults
-    steps:
-      - <<: *restore_code
-      - checkout
-      - <<: *restore_dep
-
-      - attach_workspace:
-          at: /home/circleci/project
-
-      - run:
-          name: Check root yarn.lock
-          command: yarn --frozen-lockfile
-
-  # publish-to-npm:
-  #   <<: *defaults
-  #   steps:
-  #     - <<: *restore_code
-  #     - checkout
-  #     - <<: *restore_dep
-  #     - attach_workspace:
-  #         at: /home/circleci/project
-  #     - run: yarn --frozen-lockfile # symlink packages' node_modules
-  #     - run:
-  #         name: Add NPM_TOKEN auth
-  #         command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-  #     - run:
-  #         name: Publish any updated packages to npm
-  #         command: yarn run publish
-
 workflows:
   statechannels:
     jobs:
-      - build
-
-      - run-tests:
-          requires:
-            - build
-
-      - run-tslint:
-          requires:
-            - build
-
-      - ensure-updated-lockfiles:
-          requires:
-            - build
-      # - publish-to-npm:
-      #     requires:
-      #       - build
-      #       - ensure-updated-lockfiles
-      #       - run-tests
-      #       - run-tslint
-      #     filters:
-      #       branches:
-      #         only: master
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,7 @@ jobs:
 
       - run: yarn lint
       - run: yarn build:ci
-      - run:
-          name: Run State Channels tests
-          command: yarn test
+      - run: yarn test
 
       - <<: *save_dep
 


### PR DESCRIPTION
This combines the circleci four jobs into one job.
- `ensure-updated-lockfiles` was redundant, since the only step it ran, `yarn --frozen-lockfile`, is included in other jobs
- restoring the cache, and running `yarn --frozen-lockfile` takes about 40 seconds. So, combing the three remaining jobs into one job saves 80 seconds.

I don't see much benefit in having separate jobs for building, linting, and testing. If there's no benefit, we might as well save ourselves at least 160s per pull request (once on the PR, and once on the merge into master).