### PR TITLE
Ignore Yarn in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "extends": ["config:base", "group:allNonMajor"],
   "schedule": ["every weekend"],
   "baseBranches": ["master"],
+  "ignoreDeps": ["yarn"],
   "automerge": true
 }


### PR DESCRIPTION
Ignore yarn as the circleCI image doesn't have the latest version.