### PR TITLE
[Wallet] - Etherlime fixed network id

### DIFF
--- a/packages/wallet/bin/start-ganache.js
+++ b/packages/wallet/bin/start-ganache.js
@@ -1,10 +1,10 @@
-process.env.NODE_ENV = process.env.NODE_ENV || 'test';
-const {configureEnvVariables} = require('@statechannels/devtools');
+process.env.NODE_ENV = process.env.NODE_ENV || "test";
+const { configureEnvVariables } = require("@statechannels/devtools");
 configureEnvVariables();
 
-const {exec} = require('child_process');
+const { exec } = require("child_process");
 exec(
-  `npx etherlime ganache --port=${process.env.GANACHE_PORT} > ganache.log`,
+  `npx etherlime ganache --port=${process.env.GANACHE_PORT} --network-id=${process.env.CHAIN_NETWORK_ID}> ganache.log`,
   (err, stdout, stderr) => {
     if (err) {
       console.error(err);
@@ -12,5 +12,5 @@ exec(
       console.log(`stdout: ${stdout}`);
       console.log(`stderr: ${stderr}`);
     }
-  },
+  }
 );

--- a/packages/wallet/src/contract-tests/transactions.test.ts
+++ b/packages/wallet/src/contract-tests/transactions.test.ts
@@ -1,7 +1,7 @@
-import {ethers} from "ethers";
+import { ethers } from "ethers";
 
