### PR TITLE
Fix the 'yarn test' command in the wallet

### DIFF
--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -12,9 +12,9 @@
   "scripts": {
     "start": "npm run clearContracts && node scripts/start.js",
     "build": "run-s clearContracts build:typescript build:webpack",
-    "build:typescript": "npx tsc",
+    "build:typescript": "npx tsc -b",
     "build:webpack": "CI=false node scripts/build.js",
-    "prepare": "npx tsc",
+    "prepare": "yarn build:typescript",
     "test": "run-s lint:check 'test:app --all'",
     "test:ci": "GANACHE_PORT=8503 yarn run lint:check && yarn run test:ci:contracts && yarn run test:ci:app && yarn build",
     "test:ci:contracts": "yarn test:contracts --all --ci",

--- a/packages/wallet/src/utils/contract-utils.ts
+++ b/packages/wallet/src/utils/contract-utils.ts
@@ -20,22 +20,33 @@ export function getAdjudicatorInterface(): ethers.utils.Interface {
   return new ethers.utils.Interface(NitroAdjudicatorArtifact.abi);
 }
 
+// FIXME: The tests ought to be able to run even without contracts having been built which
+// is why this try {} catch {} logic is here, but returning AddressZero is only a way of
+// avoiding errors being thrown. The situation is that all tests which actually interact
+// with the blockchain are currently skipped, and so the AddressZero value is never used.
+
 export function getETHAssetHolderAddress(): string {
-  const EthAssetHolderArtifact = require("../../build/contracts/ETHAssetHolder.json");
-  const artifact = EthAssetHolderArtifact.networks[getNetworkId()];
-  return artifact ? artifact.address : AddressZero;
+  try {
+    return require("../../build/contracts/ETHAssetHolder.json").networks[getNetworkId()].address;
+  } catch (e) {
+    return AddressZero;
+  }
 }
 
 export function getAdjudicatorContractAddress(): string {
-  const NitroAdjudicatorArtifact = require("../../build/contracts/NitroAdjudicator.json");
-  const artifact = NitroAdjudicatorArtifact.networks[getNetworkId()];
-  return artifact ? artifact.address : AddressZero;
+  try {
+    return require("../../build/contracts/NitroAdjudicator.json").networks[getNetworkId()].address;
+  } catch (e) {
+    return AddressZero;
+  }
 }
 
 export function getConsensusContractAddress(): string {
-  const ConsensusAppArtifact = require("../../build/contracts/ConsensusApp.json");
-  const artifact = ConsensusAppArtifact.networks[getNetworkId()];
-  return artifact ? artifact.address : AddressZero;
+  try {
+    return require("../../build/contracts/ConsensusApp.json").networks[getNetworkId()].address;
+  } catch (e) {
+    return AddressZero;
+  }
 }
 
 export function getNetworkId(): number {


### PR DESCRIPTION
With the #17 PR we made sure `yarn test:ci` passed, but `yarn test` is actually not passing. This is because the tests attempt to read from files which are not there at the moment. 