### PR TITLE
Persist subfolder node_modules inside workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
             - packages/*/dist
             - packages/*/build
             - packages/*/lib
+            - packages/*/node_modules
 
   lint:
     <<: *defaults


### PR DESCRIPTION
Subfolder `node_modules` were not being persisted across jobs which meant thing like `packages/*/node_modules/.bin/truffle` were not being found.