### PR TITLE
Use TypeScript references in wallet and nitro-protocol

### DIFF
--- a/packages/jest-gas-reporter/tsconfig.json
+++ b/packages/jest-gas-reporter/tsconfig.json
@@ -9,8 +9,9 @@
     "module": "commonjs",
     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "declaration": true,
-    /* Add source maps for declaration files */
+    /* Generate a .d.ts file in the build output */
     "declarationMap": true,
+    /* Add source maps for declaration files */
     "target": "es5",
     "moduleResolution": "node",
     /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */

--- a/packages/nitro-protocol/tsconfig.json
+++ b/packages/nitro-protocol/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "lib" /* Redirect output structure to the directory. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     "declaration": true,
+    "declarationMap": true,
     "target": "es5",
     "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     "strict": false /* Enable all strict type-checking options. */,

--- a/packages/nitro-protocol/tsconfig.json
+++ b/packages/nitro-protocol/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     "lib": ["es5", "es6"],
+    "composite": true,
     "allowJs": false /* Allow javascript files to be compiled. */,
     "outDir": "lib" /* Redirect output structure to the directory. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
@@ -15,8 +16,12 @@
     "noUnusedLocals": true,
     "types": ["node", "jest"]
   },
+  "include": [
+    "src/**/*",
+    "test/**/*",
+    "build/contracts/*.json"
+  ],
   "references": [
     { "path": "../jest-gas-reporter" }
-  ],
-  "exclude": ["lib", "node_modules"]
+  ]
 }

--- a/packages/wallet/tsconfig.json
+++ b/packages/wallet/tsconfig.json
@@ -9,6 +9,7 @@
     "jsx": "react",
     "moduleResolution": "node",
     "declaration": true,
+    "declarationMap": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,

--- a/packages/wallet/tsconfig.json
+++ b/packages/wallet/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "composite": true,
     "outDir": "lib",
     "module": "commonjs",
     "target": "es2015",
@@ -20,17 +21,15 @@
     "resolveJsonModule": true,
     "esModuleInterop": true
   },
+  "include": [
+    "src/**/*",
+    "types/globals.d.ts",
+    "contracts/**/*.json"
+  ],
+  "references": [
+    { "path": "../nitro-protocol"}
+  ],
   "exclude": [
-    "node_modules",
-    "build",
-    "lib",
-    "scripts",
-    "acceptance-tests",
-    "webpack",
-    "jest",
-    "src/setupTests.ts",
-    "truffle.ts",
-    "migrations/*",
-    "test/**/*"
+    "src/setupTests.ts"
   ]
 }


### PR DESCRIPTION
Gives us some nice features inside VS Code such as Jump To Source:

![2019-09-27 10 59 07](https://user-images.githubusercontent.com/1933029/65736445-f4416500-e115-11e9-8b7b-c17415333323.gif)
