### PR TITLE
[nitro-protocol] Convert IForceMove into an interface

### DIFF
--- a/packages/nitro-protocol/.prettierignore
+++ b/packages/nitro-protocol/.prettierignore
@@ -1,3 +1,4 @@
 contracts/AssetHolder.sol
 contracts/NitroAdjudicator.sol
+contracts/ForceMove.sol
 contracts/examples/SingleAssetPayments.sol

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -56,19 +56,26 @@ contract ForceMove is IForceMove {
     }
 
     function forceMove(
-        bytes calldata fixedPartBytes,
         uint48 largestTurnNum,
-        bytes calldata variablePartsBytes,
-        uint8 isFinalCount, // how many of the states are final
-        bytes calldata sigsBytes,
-        uint8[] calldata whoSignedWhat,
-        bytes calldata challengerSigBytes
+        bytes calldata supportingData_,
+        bytes calldata challengerSig_
     ) external {
-        // decode arguments
-        FixedPart memory fixedPart = abi.decode(fixedPartBytes, (FixedPart));
-        ForceMoveApp.VariablePart[] memory variableParts = abi.decode(variablePartsBytes, (ForceMoveApp.VariablePart[]));
-        Signature[] memory sigs = abi.decode(sigsBytes,(Signature[]));
-        Signature memory challengerSig = abi.decode(challengerSigBytes,(Signature));
+        // decode supportingData_
+        (
+            uint8 isFinalCount,
+            uint8[] memory whoSignedWhat, 
+            FixedPart memory fixedPart, 
+            ForceMoveApp.VariablePart[] memory variableParts, 
+            Signature[] memory sigs
+        ) = abi.decode(supportingData_,
+        (
+            uint8, 
+            uint8[], 
+            FixedPart, 
+            ForceMoveApp.VariablePart[], 
+            Signature[])
+        );
+        Signature memory challengerSig = abi.decode(challengerSig_, (Signature));
 
         bytes32 channelId = _getChannelId(fixedPart);
 
@@ -121,17 +128,23 @@ contract ForceMove is IForceMove {
 
     function respond(
         address challenger,
-        bool[2] calldata isFinalAB,
-        bytes calldata fixedPartBytes,
-        bytes calldata variablePartABBytes,
+        bytes calldata supportingData_
+    ) external {
+        // decode supportingData_
+        (
+            bool[2] memory isFinalAB,
+            FixedPart memory fixedPart, 
+            ForceMoveApp.VariablePart[2] memory variablePartAB, 
+            Signature memory sig
+        ) = abi.decode(supportingData_,
+        (
+            bool[2], 
+            FixedPart, 
+            ForceMoveApp.VariablePart[2], 
+            Signature)
+        );
         // variablePartAB[0] = challengeVariablePart
         // variablePartAB[1] = responseVariablePart
-        bytes calldata sigBytes
-    ) external {
-        // decode arguments
-        FixedPart memory fixedPart = abi.decode(fixedPartBytes, (FixedPart));
-        ForceMoveApp.VariablePart[2] memory variablePartAB = abi.decode(variablePartABBytes, (ForceMoveApp.VariablePart[2]));
-        Signature memory sig = abi.decode(sigBytes,(Signature));
 
         bytes32 channelId = _getChannelId(fixedPart);
         (uint48 turnNumRecord, uint48 finalizesAt, ) = _getData(channelId);
@@ -188,17 +201,24 @@ contract ForceMove is IForceMove {
     }
 
     function checkpoint(
-        bytes calldata fixedPartBytes,
         uint48 largestTurnNum,
-        bytes calldata variablePartsBytes,
-        uint8 isFinalCount, // how many of the states are final
-        bytes calldata sigsBytes,
-        uint8[] calldata whoSignedWhat
+        bytes calldata supportingData_
     ) external {
-        // decode arguments
-        FixedPart memory fixedPart = abi.decode(fixedPartBytes, (FixedPart));
-        ForceMoveApp.VariablePart[] memory variableParts = abi.decode(variablePartsBytes, (ForceMoveApp.VariablePart[]));
-        Signature[] memory sigs = abi.decode(sigsBytes,(Signature[]));
+        // decode supportingData_
+        (
+            uint8 isFinalCount,
+            uint8[] memory whoSignedWhat, 
+            FixedPart memory fixedPart, 
+            ForceMoveApp.VariablePart[] memory variableParts, 
+            Signature[] memory sigs
+        ) = abi.decode(supportingData_,
+        (
+            uint8, 
+            uint8[], 
+            FixedPart, 
+            ForceMoveApp.VariablePart[], 
+            Signature[])
+        );
 
         bytes32 channelId = _getChannelId(fixedPart);
 
@@ -222,16 +242,25 @@ contract ForceMove is IForceMove {
 
     function conclude(
         uint48 largestTurnNum,
-        bytes calldata fixedPartBytes,
-        bytes32 appPartHash,
-        bytes32 outcomeHash,
-        uint8 numStates,
-        uint8[] calldata whoSignedWhat,
-        bytes calldata sigsBytes
+        bytes calldata supportingData_
     ) external {
-        // decode arguments
-        FixedPart memory fixedPart = abi.decode(fixedPartBytes, (FixedPart));
-        Signature[] memory sigs = abi.decode(sigsBytes,(Signature[]));
+        // decode supportingData_
+        (
+            uint8 numStates,
+            bytes32 appPartHash,
+            bytes32 outcomeHash, 
+            uint8[] memory whoSignedWhat,
+            FixedPart memory fixedPart, 
+            Signature[] memory sigs
+        ) = abi.decode(supportingData_,
+        (
+            uint8, 
+            bytes32,
+            bytes32, 
+            uint8[],
+            FixedPart, 
+            Signature[])
+        );
 
         bytes32 channelId = _getChannelId(fixedPart);
         _requireChannelNotFinalized(channelId);

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -52,7 +52,6 @@ contract ForceMove is IForceMove {
 
     struct RespondData {
         bool[2] isFinalAB;
-        uint8[] whoSignedWhat;
         FixedPart fixedPart;
         ForceMoveApp.VariablePart[2] variablePartAB;
         Signature sig;
@@ -214,7 +213,7 @@ contract ForceMove is IForceMove {
     }
 
     function conclude(uint48 largestTurnNum, bytes calldata concludeData_) external {
-        // decode supportingData_
+        // decode concludeData_
         ConcludeData memory concludeData = abi.decode(concludeData_, (ConcludeData));
 
         bytes32 channelId = _getChannelId(concludeData.fixedPart);

--- a/packages/nitro-protocol/contracts/inheritance-graph.md
+++ b/packages/nitro-protocol/contracts/inheritance-graph.md
@@ -53,8 +53,7 @@ classDef Interface fill:#bfa129;
 classDef TestContract fill:#fafe4f;
 classDef Library fill:#bbbb;
 class Outcome,SafeMath Library;
-class IForceMove Abstract;
-class Adjudicator,IAssetHolder,ForceMoveApp,IERC20 Interface;
+class Adjudicator,IAssetHolder,ForceMoveApp,IERC20,IForceMove Interface;
 class NitroAdjudicator,ForceMove,AssetHolder,ETHAssetHolder,ERC20AssetHolder,SingleAssetPayments,TrivialApp,CountingApp,ERC20,Token,ConsensusApp Contract;
 class TESTForceMove,TESTNitroAdjudicator,TESTAssetHolder TestContract;
 ```
@@ -64,7 +63,6 @@ key:
 ```mermaid
 graph LR
 linkStyle default interpolate basis
-Abstraction-->|Inherited by| Contract
 Contract-->|Inherited by| TestContract
 Interface-->|Inherited by| Contract
 Library

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -4,126 +4,88 @@ pragma experimental ABIEncoderV2;
 import './ForceMoveApp.sol';
 
 /**
-  * @dev The ForceMove contract allows state channels to be adjudicated and finalized.
+  * @dev A ForceMove contract allows state channels to be adjudicated and finalized.
 */
-contract IForceMove {
-    struct Signature {
-        uint8 v;
-        bytes32 r;
-        bytes32 s;
-    }
-
-    struct FixedPart {
-        uint256 chainId;
-        address[] participants;
-        uint256 channelNonce;
-        address appDefinition;
-        uint256 challengeDuration;
-    }
-
-    struct State {
-        // participants sign the hash of this
-        uint256 turnNum;
-        bool isFinal;
-        bytes32 channelId; // keccack(chainId,participants,channelNonce)
-        bytes32 appPartHash;
-        //     keccak256(abi.encode(
-        //         fixedPart.challengeDuration,
-        //         fixedPart.appDefinition,
-        //         variablePart.appData
-        //     )
-        // )
-        bytes32 outcomeHash;
-    }
-
-    struct ChannelStorage {
-        uint256 turnNumRecord;
-        uint256 finalizesAt;
-        bytes32 stateHash; // keccak256(abi.encode(State))
-        address challengerAddress;
-        bytes32 outcomeHash;
-    }
-
-    enum ChannelMode {Open, Challenge, Finalized}
-
+interface IForceMove {
     /**
     * @notice Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
     * @dev Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
-    * @param fixedPart Data describing properties of the state channel that do not change with state updates.
+    * @param fixedPartBytes Data describing properties of the state channel that do not change with state updates.
     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
-    * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
+    * @param variablePartsBytes An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
     * @param isFinalCount Describes how many of the submitted states have the `isFinal` property set to `true`. It is implied that the rightmost `isFinalCount` states are final, and the rest are not final.
-    * @param sigs An array of signatures that support the state with the `largestTurnNum`.
+    * @param sigsBytes An array of signatures that support the state with the `largestTurnNum`.
     * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
-    * @param challengerSig The signature of a participant on the keccak256 of the abi.encode of (supportedStateHash, 'forceMove').
+    * @param challengerSigBytes The signature of a participant on the keccak256 of the abi.encode of (supportedStateHash, 'forceMove').
     */
     function forceMove(
-        FixedPart memory fixedPart,
+        bytes calldata fixedPartBytes,
         uint48 largestTurnNum,
-        ForceMoveApp.VariablePart[] memory variableParts,
+        bytes calldata variablePartsBytes,
         uint8 isFinalCount, // how many of the states are final
-        Signature[] memory sigs,
-        uint8[] memory whoSignedWhat,
-        Signature memory challengerSig
-    ) public;
+        bytes calldata sigsBytes,
+        uint8[] calldata whoSignedWhat,
+        bytes calldata challengerSigBytes
+    ) external;
 
     /**
     * @notice Repsonds to an ongoing challenge registered against a state channel.
     * @dev Repsonds to an ongoing challenge registered against a state channel.
     * @param challenger The address of the participant whom registered the challenge.
     * @param isFinalAB An pair of booleans describing if the challenge state and/or the response state have the `isFinal` property set to `true`.
-    * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-    * @param variablePartAB An pair of structs, each decribing the properties of the state channel that may change with each state update (for the challenge state and for the response state).
-    * @param sig The responder's signature on the `responseStateHash`.
+    * @param fixedPartBytes Data describing properties of the state channel that do not change with state updates.
+    * @param variablePartABBytes An pair of structs, each decribing the properties of the state channel that may change with each state update (for the challenge state and for the response state).
+    * @param sigBytes The responder's signature on the `responseStateHash`.
     */
     function respond(
         address challenger,
-        bool[2] memory isFinalAB,
-        FixedPart memory fixedPart,
-        ForceMoveApp.VariablePart[2] memory variablePartAB,
+        bool[2] calldata isFinalAB,
+        bytes calldata fixedPartBytes,
+        bytes calldata variablePartABBytes,
         // variablePartAB[0] = challengeVariablePart
         // variablePartAB[1] = responseVariablePart
-        Signature memory sig
-    ) public;
+        bytes calldata sigBytes
+    ) external;
 
     /**
     * @notice Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
     * @dev Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
-    * @param fixedPart Data describing properties of the state channel that do not change with state updates.
+    * @param fixedPartBytes Data describing properties of the state channel that do not change with state updates.
     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
-    * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
+    * @param variablePartsBytes An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
     * @param isFinalCount Describes how many of the submitted states have the `isFinal` property set to `true`. It is implied that the rightmost `isFinalCount` states are final, and the rest are not final.
-    * @param sigs An array of signatures that support the state with the `largestTurnNum`.
+    * @param sigsBytes An array of signatures that support the state with the `largestTurnNum`.
     * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
     */
     function checkpoint(
-        FixedPart memory fixedPart,
+        bytes calldata fixedPartBytes,
         uint48 largestTurnNum,
-        ForceMoveApp.VariablePart[] memory variableParts,
+        bytes calldata variablePartsBytes,
         uint8 isFinalCount, // how many of the states are final
-        Signature[] memory sigs,
-        uint8[] memory whoSignedWhat
-    ) public;
+        bytes calldata sigsBytes,
+        uint8[] calldata whoSignedWhat
+    ) external;
 
     /**
     * @notice Finalizes a channel by providing a finalization proof.
     * @dev Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
-    * @param fixedPart Data describing properties of the state channel that do not change with state updates.
+    * @param fixedPartBytes Data describing properties of the state channel that do not change with state updates.
     * @param appPartHash The keccak256 of the abi.encode of `(challengeDuration, appDefinition, appData)`. Applies to all states in the finalization proof.
     * @param outcomeHash The keccak256 of the abi.encode of the `outcome`. Applies to all stats in the finalization proof.
+    * @param numStates The number of states submitted.
     * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
-    * @param sigs An array of signatures that support the state with the `largestTurnNum`.
+    * @param sigsBytes An array of signatures that support the state with the `largestTurnNum`.
     */
     function conclude(
         uint48 largestTurnNum,
-        FixedPart memory fixedPart,
+        bytes calldata fixedPartBytes,
         bytes32 appPartHash,
         bytes32 outcomeHash,
         uint8 numStates,
-        uint8[] memory whoSignedWhat,
-        Signature[] memory sigs
-    ) public;
+        uint8[] calldata whoSignedWhat,
+        bytes calldata sigsBytes
+    ) external;
 
     // events
 
@@ -134,8 +96,8 @@ contract IForceMove {
     * @param finalizesAt The unix timestamp when `channelId` will finalize.
     * @param challenger The address of the participant whom registered the challenge.
     * @param isFinal Boolean denoting whether the challenge state is final.
-    * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-    * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
+    * @param fixedPartBytes Data describing properties of the state channel that do not change with state updates.
+    * @param variablePartsBytes An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
     */
     event ChallengeRegistered(
         bytes32 indexed channelId,
@@ -144,8 +106,8 @@ contract IForceMove {
         uint256 finalizesAt,
         address challenger,
         bool isFinal,
-        FixedPart fixedPart,
-        ForceMoveApp.VariablePart[] variableParts
+        bytes fixedPartBytes,
+        bytes variablePartsBytes
     );
 
     /**

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -10,82 +10,39 @@ interface IForceMove {
     /**
     * @notice Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
     * @dev Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
-    * @param fixedPartBytes Data describing properties of the state channel that do not change with state updates.
     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
-    * @param variablePartsBytes An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
-    * @param isFinalCount Describes how many of the submitted states have the `isFinal` property set to `true`. It is implied that the rightmost `isFinalCount` states are final, and the rest are not final.
-    * @param sigsBytes An array of signatures that support the state with the `largestTurnNum`.
-    * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
-    * @param challengerSigBytes The signature of a participant on the keccak256 of the abi.encode of (supportedStateHash, 'forceMove').
+    * @param supportingData_ Encoded data sufficient to support a state with `largestTurnNum`.
+    * @param challengerSig_ The abi.encoded signature of a participant on the keccak256 of the abi.encode of (supportedStateHash, 'forceMove').
     */
     function forceMove(
-        bytes calldata fixedPartBytes,
         uint48 largestTurnNum,
-        bytes calldata variablePartsBytes,
-        uint8 isFinalCount, // how many of the states are final
-        bytes calldata sigsBytes,
-        uint8[] calldata whoSignedWhat,
-        bytes calldata challengerSigBytes
+        bytes calldata supportingData_,
+        bytes calldata challengerSig_
     ) external;
 
     /**
     * @notice Repsonds to an ongoing challenge registered against a state channel.
     * @dev Repsonds to an ongoing challenge registered against a state channel.
     * @param challenger The address of the participant whom registered the challenge.
-    * @param isFinalAB An pair of booleans describing if the challenge state and/or the response state have the `isFinal` property set to `true`.
-    * @param fixedPartBytes Data describing properties of the state channel that do not change with state updates.
-    * @param variablePartABBytes An pair of structs, each decribing the properties of the state channel that may change with each state update (for the challenge state and for the response state).
-    * @param sigBytes The responder's signature on the `responseStateHash`.
+    * @param supportingData_ Encoded data, which when combined with a state stored on chain with turn number t, is sufficient to imply the support of a state with turn number t+1.
     */
-    function respond(
-        address challenger,
-        bool[2] calldata isFinalAB,
-        bytes calldata fixedPartBytes,
-        bytes calldata variablePartABBytes,
-        // variablePartAB[0] = challengeVariablePart
-        // variablePartAB[1] = responseVariablePart
-        bytes calldata sigBytes
-    ) external;
+    function respond(address challenger, bytes calldata supportingData_) external;
 
     /**
     * @notice Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
     * @dev Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
-    * @param fixedPartBytes Data describing properties of the state channel that do not change with state updates.
     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
-    * @param variablePartsBytes An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
-    * @param isFinalCount Describes how many of the submitted states have the `isFinal` property set to `true`. It is implied that the rightmost `isFinalCount` states are final, and the rest are not final.
-    * @param sigsBytes An array of signatures that support the state with the `largestTurnNum`.
-    * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
+    * @param supportingData_ Encoded data sufficient to support a state with `largestTurnNum`.
     */
-    function checkpoint(
-        bytes calldata fixedPartBytes,
-        uint48 largestTurnNum,
-        bytes calldata variablePartsBytes,
-        uint8 isFinalCount, // how many of the states are final
-        bytes calldata sigsBytes,
-        uint8[] calldata whoSignedWhat
-    ) external;
+    function checkpoint(uint48 largestTurnNum, bytes calldata supportingData_) external;
 
     /**
     * @notice Finalizes a channel by providing a finalization proof.
     * @dev Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
-    * @param fixedPartBytes Data describing properties of the state channel that do not change with state updates.
-    * @param appPartHash The keccak256 of the abi.encode of `(challengeDuration, appDefinition, appData)`. Applies to all states in the finalization proof.
-    * @param outcomeHash The keccak256 of the abi.encode of the `outcome`. Applies to all stats in the finalization proof.
-    * @param numStates The number of states submitted.
-    * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
-    * @param sigsBytes An array of signatures that support the state with the `largestTurnNum`.
+    * @param supportingData_ Encoded data sufficient to support a state with `largestTurnNum`.
     */
-    function conclude(
-        uint48 largestTurnNum,
-        bytes calldata fixedPartBytes,
-        bytes32 appPartHash,
-        bytes32 outcomeHash,
-        uint8 numStates,
-        uint8[] calldata whoSignedWhat,
-        bytes calldata sigsBytes
-    ) external;
+    function conclude(uint48 largestTurnNum, bytes calldata supportingData_) external;
 
     // events
 

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -24,9 +24,9 @@ interface IForceMove {
     * @notice Repsonds to an ongoing challenge registered against a state channel.
     * @dev Repsonds to an ongoing challenge registered against a state channel.
     * @param challenger The address of the participant whom registered the challenge.
-    * @param supportingData_ Encoded data, which when combined with a state stored on chain with turn number t, is sufficient to imply the support of a state with turn number t+1.
+    * @param respondData_ Encoded data, which when combined with a state stored on chain with turn number t, is sufficient to imply the support of a state with turn number t+1.
     */
-    function respond(address challenger, bytes calldata supportingData_) external;
+    function respond(address challenger, bytes calldata respondData_) external;
 
     /**
     * @notice Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
@@ -40,9 +40,9 @@ interface IForceMove {
     * @notice Finalizes a channel by providing a finalization proof.
     * @dev Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
-    * @param supportingData_ Encoded data sufficient to support a state with `largestTurnNum`.
+    * @param concludeData_ Encoded data sufficient to support a final state with `largestTurnNum`.
     */
-    function conclude(uint48 largestTurnNum, bytes calldata supportingData_) external;
+    function conclude(uint48 largestTurnNum, bytes calldata concludeData_) external;
 
     // events
 


### PR DESCRIPTION
In #70, the `ForceMove` contract extends an abstract contract `IForceMove`. This PR performs the necessary further work to make `IForceMove` an actual [`interface`](https://solidity.readthedocs.io/en/v0.5.11/contracts.html?highlight=interface#interfaces). 

The bulk of the work involved making all of the `ForceMove` public methods `external`. This seemed right, since these methods should probably only be called by external accounts and not by other methods in the same contract (the exception might be a future `batch` function that performs multiple actions in one transaction). Another benefit is that the function parameters remain in `calldata` (instead of being copied into `memory` as in a `public` method), hinting at reductions in gas consumption. 

However, a problem is that [you cannot use structs in `calldata`](https://github.com/ethereum/solidity/pull/5806).  I therefore had to encode much of the function parameters into a basic `bytes` type, and then decode them as the first step in the function implementation. There are at least two downsides to this: 

- There is now some *upwards* pressure on the gas consumption. 
- Debugging malformed input is likely more difficult.

The gas consumption appeared to go up overall: 

| Contract Name | Method Name              | Calls | Min Gas | Max Gas | Average Gas |
| ------------- | ------------------------ | ----- | ------- | ------- | ----------- |
| TESTForceMove | forceMove (currently)    | 12    | 64054   | 183871  | 112951      |
| TESTForceMove | forceMove (this branch)  | 12    | 65556   | 186221  | 114973      |
| TESTForceMove | conclude (currently)     | 11    | 56688   | 98347   | 79545       |
| TESTForceMove | conclude (this branch)   | 11    | 58420   | 100239  | 81363       |
| TESTForceMove | checkpoint (currently)   | 10    | 58890   | 107155  | 83740       |
| TESTForceMove | checkpoint (this branch) | 10    | 60340   | 108877  | 85337       |
| TESTForceMove | respond (currently)      | 5     | 61148   | 86421   | 70384       |
| TESTForceMove | respond (this branch)    | 5     | 63246   | 88576   | 72509       |

Fixes #37 .

On balance it seems not to be worth making this change, but I'm interested in what others think.