-import {signCommitment, signVerificationData, signCommitment2} from "../domain";
-import {getLibraryAddress, createChallenge, concludeGame} from "./test-utils";
+import { signCommitment, signVerificationData, signCommitment2 } from "../domain";
+import { getLibraryAddress, createChallenge, concludeGame } from "./test-utils";
 import {
   createForceMoveTransaction,
   createDepositTransaction,
@@ -11,18 +11,18 @@ import {
   createWithdrawTransaction,
   ConcludeAndWithdrawArgs,
   createConcludeAndWithdrawTransaction,
-  createTransferAndWithdrawTransaction
+  createTransferAndWithdrawTransaction,
 } from "../utils/transaction-generator";
 
-import {depositContract} from "./test-utils";
-import {Channel, Commitment, CommitmentType} from "fmg-core";
-import {channelID} from "fmg-core/lib/channel";
-import {getGanacheProvider} from "@statechannels/devtools";
-import {transactionSender} from "../redux/sagas/transaction-sender";
-import {testSaga} from "redux-saga-test-plan";
-import {getProvider} from "../utils/contract-utils";
-import {transactionSent, transactionSubmitted, transactionConfirmed} from "../redux/actions";
-import {ADJUDICATOR_ADDRESS, ETH_ASSET_HOLDER_ADDRESS} from "../constants";
+import { depositContract } from "./test-utils";
+import { Channel, Commitment, CommitmentType } from "fmg-core";
+import { channelID } from "fmg-core/lib/channel";
+import { getGanacheProvider } from "@statechannels/devtools";
+import { transactionSender } from "../redux/sagas/transaction-sender";
+import { testSaga } from "redux-saga-test-plan";
+import { getProvider } from "../utils/contract-utils";
+import { transactionSent, transactionSubmitted, transactionConfirmed } from "../redux/actions";
+import { ADJUDICATOR_ADDRESS, ETH_ASSET_HOLDER_ADDRESS } from "../constants";
 
 jest.setTimeout(90000);
 
@@ -42,10 +42,10 @@ describe("transactions", () => {
 
   async function testTransactionSender(transactionToSend) {
     const processId = "processId";
-    const queuedTransaction = {transactionRequest: transactionToSend, processId};
+    const queuedTransaction = { transactionRequest: transactionToSend, processId };
     const transactionPayload = {
       to: ADJUDICATOR_ADDRESS,
-      ...queuedTransaction.transactionRequest
+      ...queuedTransaction.transactionRequest,
     };
 
     // TODO: Currently we're actually attempting to send the transactions
@@ -59,18 +59,18 @@ describe("transactions", () => {
       .next(provider)
       .call([provider, provider.getSigner])
       .next(signer)
-      .put(transactionSent({processId}))
+      .put(transactionSent({ processId }))
       .next()
       .call([signer, signer.sendTransaction], transactionPayload)
       .next(transactionResult)
-      .put(transactionSubmitted({processId, transactionHash: transactionResult.hash || ""}))
+      .put(transactionSubmitted({ processId, transactionHash: transactionResult.hash || "" }))
       .next(transactionResult)
       .call([transactionResult, transactionResult.wait])
       .next(confirmedTransaction)
       .put(
         transactionConfirmed({
           processId,
-          contractAddress: confirmedTransaction.contractAddress
+          contractAddress: confirmedTransaction.contractAddress,
         })
       )
       .next()
@@ -80,8 +80,7 @@ describe("transactions", () => {
   beforeAll(async () => {
     const network = await provider.getNetwork();
     networkId = network.chainId;
-    libraryAddress = await getLibraryAddress(networkId);
-    
+    libraryAddress = await getLibraryAddress(networkId, "TrivialApp");
   });
 
   it("should deposit into the contract", async () => {
@@ -93,12 +92,12 @@ describe("transactions", () => {
     await testTransactionSender({
       ...depositTransactionData,
       to: ETH_ASSET_HOLDER_ADDRESS,
-      value: 5
+      value: 5,
     });
   });
 
   it("should send a forceMove transaction", async () => {
-    const channel: Channel = {channelType: libraryAddress, nonce: getNextNonce(), participants};
+    const channel: Channel = { channelType: libraryAddress, nonce: getNextNonce(), participants };
     await depositContract(provider, participantA.address);
     await depositContract(provider, participantB.address);
 
@@ -109,7 +108,7 @@ describe("transactions", () => {
       turnNum: 4,
       commitmentType: CommitmentType.App,
       appAttributes: "0x0",
-      commitmentCount: 0
+      commitmentCount: 0,
     };
 
     const toCommitment: Commitment = {
@@ -119,7 +118,7 @@ describe("transactions", () => {
       turnNum: 5,
       commitmentType: CommitmentType.App,
       appAttributes: "0x0",
-      commitmentCount: 1
+      commitmentCount: 1,
     };
 
     const forceMoveTransaction = createForceMoveTransaction(
@@ -132,8 +131,8 @@ describe("transactions", () => {
   });
 
   it.skip("should send a respondWithMove transaction", async () => {
-    const channel: Channel = {channelType: libraryAddress, nonce: getNextNonce(), participants};
-    const {nonce: channelNonce} = channel;
+    const channel: Channel = { channelType: libraryAddress, nonce: getNextNonce(), participants };
+    const { nonce: channelNonce } = channel;
     await depositContract(provider, participantA.address);
     await depositContract(provider, participantB.address);
     await createChallenge(provider, channelNonce, participantA, participantB);
@@ -144,7 +143,7 @@ describe("transactions", () => {
       turnNum: 7,
       commitmentType: CommitmentType.App,
       appAttributes: "0x0",
-      commitmentCount: 1
+      commitmentCount: 1,
     };
 
     const respondWithMoveTransaction = createRespondWithMoveTransaction(toCommitment, participantB.privateKey);
@@ -152,8 +151,8 @@ describe("transactions", () => {
   });
 
   it.skip("should send a refute transaction", async () => {
-    const channel: Channel = {channelType: libraryAddress, nonce: getNextNonce(), participants};
-    const {nonce: channelNonce} = channel;
+    const channel: Channel = { channelType: libraryAddress, nonce: getNextNonce(), participants };
+    const { nonce: channelNonce } = channel;
     await depositContract(provider, participantA.address);
     await depositContract(provider, participantB.address);
     await createChallenge(provider, channelNonce, participantA, participantB);
@@ -164,7 +163,7 @@ describe("transactions", () => {
       turnNum: 8,
       commitmentType: CommitmentType.App,
       appAttributes: "0x0",
-      commitmentCount: 1
+      commitmentCount: 1,
     };
 
     const toSig = signCommitment(toCommitment, participantA.privateKey);
@@ -174,7 +173,7 @@ describe("transactions", () => {
   });
 
   it.skip("should send a conclude transaction", async () => {
-    const channel: Channel = {channelType: libraryAddress, nonce: getNextNonce(), participants};
+    const channel: Channel = { channelType: libraryAddress, nonce: getNextNonce(), participants };
     await depositContract(provider, participantA.address);
     await depositContract(provider, participantB.address);
     const fromCommitment: Commitment = {
@@ -184,7 +183,7 @@ describe("transactions", () => {
       turnNum: 5,
       commitmentType: CommitmentType.Conclude,
       appAttributes: "0x0",
-      commitmentCount: 0
+      commitmentCount: 0,
     };
 
     const toCommitment: Commitment = {
@@ -194,7 +193,7 @@ describe("transactions", () => {
       turnNum: 6,
       commitmentType: CommitmentType.Conclude,
       appAttributes: "0x0",
-      commitmentCount: 1
+      commitmentCount: 1,
     };
     const signedFromCommitment = signCommitment2(fromCommitment, participantA.privateKey);
     const signedToCommitment = signCommitment2(toCommitment, participantB.privateKey);
@@ -204,7 +203,7 @@ describe("transactions", () => {
   });
 
   it.skip("should send a transferAndWithdraw transaction", async () => {
-    const channel: Channel = {channelType: libraryAddress, nonce: getNextNonce(), participants};
+    const channel: Channel = { channelType: libraryAddress, nonce: getNextNonce(), participants };
     const channelId = channelID(channel);
     await depositContract(provider, channelId);
     await depositContract(provider, channelId);
@@ -237,17 +236,12 @@ describe("transactions", () => {
       senderAddress,
       participantA.privateKey
     );
-    const withdrawTransaction = createWithdrawTransaction(
-      "0x01",
-      participantA.address,
-      participantA.address,
-      verificationSignature
-    );
+    const withdrawTransaction = createWithdrawTransaction("0x01", participantA.address, participantA.address, verificationSignature);
     await testTransactionSender(withdrawTransaction);
   });
 
   it.skip("should send a conclude and withdraw transaction", async () => {
-    const channel: Channel = {channelType: libraryAddress, nonce: getNextNonce(), participants};
+    const channel: Channel = { channelType: libraryAddress, nonce: getNextNonce(), participants };
     const channelId = channelID(channel);
     await depositContract(provider, channelId);
     const senderAddress = await provider.getSigner().getAddress();
@@ -265,7 +259,7 @@ describe("transactions", () => {
       turnNum: 5,
       commitmentType: CommitmentType.Conclude,
       appAttributes: "0x0",
-      commitmentCount: 0
+      commitmentCount: 0,
     };
 
     const toCommitment: Commitment = {
@@ -275,7 +269,7 @@ describe("transactions", () => {
       turnNum: 6,
       commitmentType: CommitmentType.Conclude,
       appAttributes: "0x0",
-      commitmentCount: 1
+      commitmentCount: 1,
     };
     const fromSignature = signCommitment(fromCommitment, participantA.privateKey);
     const toSignature = signCommitment(toCommitment, participantB.privateKey);
@@ -288,7 +282,7 @@ describe("transactions", () => {
       verificationSignature,
       participant: participantA.address,
       destination: participantA.address,
-      amount: "0x05"
+      amount: "0x05",
     };
     const concludeAndWithdrawTransaction = createConcludeAndWithdrawTransaction(args);
     await testTransactionSender(concludeAndWithdrawTransaction);

--- a/packages/wallet/src/contract-tests/transactions.test.ts
+++ b/packages/wallet/src/contract-tests/transactions.test.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 
 import { signCommitment, signVerificationData, signCommitment2 } from "../domain";
-import { getLibraryAddress, createChallenge, concludeGame } from "./test-utils";
+import { createChallenge, concludeGame } from "./test-utils";
 import {
   createForceMoveTransaction,
   createDepositTransaction,
@@ -20,7 +20,7 @@ import { channelID } from "fmg-core/lib/channel";
 import { getGanacheProvider } from "@statechannels/devtools";
 import { transactionSender } from "../redux/sagas/transaction-sender";
 import { testSaga } from "redux-saga-test-plan";
-import { getProvider } from "../utils/contract-utils";
+import { getProvider, getLibraryAddress } from "../utils/contract-utils";
 import { transactionSent, transactionSubmitted, transactionConfirmed } from "../redux/actions";
 import { ADJUDICATOR_ADDRESS, ETH_ASSET_HOLDER_ADDRESS } from "../constants";
 


### PR DESCRIPTION
Gets etherlime working with the fixed `CHAIN_NETWORK_ID` and change `getLibraryAddress` to be a sync method.

This allows us to treat contract addresses as constants as we were before.