### PR TITLE
Separate build process in circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
       - run:
           command: yarn startGanache
           background: true
-      - run: yarn test:ci --since $(git merge-base $CIRCLE_BRANCH origin/master)
+      - run: yarn test:ci
       - upload_logs:
           file: test-stats
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,21 +50,17 @@ commands:
           destination: << parameters.file >>
 
 jobs:
-  build:
+  prepare:
     <<: *defaults
     steps:
       - <<: *restore_code
       - checkout
       - log_stats:
-          file: build-stats
+          file: prepare-stats
       - <<: *save_code
       - <<: *restore_dep
-      - run:
-          name: "yarn --frozen-lockfile"
-          command: yarn --frozen-lockfile
-
-      - run: yarn build:ci
-
+      - run: yarn --frozen-lockfile
+      - run: yarn prepare
       - <<: *save_dep
 
       - persist_to_workspace:
@@ -76,7 +72,16 @@ jobs:
             - packages/*/node_modules
             - node_modules
       - upload_logs:
-          file: build-stats
+          file: prepare-stats
+
+  build:
+    <<: *defaults
+    steps:
+      - <<: *restore_code
+      - checkout
+      - attach_workspace:
+          at: /home/circleci/project
+      - run: yarn build:ci
 
   lint:
     <<: *defaults
@@ -89,7 +94,6 @@ jobs:
 
   test:
     <<: *defaults
-
     steps:
       - <<: *restore_code
       - checkout
@@ -107,12 +111,16 @@ jobs:
 workflows:
   statechannels:
     jobs:
-      - build
+      - prepare
+
+      - build:
+          requires:
+            - prepare
 
       - lint:
           requires:
-            - build
+            - prepare
 
       - test:
           requires:
-            - build
+            - prepare

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "lerna run build",
-    "build:ci": "lerna run build:ci",
+    "build:ci": "lerna run --since $(git merge-base $CIRCLE_BRANCH origin/master) build:ci",
     "run:w3t": "lerna run start --parallel --scope=**/web3torrent ",
     "clean": "git clean -Xdf --exclude=\"!.env\"",
     "clean:dry": "git clean -Xdn --exclude=\"!.env\"",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "node": "10.16.3"
   },
   "scripts": {
+    "prepare": "lerna run --parallel prepare",
     "build": "lerna run build",
     "build:ci": "lerna run --since $(git merge-base $CIRCLE_BRANCH origin/master) build:ci",
     "run:w3t": "lerna run start --parallel --scope=**/web3torrent ",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": "10.16.3"
   },
   "scripts": {
-    "prepare": "lerna run --parallel prepare",
+    "prepare": "lerna run --concurrency 2 --stream prepare",
     "build": "lerna run build",
     "build:ci": "lerna run --since $(git merge-base $CIRCLE_BRANCH origin/master) build:ci",
     "run:w3t": "lerna run start --parallel --scope=**/web3torrent ",

--- a/packages/jest-gas-reporter/package.json
+++ b/packages/jest-gas-reporter/package.json
@@ -9,8 +9,7 @@
   "license": "MIT",
   "scripts": {
     "prepare": "yarn build",
-    "build": "tslint --project . && tsc -b",
-    "build:ci": "yarn build"
+    "build": "tslint --project . && tsc -b"
   },
   "devDependencies": {
     "@types/easy-table": "0.0.32",

--- a/packages/jest-gas-reporter/package.json
+++ b/packages/jest-gas-reporter/package.json
@@ -8,6 +8,7 @@
   "author": "Alex Gap <alex@magmo.com>",
   "license": "MIT",
   "scripts": {
+    "prepare": "yarn build",
     "build": "tslint --project . && tsc -b",
     "build:ci": "yarn build"
   },

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -41,7 +41,7 @@
     "deploy": "npx etherlime deploy --compile=false",
     "lint:check": "npx tslint --config tslint.json --project .",
     "lint:write": "npx tslint --config tslint.json --project . --fix",
-    "prepare": "yarn build",
+    "prepare": "yarn build:typescript",
     "prettier:check": "npx prettier --check '{contracts,src,test}/**/*.{ts,tsx,sol}'",
     "prettier:write": "npx prettier --write '{contracts,src,test}/**/*.{ts,tsx,sol}'",
     "startGanache": "node bin/start-ganache.js",

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -32,7 +32,6 @@
   "homepage": "https://github.com/statechannels/nitro-protocol/",
   "scripts": {
     "build": "run-s clearContracts clearLib contract:compile build:typescript",
-    "build:ci": "yarn build",
     "build:typescript": "tslint --project . && tsc -b",
     "clearContracts": "rm -rf build/contracts",
     "clearLib": "rm -rf lib",
@@ -41,7 +40,7 @@
     "deploy": "npx etherlime deploy --compile=false",
     "lint:check": "npx tslint --config tslint.json --project .",
     "lint:write": "npx tslint --config tslint.json --project . --fix",
-    "prepare": "yarn contract:compile && yarn build:typescript",
+    "prepare": "yarn build",
     "prettier:check": "npx prettier --check '{contracts,src,test}/**/*.{ts,tsx,sol}'",
     "prettier:write": "npx prettier --write '{contracts,src,test}/**/*.{ts,tsx,sol}'",
     "startGanache": "node bin/start-ganache.js",

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -41,7 +41,7 @@
     "deploy": "npx etherlime deploy --compile=false",
     "lint:check": "npx tslint --config tslint.json --project .",
     "lint:write": "npx tslint --config tslint.json --project . --fix",
-    "prepare": "yarn build:typescript",
+    "prepare": "yarn contract:compile && yarn build:typescript",
     "prettier:check": "npx prettier --check '{contracts,src,test}/**/*.{ts,tsx,sol}'",
     "prettier:write": "npx prettier --write '{contracts,src,test}/**/*.{ts,tsx,sol}'",
     "startGanache": "node bin/start-ganache.js",


### PR DESCRIPTION
### Description

Since `packageA` is linked to `packageB` when `packageA` depends on `packageB`, some of the current build process is needed for tests to run in `packageA`. An example of this is the `wallet` package depending on `nitro-protocol`.

However, some of the build process is not needed to run tests, such as `build:webpack` in the `wallet` package. This script takes over 30s on my laptop. The goal of running `yarn build:webpack` in a circleci build is to make sure that the current changes don't break the app in a way not covered by our test suite.

This PR separates the build commands required by dependencies from commands building the project for production. The former go in `prepare`, and are run in the `prepare` job on circle. The latter go in `build:ci`, and go into the `build` job on circle. `build:ci` is only run on packages that have changed in the current branch.

It seems to save about 30s per build.

Open to alternative script names. One idea:
- `yarn build:ci` to prepare the circle workspace
- `yarn build:production` to test the production build sequence