### PR TITLE
Add sourceMap to nitro-protocol

### DIFF
--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -2,7 +2,7 @@
   "name": "@statechannels/nitro-protocol",
   "version": "0.0.1",
   "description": "A protocol for state channel networks",
-  "main": "src/index.ts",
+  "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
   "files": [
     "lib/*",

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -2,7 +2,7 @@
   "name": "@statechannels/nitro-protocol",
   "version": "0.0.1",
   "description": "A protocol for state channel networks",
-  "main": "lib/src/index.js",
+  "main": "src/index.ts",
   "types": "lib/src/index.d.ts",
   "files": [
     "lib/*",

--- a/packages/nitro-protocol/tsconfig.json
+++ b/packages/nitro-protocol/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     "lib": ["es5", "es6"],
+    "sourceMap": true,
     "composite": true,
     "allowJs": false /* Allow javascript files to be compiled. */,
     "outDir": "lib" /* Redirect output structure to the directory. */,


### PR DESCRIPTION
This has been helpful for me while writing transactions tests.

~It also makes `nitro-protocol` only export `.ts` files.~