### PR TITLE
Linting improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,16 +81,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: /home/circleci/project
-      - run: yarn build:ci
-
-  lint:
-    <<: *defaults
-    steps:
-      - <<: *restore_code
-      - checkout
-      - attach_workspace:
-          at: /home/circleci/project
       - run: yarn lint:check
+      - run: yarn build:ci
 
   test:
     <<: *defaults
@@ -114,10 +106,6 @@ workflows:
       - prepare
 
       - build:
-          requires:
-            - prepare
-
-      - lint:
           requires:
             - prepare
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lerna run --concurrency 1 --stream precommit"
+      "pre-commit": "lerna run --concurrency 1 --stream precommit --since HEAD~1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lerna run --concurrency 1 --stream precommit --since HEAD~1"
+      "pre-commit": "lerna run --concurrency 1 --stream precommit --since HEAD"
     }
   }
 }


### PR DESCRIPTION
The `build` circle job never seems to be rate-limiting, so adding `yarn lint:ci` to it won't slow down the workflow, but will save ~20s of container time.

In addition, if `HEAD` was already lint-checked, I believe we only have to lint-check packages that have changed based on the staged changes.