### PR TITLE
Remove redundant abi.encode calls

### DIFF
--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -587,7 +587,7 @@ contract ForceMove {
     }
 
     function _hashOutcome(bytes memory outcome) internal pure returns (bytes32) {
-        return keccak256(abi.encode(outcome));
+        return keccak256(outcome);
     }
 
     function _getChannelId(FixedPart memory fixedPart) internal pure returns (bytes32 channelId) {

--- a/packages/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -21,7 +21,7 @@ contract NitroAdjudicator is ForceMove {
         // requirements
         _requireChannelFinalized(channelId);
 
-        bytes32 outcomeHash = keccak256(abi.encode(outcomeBytes));
+        bytes32 outcomeHash = keccak256(outcomeBytes);
 
         _requireMatchingStorage(
             ChannelStorage(

--- a/packages/nitro-protocol/docs/adjudicator/state-format.md
+++ b/packages/nitro-protocol/docs/adjudicator/state-format.md
@@ -34,7 +34,7 @@ Since updates must ultimately be interpreted by smart contracts, the encoding of
         //         variablePart.appData
         //     )
         // )
-        bytes32 outcomeHash; //  keccak256(abi.encode(outcome))
+        bytes32 outcomeHash; //  keccak256(outcome)
     }
 ```
 


### PR DESCRIPTION
I don't think these are necessary when the only input is a `bytes` type.