### PR TITLE
[wallet] Type action names

### DIFF
--- a/packages/wallet/src/contract-tests/adjudicator-events.test.ts
+++ b/packages/wallet/src/contract-tests/adjudicator-events.test.ts
@@ -15,7 +15,7 @@ import * as walletStates from "../redux/state";
 import {getGanacheProvider} from "@statechannels/devtools";
 jest.setTimeout(60000);
 
-const Action = actions.WalletActionType;
+const WalletActionType = actions.WalletActionType;
 
 const createWatcherState = (processId: string, ...channelIds: string[]): walletStates.Initialized => {
   const channelSubscriptions: walletStates.ChannelSubscriptions = {};
@@ -113,7 +113,7 @@ describe.skip("adjudicator listener", () => {
     const sagaTester = new SagaTester({initialState: createWatcherState(processId, channelId)});
     sagaTester.start(adjudicatorWatcher, provider);
     await createChallenge(provider, channelNonce, participantA, participantB);
-    await sagaTester.waitFor(Action.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET);
+    await sagaTester.waitFor(WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET);
 
     const action: actions.ChallengeExpirySetEvent = sagaTester.getLatestCalledAction();
     expect(action.expiryTime).toBeGreaterThan(startTimestamp);
@@ -130,7 +130,7 @@ describe.skip("adjudicator listener", () => {
 
     const challengeState = await createChallenge(provider, channelNonce, participantA, participantB);
 
-    await sagaTester.waitFor(Action.WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT);
+    await sagaTester.waitFor(WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT);
 
     const action: actions.ChallengeCreatedEvent = sagaTester.getLatestCalledAction();
 
@@ -147,7 +147,7 @@ describe.skip("adjudicator listener", () => {
 
     await concludeGame(provider, channelNonce, participantA, participantB);
 
-    await sagaTester.waitFor("WALLET.ADJUDICATOR.CONCLUDED_EVENT");
+    await sagaTester.waitFor(WalletActionType.WALLET_ADJUDICATOR_CONCLUDED_EVENT);
     const action: actions.ConcludedEvent = sagaTester.getLatestCalledAction();
 
     expect(action).toEqual(actions.concludedEvent({channelId}));
@@ -164,7 +164,7 @@ describe.skip("adjudicator listener", () => {
 
     const refuteCommitment = await refuteChallenge(provider, channelNonce, participantA, participantB);
 
-    await sagaTester.waitFor("WALLET.ADJUDICATOR.REFUTED_EVENT");
+    await sagaTester.waitFor(WalletActionType.WALLET_ADJUDICATOR_REFUTED_EVENT);
 
     const action: actions.RefutedEvent = sagaTester.getLatestCalledAction();
     expect(action).toEqual(actions.refutedEvent({processId, protocolLocator: [], channelId, refuteCommitment}));

--- a/packages/wallet/src/contract-tests/adjudicator-events.test.ts
+++ b/packages/wallet/src/contract-tests/adjudicator-events.test.ts
@@ -67,7 +67,7 @@ describe.skip("adjudicator listener", () => {
     sagaTester.start(adjudicatorWatcher, provider);
     await depositContract(provider, channelId);
 
-    expect(sagaTester.numCalled("WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT")).toEqual(0);
+    expect(sagaTester.numCalled(WalletActionType.WALLET_ADJUDICATOR_FUNDING_RECEIVED_EVENT)).toEqual(0);
   });
 
   it.skip("should ignore events for other channels", async () => {
@@ -78,7 +78,7 @@ describe.skip("adjudicator listener", () => {
     sagaTester.start(adjudicatorWatcher, provider);
 
     await depositContract(provider, channelIdToIgnore);
-    expect(sagaTester.numCalled("WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT")).toEqual(0);
+    expect(sagaTester.numCalled(WalletActionType.WALLET_ADJUDICATOR_FUNDING_RECEIVED_EVENT)).toEqual(0);
   });
 
   it.skip("should handle a funds received event when registered for that channel", async () => {
@@ -90,7 +90,7 @@ describe.skip("adjudicator listener", () => {
     sagaTester.start(adjudicatorWatcher, provider);
 
     await depositContract(provider, channelId);
-    await sagaTester.waitFor("WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT");
+    await sagaTester.waitFor(WalletActionType.WALLET_ADJUDICATOR_FUNDING_RECEIVED_EVENT);
 
     const action: actions.FundingReceivedEvent = sagaTester.getLatestCalledAction();
     expect(action).toEqual(

--- a/packages/wallet/src/contract-tests/adjudicator-events.test.ts
+++ b/packages/wallet/src/contract-tests/adjudicator-events.test.ts
@@ -15,6 +15,8 @@ import * as walletStates from "../redux/state";
 import {getGanacheProvider} from "@statechannels/devtools";
 jest.setTimeout(60000);
 
+const Action = actions.WalletActionType;
+
 const createWatcherState = (processId: string, ...channelIds: string[]): walletStates.Initialized => {
   const channelSubscriptions: walletStates.ChannelSubscriptions = {};
   for (const channelId of channelIds) {
@@ -111,7 +113,7 @@ describe.skip("adjudicator listener", () => {
     const sagaTester = new SagaTester({initialState: createWatcherState(processId, channelId)});
     sagaTester.start(adjudicatorWatcher, provider);
     await createChallenge(provider, channelNonce, participantA, participantB);
-    await sagaTester.waitFor("WALLET.ADJUDICATOR.CHALLENGE_EXPIRY_TIME_SET");
+    await sagaTester.waitFor(Action.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET);
 
     const action: actions.ChallengeExpirySetEvent = sagaTester.getLatestCalledAction();
     expect(action.expiryTime).toBeGreaterThan(startTimestamp);
@@ -128,7 +130,7 @@ describe.skip("adjudicator listener", () => {
 
     const challengeState = await createChallenge(provider, channelNonce, participantA, participantB);
 
-    await sagaTester.waitFor("WALLET.ADJUDICATOR.CHALLENGE_CREATED_EVENT");
+    await sagaTester.waitFor(Action.WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT);
 
     const action: actions.ChallengeCreatedEvent = sagaTester.getLatestCalledAction();
 

--- a/packages/wallet/src/contract-tests/adjudicator-events.test.ts
+++ b/packages/wallet/src/contract-tests/adjudicator-events.test.ts
@@ -182,7 +182,7 @@ describe.skip("adjudicator listener", () => {
 
     const response = await respondWithMove(provider, channelNonce, participantA, participantB);
 
-    await sagaTester.waitFor("WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT");
+    await sagaTester.waitFor(WalletActionType.WALLET_ADJUDICATOR_RESPOND_WITH_MOVE_EVENT);
 
     const action: actions.RespondWithMoveEvent = sagaTester.getLatestCalledAction();
     expect(action).toEqual(

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -29,6 +29,8 @@ export enum WalletActionType {
   METAMASK_LOAD_ERROR = "METAMASK_LOAD_ERROR",
   WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET = "WALLET.ADJUDICATOR.CHALLENGE_EXPIRY_TIME_SET",
   WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT = "WALLET.ADJUDICATOR.CHALLENGE_CREATED_EVENT",
+  WALLET_ADJUDICATOR_CONCLUDED_EVENT = "WALLET.ADJUDICATOR.CONCLUDED_EVENT",
+  WALLET_ADJUDICATOR_REFUTED_EVENT = "WALLET.ADJUDICATOR.REFUTED_EVENT",
   WALLET_MULTIPLE_ACTIONS = "WALLET.MULTIPLE_ACTIONS",
   WALLET_LOGGED_IN = "WALLET.LOGGED_IN",
   WALLET_ADJUDICATOR_KNOWN = "WALLET.ADJUDICATOR_KNOWN",
@@ -91,11 +93,11 @@ export interface ChallengeCreatedEvent {
 
 export interface ConcludedEvent {
   channelId: string;
-  type: "WALLET.ADJUDICATOR.CONCLUDED_EVENT";
+  type: WalletActionType.WALLET_ADJUDICATOR_CONCLUDED_EVENT;
 }
 
 export interface RefutedEvent {
-  type: "WALLET.ADJUDICATOR.REFUTED_EVENT";
+  type: WalletActionType.WALLET_ADJUDICATOR_REFUTED_EVENT;
   processId: string;
   protocolLocator: ProtocolLocator;
   channelId: string;
@@ -179,12 +181,12 @@ export const challengeCreatedEvent: ActionConstructor<ChallengeCreatedEvent> = p
 
 export const concludedEvent: ActionConstructor<ConcludedEvent> = p => ({
   ...p,
-  type: "WALLET.ADJUDICATOR.CONCLUDED_EVENT"
+  type: WalletActionType.WALLET_ADJUDICATOR_CONCLUDED_EVENT
 });
 
 export const refutedEvent: ActionConstructor<RefutedEvent> = p => ({
   ...p,
-  type: "WALLET.ADJUDICATOR.REFUTED_EVENT"
+  type: WalletActionType.WALLET_ADJUDICATOR_REFUTED_EVENT
 });
 
 export const respondWithMoveEvent: ActionConstructor<RespondWithMoveEvent> = p => ({
@@ -259,8 +261,8 @@ export function isSharedDataUpdateAction(action: WalletAction): action is Shared
 
 export function isAdjudicatorEventAction(action: WalletAction): action is AdjudicatorEventAction {
   return (
-    action.type === "WALLET.ADJUDICATOR.CONCLUDED_EVENT" ||
-    action.type === "WALLET.ADJUDICATOR.REFUTED_EVENT" ||
+    action.type === WalletActionType.WALLET_ADJUDICATOR_CONCLUDED_EVENT ||
+    action.type === WalletActionType.WALLET_ADJUDICATOR_REFUTED_EVENT ||
     action.type === "WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT" ||
     action.type === "WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT" ||
     action.type === "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED" ||

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -24,8 +24,11 @@ export {CommitmentReceived, commitmentReceived};
 export type TransactionAction = TA;
 export const isTransactionAction = isTA;
 
-export enum Action {
+export enum WalletActionType {
   BLOCK_MINED = "BLOCK_MINED",
+  METAMASK_LOAD_ERROR = "METAMASK_LOAD_ERROR",
+  WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET = "WALLET.ADJUDICATOR.CHALLENGE_EXPIRY_TIME_SET",
+  WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT = "WALLET.ADJUDICATOR.CHALLENGE_CREATED_EVENT",
   WALLET_MULTIPLE_ACTIONS = "WALLET.MULTIPLE_ACTIONS",
   WALLET_LOGGED_IN = "WALLET.LOGGED_IN",
   WALLET_ADJUDICATOR_KNOWN = "WALLET.ADJUDICATOR_KNOWN",
@@ -38,41 +41,41 @@ export enum Action {
 // -------
 
 export interface MultipleWalletActions {
-  type: Action.WALLET_MULTIPLE_ACTIONS;
+  type: WalletActionType.WALLET_MULTIPLE_ACTIONS;
   actions: WalletAction[];
 }
 export interface LoggedIn {
-  type: Action.WALLET_LOGGED_IN;
+  type: WalletActionType.WALLET_LOGGED_IN;
   uid: string;
 }
 
 export interface AdjudicatorKnown {
-  type: Action.WALLET_ADJUDICATOR_KNOWN;
+  type: WalletActionType.WALLET_ADJUDICATOR_KNOWN;
   networkId: string;
   adjudicator: string;
 }
 
 export interface MessageSent {
-  type: Action.WALLET_MESSAGE_SENT;
+  type: WalletActionType.WALLET_MESSAGE_SENT;
 }
 
 export interface DisplayMessageSent {
-  type: Action.WALLET_DISPLAY_MESSAGE_SENT;
+  type: WalletActionType.WALLET_DISPLAY_MESSAGE_SENT;
 }
 
 export interface BlockMined {
-  type: Action.BLOCK_MINED;
+  type: WalletActionType.BLOCK_MINED;
   block: {timestamp: number; number: number};
 }
 
 export interface MetamaskLoadError {
-  type: "METAMASK_LOAD_ERROR";
+  type: WalletActionType.METAMASK_LOAD_ERROR;
 }
 
 export type Message = "FundingDeclined";
 
 export interface ChallengeExpirySetEvent {
-  type: "WALLET.ADJUDICATOR.CHALLENGE_EXPIRY_TIME_SET";
+  type: WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET;
   processId: string;
   protocolLocator: ProtocolLocator;
   channelId: string;
@@ -80,7 +83,7 @@ export interface ChallengeExpirySetEvent {
 }
 
 export interface ChallengeCreatedEvent {
-  type: "WALLET.ADJUDICATOR.CHALLENGE_CREATED_EVENT";
+  type: WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT;
   channelId: string;
   commitment: Commitment;
   finalizedAt: number;
@@ -137,41 +140,41 @@ export interface ChannelUpdate {
 
 export const multipleWalletActions: ActionConstructor<MultipleWalletActions> = p => ({
   ...p,
-  type: Action.WALLET_MULTIPLE_ACTIONS
+  type: WalletActionType.WALLET_MULTIPLE_ACTIONS
 });
 
-export const loggedIn: ActionConstructor<LoggedIn> = p => ({...p, type: Action.WALLET_LOGGED_IN});
+export const loggedIn: ActionConstructor<LoggedIn> = p => ({...p, type: WalletActionType.WALLET_LOGGED_IN});
 
 export const adjudicatorKnown: ActionConstructor<AdjudicatorKnown> = p => ({
   ...p,
-  type: Action.WALLET_ADJUDICATOR_KNOWN
+  type: WalletActionType.WALLET_ADJUDICATOR_KNOWN
 });
 
 export const messageSent: ActionConstructor<MessageSent> = p => ({
   ...p,
-  type: Action.WALLET_MESSAGE_SENT
+  type: WalletActionType.WALLET_MESSAGE_SENT
 });
 
 export const displayMessageSent: ActionConstructor<DisplayMessageSent> = p => ({
   ...p,
-  type: Action.WALLET_DISPLAY_MESSAGE_SENT
+  type: WalletActionType.WALLET_DISPLAY_MESSAGE_SENT
 });
 
-export const blockMined: ActionConstructor<BlockMined> = p => ({...p, type: Action.BLOCK_MINED});
+export const blockMined: ActionConstructor<BlockMined> = p => ({...p, type: WalletActionType.BLOCK_MINED});
 
 export const metamaskLoadError: ActionConstructor<MetamaskLoadError> = p => ({
   ...p,
-  type: "METAMASK_LOAD_ERROR"
+  type: WalletActionType.METAMASK_LOAD_ERROR
 });
 
 export const challengeExpirySetEvent: ActionConstructor<ChallengeExpirySetEvent> = p => ({
   ...p,
-  type: "WALLET.ADJUDICATOR.CHALLENGE_EXPIRY_TIME_SET"
+  type: WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET
 });
 
 export const challengeCreatedEvent: ActionConstructor<ChallengeCreatedEvent> = p => ({
   ...p,
-  type: "WALLET.ADJUDICATOR.CHALLENGE_CREATED_EVENT"
+  type: WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT
 });
 
 export const concludedEvent: ActionConstructor<ConcludedEvent> = p => ({
@@ -261,8 +264,8 @@ export function isAdjudicatorEventAction(action: WalletAction): action is Adjudi
     action.type === "WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT" ||
     action.type === "WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT" ||
     action.type === "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED" ||
-    action.type === "WALLET.ADJUDICATOR.CHALLENGE_CREATED_EVENT" ||
-    action.type === "WALLET.ADJUDICATOR.CHALLENGE_EXPIRY_TIME_SET" ||
+    action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT ||
+    action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET ||
     action.type === "WALLET.ADJUDICATOR.CHANNEL_UPDATE"
   );
 }

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -30,6 +30,7 @@ export enum WalletActionType {
   WALLET_ADJUDICATOR_CHALLENGE_EXPIRED = "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED",
   WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET = "WALLET.ADJUDICATOR.CHALLENGE_EXPIRY_TIME_SET",
   WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT = "WALLET.ADJUDICATOR.CHALLENGE_CREATED_EVENT",
+  WALLET_ADJUDICATOR_CHANNEL_UPDATE = "WALLET.ADJUDICATOR.CHANNEL_UPDATE",
   WALLET_ADJUDICATOR_CONCLUDED_EVENT = "WALLET.ADJUDICATOR.CONCLUDED_EVENT",
   WALLET_ADJUDICATOR_FUNDING_RECEIVED_EVENT = "WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT",
   WALLET_ADJUDICATOR_REFUTED_EVENT = "WALLET.ADJUDICATOR.REFUTED_EVENT",
@@ -134,7 +135,7 @@ export interface ChallengeExpiredEvent {
 }
 
 export interface ChannelUpdate {
-  type: "WALLET.ADJUDICATOR.CHANNEL_UPDATE";
+  type: WalletActionType.WALLET_ADJUDICATOR_CHANNEL_UPDATE;
   channelId: string;
   isFinalized: boolean;
   balance: string;
@@ -206,7 +207,7 @@ export const challengeExpiredEvent: ActionConstructor<ChallengeExpiredEvent> = p
 });
 export const channelUpdate: ActionConstructor<ChannelUpdate> = p => ({
   ...p,
-  type: "WALLET.ADJUDICATOR.CHANNEL_UPDATE"
+  type: WalletActionType.WALLET_ADJUDICATOR_CHANNEL_UPDATE
 });
 
 // -------
@@ -271,7 +272,7 @@ export function isAdjudicatorEventAction(action: WalletAction): action is Adjudi
     action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRED ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET ||
-    action.type === "WALLET.ADJUDICATOR.CHANNEL_UPDATE"
+    action.type === WalletActionType.WALLET_ADJUDICATOR_CHANNEL_UPDATE
   );
 }
 

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -25,8 +25,12 @@ export type TransactionAction = TA;
 export const isTransactionAction = isTA;
 
 export enum Action {
+  BLOCK_MINED = "BLOCK_MINED",
   WALLET_MULTIPLE_ACTIONS = "WALLET.MULTIPLE_ACTIONS",
-  WALLET_LOGGED_IN = "WALLET.LOGGED_IN"
+  WALLET_LOGGED_IN = "WALLET.LOGGED_IN",
+  WALLET_ADJUDICATOR_KNOWN = "WALLET.ADJUDICATOR_KNOWN",
+  WALLET_MESSAGE_SENT = "WALLET.MESSAGE_SENT",
+  WALLET_DISPLAY_MESSAGE_SENT = "WALLET.DISPLAY_MESSAGE_SENT"
 }
 
 // -------
@@ -43,21 +47,21 @@ export interface LoggedIn {
 }
 
 export interface AdjudicatorKnown {
-  type: "WALLET.ADJUDICATOR_KNOWN";
+  type: Action.WALLET_ADJUDICATOR_KNOWN;
   networkId: string;
   adjudicator: string;
 }
 
 export interface MessageSent {
-  type: "WALLET.MESSAGE_SENT";
+  type: Action.WALLET_MESSAGE_SENT;
 }
 
 export interface DisplayMessageSent {
-  type: "WALLET.DISPLAY_MESSAGE_SENT";
+  type: Action.WALLET_DISPLAY_MESSAGE_SENT;
 }
 
 export interface BlockMined {
-  type: "BLOCK_MINED";
+  type: Action.BLOCK_MINED;
   block: {timestamp: number; number: number};
 }
 
@@ -140,20 +144,20 @@ export const loggedIn: ActionConstructor<LoggedIn> = p => ({...p, type: Action.W
 
 export const adjudicatorKnown: ActionConstructor<AdjudicatorKnown> = p => ({
   ...p,
-  type: "WALLET.ADJUDICATOR_KNOWN"
+  type: Action.WALLET_ADJUDICATOR_KNOWN
 });
 
 export const messageSent: ActionConstructor<MessageSent> = p => ({
   ...p,
-  type: "WALLET.MESSAGE_SENT"
+  type: Action.WALLET_MESSAGE_SENT
 });
 
 export const displayMessageSent: ActionConstructor<DisplayMessageSent> = p => ({
   ...p,
-  type: "WALLET.DISPLAY_MESSAGE_SENT"
+  type: Action.WALLET_DISPLAY_MESSAGE_SENT
 });
 
-export const blockMined: ActionConstructor<BlockMined> = p => ({...p, type: "BLOCK_MINED"});
+export const blockMined: ActionConstructor<BlockMined> = p => ({...p, type: Action.BLOCK_MINED});
 
 export const metamaskLoadError: ActionConstructor<MetamaskLoadError> = p => ({
   ...p,

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -30,6 +30,7 @@ export enum WalletActionType {
   WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET = "WALLET.ADJUDICATOR.CHALLENGE_EXPIRY_TIME_SET",
   WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT = "WALLET.ADJUDICATOR.CHALLENGE_CREATED_EVENT",
   WALLET_ADJUDICATOR_CONCLUDED_EVENT = "WALLET.ADJUDICATOR.CONCLUDED_EVENT",
+  WALLET_ADJUDICATOR_FUNDING_RECEIVED_EVENT = "WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT",
   WALLET_ADJUDICATOR_REFUTED_EVENT = "WALLET.ADJUDICATOR.REFUTED_EVENT",
   WALLET_ADJUDICATOR_RESPOND_WITH_MOVE_EVENT = "WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT",
   WALLET_MULTIPLE_ACTIONS = "WALLET.MULTIPLE_ACTIONS",
@@ -115,7 +116,7 @@ export interface RespondWithMoveEvent {
 }
 
 export interface FundingReceivedEvent {
-  type: "WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT";
+  type: WalletActionType.WALLET_ADJUDICATOR_FUNDING_RECEIVED_EVENT;
   processId: string;
   protocolLocator: ProtocolLocator;
   channelId: string;
@@ -196,7 +197,7 @@ export const respondWithMoveEvent: ActionConstructor<RespondWithMoveEvent> = p =
 });
 export const fundingReceivedEvent: ActionConstructor<FundingReceivedEvent> = p => ({
   ...p,
-  type: "WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT"
+  type: WalletActionType.WALLET_ADJUDICATOR_FUNDING_RECEIVED_EVENT
 });
 export const challengeExpiredEvent: ActionConstructor<ChallengeExpiredEvent> = p => ({
   ...p,
@@ -265,7 +266,7 @@ export function isAdjudicatorEventAction(action: WalletAction): action is Adjudi
     action.type === WalletActionType.WALLET_ADJUDICATOR_CONCLUDED_EVENT ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_REFUTED_EVENT ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_RESPOND_WITH_MOVE_EVENT ||
-    action.type === "WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT" ||
+    action.type === WalletActionType.WALLET_ADJUDICATOR_FUNDING_RECEIVED_EVENT ||
     action.type === "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED" ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET ||

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -31,6 +31,7 @@ export enum WalletActionType {
   WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT = "WALLET.ADJUDICATOR.CHALLENGE_CREATED_EVENT",
   WALLET_ADJUDICATOR_CONCLUDED_EVENT = "WALLET.ADJUDICATOR.CONCLUDED_EVENT",
   WALLET_ADJUDICATOR_REFUTED_EVENT = "WALLET.ADJUDICATOR.REFUTED_EVENT",
+  WALLET_ADJUDICATOR_RESPOND_WITH_MOVE_EVENT = "WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT",
   WALLET_MULTIPLE_ACTIONS = "WALLET.MULTIPLE_ACTIONS",
   WALLET_LOGGED_IN = "WALLET.LOGGED_IN",
   WALLET_ADJUDICATOR_KNOWN = "WALLET.ADJUDICATOR_KNOWN",
@@ -110,7 +111,7 @@ export interface RespondWithMoveEvent {
   channelId: string;
   responseCommitment: Commitment;
   responseSignature: string;
-  type: "WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT";
+  type: WalletActionType.WALLET_ADJUDICATOR_RESPOND_WITH_MOVE_EVENT;
 }
 
 export interface FundingReceivedEvent {
@@ -191,7 +192,7 @@ export const refutedEvent: ActionConstructor<RefutedEvent> = p => ({
 
 export const respondWithMoveEvent: ActionConstructor<RespondWithMoveEvent> = p => ({
   ...p,
-  type: "WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT"
+  type: WalletActionType.WALLET_ADJUDICATOR_RESPOND_WITH_MOVE_EVENT
 });
 export const fundingReceivedEvent: ActionConstructor<FundingReceivedEvent> = p => ({
   ...p,
@@ -263,7 +264,7 @@ export function isAdjudicatorEventAction(action: WalletAction): action is Adjudi
   return (
     action.type === WalletActionType.WALLET_ADJUDICATOR_CONCLUDED_EVENT ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_REFUTED_EVENT ||
-    action.type === "WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT" ||
+    action.type === WalletActionType.WALLET_ADJUDICATOR_RESPOND_WITH_MOVE_EVENT ||
     action.type === "WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT" ||
     action.type === "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED" ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT ||

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -27,6 +27,7 @@ export const isTransactionAction = isTA;
 export enum WalletActionType {
   BLOCK_MINED = "BLOCK_MINED",
   METAMASK_LOAD_ERROR = "METAMASK_LOAD_ERROR",
+  WALLET_ADJUDICATOR_CHALLENGE_EXPIRED = "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED",
   WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET = "WALLET.ADJUDICATOR.CHALLENGE_EXPIRY_TIME_SET",
   WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT = "WALLET.ADJUDICATOR.CHALLENGE_CREATED_EVENT",
   WALLET_ADJUDICATOR_CONCLUDED_EVENT = "WALLET.ADJUDICATOR.CONCLUDED_EVENT",
@@ -125,7 +126,7 @@ export interface FundingReceivedEvent {
 }
 
 export interface ChallengeExpiredEvent {
-  type: "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED";
+  type: WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRED;
   processId: string;
   protocolLocator: ProtocolLocator;
   channelId: string;
@@ -201,7 +202,7 @@ export const fundingReceivedEvent: ActionConstructor<FundingReceivedEvent> = p =
 });
 export const challengeExpiredEvent: ActionConstructor<ChallengeExpiredEvent> = p => ({
   ...p,
-  type: "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED"
+  type: WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRED
 });
 export const channelUpdate: ActionConstructor<ChannelUpdate> = p => ({
   ...p,
@@ -267,7 +268,7 @@ export function isAdjudicatorEventAction(action: WalletAction): action is Adjudi
     action.type === WalletActionType.WALLET_ADJUDICATOR_REFUTED_EVENT ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_RESPOND_WITH_MOVE_EVENT ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_FUNDING_RECEIVED_EVENT ||
-    action.type === "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED" ||
+    action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRED ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET ||
     action.type === "WALLET.ADJUDICATOR.CHANNEL_UPDATE"

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -24,16 +24,21 @@ export {CommitmentReceived, commitmentReceived};
 export type TransactionAction = TA;
 export const isTransactionAction = isTA;
 
+export enum Action {
+  WALLET_MULTIPLE_ACTIONS = "WALLET.MULTIPLE_ACTIONS",
+  WALLET_LOGGED_IN = "WALLET.LOGGED_IN"
+}
+
 // -------
 // Actions
 // -------
 
 export interface MultipleWalletActions {
-  type: "WALLET.MULTIPLE_ACTIONS";
+  type: Action.WALLET_MULTIPLE_ACTIONS;
   actions: WalletAction[];
 }
 export interface LoggedIn {
-  type: "WALLET.LOGGED_IN";
+  type: Action.WALLET_LOGGED_IN;
   uid: string;
 }
 
@@ -128,10 +133,10 @@ export interface ChannelUpdate {
 
 export const multipleWalletActions: ActionConstructor<MultipleWalletActions> = p => ({
   ...p,
-  type: "WALLET.MULTIPLE_ACTIONS"
+  type: Action.WALLET_MULTIPLE_ACTIONS
 });
 
-export const loggedIn: ActionConstructor<LoggedIn> = p => ({...p, type: "WALLET.LOGGED_IN"});
+export const loggedIn: ActionConstructor<LoggedIn> = p => ({...p, type: Action.WALLET_LOGGED_IN});
 
 export const adjudicatorKnown: ActionConstructor<AdjudicatorKnown> = p => ({
   ...p,

--- a/packages/wallet/src/redux/adjudicator-state/reducer.ts
+++ b/packages/wallet/src/redux/adjudicator-state/reducer.ts
@@ -16,7 +16,7 @@ export const adjudicatorStateReducer = (
     case WalletActionType.WALLET_ADJUDICATOR_CONCLUDED_EVENT:
       return concludedEventReducer(state, action);
     case WalletActionType.WALLET_ADJUDICATOR_REFUTED_EVENT:
-    case "WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT":
+    case WalletActionType.WALLET_ADJUDICATOR_RESPOND_WITH_MOVE_EVENT:
       return challengeRespondedReducer(state, action);
     case WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT:
       return challengeCreatedEventReducer(state, action);

--- a/packages/wallet/src/redux/adjudicator-state/reducer.ts
+++ b/packages/wallet/src/redux/adjudicator-state/reducer.ts
@@ -20,7 +20,7 @@ export const adjudicatorStateReducer = (
       return challengeRespondedReducer(state, action);
     case WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT:
       return challengeCreatedEventReducer(state, action);
-    case "WALLET.ADJUDICATOR.CHANNEL_UPDATE":
+    case WalletActionType.WALLET_ADJUDICATOR_CHANNEL_UPDATE:
       return channelUpdateReducer(state, action);
     case WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET:
       // We already handle this in the challenge created event

--- a/packages/wallet/src/redux/adjudicator-state/reducer.ts
+++ b/packages/wallet/src/redux/adjudicator-state/reducer.ts
@@ -2,6 +2,8 @@ import {AdjudicatorState, clearChallenge, markAsFinalized, setBalance, setChalle
 import * as actions from "../actions";
 import {unreachable} from "../../utils/reducer-utils";
 
+const Action = actions.WalletActionType;
+
 export const adjudicatorStateReducer = (
   state: AdjudicatorState,
   action: actions.AdjudicatorEventAction | actions.ChallengeCreatedEvent
@@ -16,11 +18,11 @@ export const adjudicatorStateReducer = (
     case "WALLET.ADJUDICATOR.REFUTED_EVENT":
     case "WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT":
       return challengeRespondedReducer(state, action);
-    case "WALLET.ADJUDICATOR.CHALLENGE_CREATED_EVENT":
+    case Action.WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT:
       return challengeCreatedEventReducer(state, action);
     case "WALLET.ADJUDICATOR.CHANNEL_UPDATE":
       return channelUpdateReducer(state, action);
-    case "WALLET.ADJUDICATOR.CHALLENGE_EXPIRY_TIME_SET":
+    case Action.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET:
       // We already handle this in the challenge created event
       return state;
     default:

--- a/packages/wallet/src/redux/adjudicator-state/reducer.ts
+++ b/packages/wallet/src/redux/adjudicator-state/reducer.ts
@@ -11,7 +11,7 @@ export const adjudicatorStateReducer = (
   switch (action.type) {
     case "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED":
       return challengeExpiredReducer(state, action);
-    case "WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT":
+    case WalletActionType.WALLET_ADJUDICATOR_FUNDING_RECEIVED_EVENT:
       return fundingReceivedEventReducer(state, action);
     case WalletActionType.WALLET_ADJUDICATOR_CONCLUDED_EVENT:
       return concludedEventReducer(state, action);

--- a/packages/wallet/src/redux/adjudicator-state/reducer.ts
+++ b/packages/wallet/src/redux/adjudicator-state/reducer.ts
@@ -9,7 +9,7 @@ export const adjudicatorStateReducer = (
   action: actions.AdjudicatorEventAction | actions.ChallengeCreatedEvent
 ): AdjudicatorState => {
   switch (action.type) {
-    case "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED":
+    case WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRED:
       return challengeExpiredReducer(state, action);
     case WalletActionType.WALLET_ADJUDICATOR_FUNDING_RECEIVED_EVENT:
       return fundingReceivedEventReducer(state, action);

--- a/packages/wallet/src/redux/adjudicator-state/reducer.ts
+++ b/packages/wallet/src/redux/adjudicator-state/reducer.ts
@@ -2,7 +2,7 @@ import {AdjudicatorState, clearChallenge, markAsFinalized, setBalance, setChalle
 import * as actions from "../actions";
 import {unreachable} from "../../utils/reducer-utils";
 
-const Action = actions.WalletActionType;
+const WalletActionType = actions.WalletActionType;
 
 export const adjudicatorStateReducer = (
   state: AdjudicatorState,
@@ -13,16 +13,16 @@ export const adjudicatorStateReducer = (
       return challengeExpiredReducer(state, action);
     case "WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT":
       return fundingReceivedEventReducer(state, action);
-    case "WALLET.ADJUDICATOR.CONCLUDED_EVENT":
+    case WalletActionType.WALLET_ADJUDICATOR_CONCLUDED_EVENT:
       return concludedEventReducer(state, action);
-    case "WALLET.ADJUDICATOR.REFUTED_EVENT":
+    case WalletActionType.WALLET_ADJUDICATOR_REFUTED_EVENT:
     case "WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT":
       return challengeRespondedReducer(state, action);
-    case Action.WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT:
+    case WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT:
       return challengeCreatedEventReducer(state, action);
     case "WALLET.ADJUDICATOR.CHANNEL_UPDATE":
       return channelUpdateReducer(state, action);
-    case Action.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET:
+    case WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET:
       // We already handle this in the challenge created event
       return state;
     default:

--- a/packages/wallet/src/redux/outbox/reducer.ts
+++ b/packages/wallet/src/redux/outbox/reducer.ts
@@ -3,7 +3,7 @@ import * as actions from "../actions";
 
 export function clearOutbox(state: OutboxState, action: actions.WalletAction): OutboxState {
   const nextOutbox = {...state};
-  if (action.type === "WALLET.MESSAGE_SENT") {
+  if (action.type === actions.Action.WALLET_MESSAGE_SENT) {
     nextOutbox.messageOutbox = nextOutbox.messageOutbox.slice(1);
   }
   if (action.type === "WALLET.DISPLAY_MESSAGE_SENT") {

--- a/packages/wallet/src/redux/outbox/reducer.ts
+++ b/packages/wallet/src/redux/outbox/reducer.ts
@@ -1,12 +1,12 @@
 import {OutboxState} from "./state";
-import * as actions from "../actions";
+import {WalletAction, WalletActionType} from "../actions";
 
-export function clearOutbox(state: OutboxState, action: actions.WalletAction): OutboxState {
+export function clearOutbox(state: OutboxState, action: WalletAction): OutboxState {
   const nextOutbox = {...state};
-  if (action.type === actions.Action.WALLET_MESSAGE_SENT) {
+  if (action.type === WalletActionType.WALLET_MESSAGE_SENT) {
     nextOutbox.messageOutbox = nextOutbox.messageOutbox.slice(1);
   }
-  if (action.type === "WALLET.DISPLAY_MESSAGE_SENT") {
+  if (action.type === WalletActionType.WALLET_DISPLAY_MESSAGE_SENT) {
     nextOutbox.displayOutbox = nextOutbox.displayOutbox.slice(1);
   }
   if (action.type === "WALLET.TRANSACTION_SUBMISSION.TRANSACTION_SENT") {

--- a/packages/wallet/src/redux/protocols/direct-funding/actions.ts
+++ b/packages/wallet/src/redux/protocols/direct-funding/actions.ts
@@ -22,7 +22,7 @@ function isEmbeddedAction(action: actions.WalletAction): action is EmbeddedActio
 
 export function isDirectFundingAction(action: actions.WalletAction): action is DirectFundingAction {
   return (
-    action.type === "WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT" ||
+    action.type === actions.WalletActionType.WALLET_ADJUDICATOR_FUNDING_RECEIVED_EVENT ||
     isCommonAction(action, EmbeddedProtocol.DirectFunding) ||
     isEmbeddedAction(action)
   );

--- a/packages/wallet/src/redux/protocols/direct-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/direct-funding/reducer.ts
@@ -112,7 +112,10 @@ export const directFundingStateReducer: DFReducer = (
   sharedData: SharedData,
   action: actions.WalletAction
 ): ProtocolStateWithSharedData<states.DirectFundingState> => {
-  if (action.type === "WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT" && action.channelId === state.channelId) {
+  if (
+    action.type === actions.WalletActionType.WALLET_ADJUDICATOR_FUNDING_RECEIVED_EVENT &&
+    action.channelId === state.channelId
+  ) {
     if (bigNumberify(action.totalForDestination).gte(state.totalFundingRequired)) {
       return fundingConfirmedReducer(state, sharedData, action);
     }
@@ -155,7 +158,7 @@ const notSafeToDepositReducer: DFReducer = (
   action: actions.WalletAction
 ): ProtocolStateWithSharedData<states.DirectFundingState> => {
   switch (action.type) {
-    case "WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT":
+    case actions.WalletActionType.WALLET_ADJUDICATOR_FUNDING_RECEIVED_EVENT:
       if (
         action.channelId === state.channelId &&
         bigNumberify(action.totalForDestination).gte(state.safeToDepositLevel)
@@ -194,7 +197,7 @@ const waitForDepositTransactionReducer: DFReducer = (
   sharedData: SharedData,
   action: actions.WalletAction
 ): ProtocolStateWithSharedData<states.DirectFundingState> => {
-  if (action.type === "WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT") {
+  if (action.type === actions.WalletActionType.WALLET_ADJUDICATOR_FUNDING_RECEIVED_EVENT) {
     return {protocolState: {...protocolState, funded: true}, sharedData};
   }
   if (!isTransactionAction(action)) {
@@ -238,7 +241,7 @@ const channelFundedReducer: DFReducer = (
   sharedData: SharedData,
   action: actions.WalletAction
 ): ProtocolStateWithSharedData<states.DirectFundingState> => {
-  if (action.type === "WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT") {
+  if (action.type === actions.WalletActionType.WALLET_ADJUDICATOR_FUNDING_RECEIVED_EVENT) {
     if (bigNumberify(action.totalForDestination).lt(state.totalFundingRequired)) {
       // TODO: Deal with chain re-orgs that de-fund the channel here
       return {protocolState: state, sharedData};

--- a/packages/wallet/src/redux/protocols/dispute/challenger/actions.ts
+++ b/packages/wallet/src/redux/protocols/dispute/challenger/actions.ts
@@ -78,7 +78,7 @@ export function isChallengerAction(action: WalletAction): action is ChallengerAc
     action.type === "WALLET.DISPUTE.CHALLENGER.CHALLENGE_APPROVED" ||
     action.type === "WALLET.DISPUTE.CHALLENGER.CHALLENGE_DENIED" ||
     action.type === "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED" ||
-    action.type === "WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT" ||
+    action.type === WalletActionType.WALLET_ADJUDICATOR_RESPOND_WITH_MOVE_EVENT ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_REFUTED_EVENT ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET ||
     action.type === "WALLET.DISPUTE.CHALLENGER.ACKNOWLEDGED" ||

--- a/packages/wallet/src/redux/protocols/dispute/challenger/actions.ts
+++ b/packages/wallet/src/redux/protocols/dispute/challenger/actions.ts
@@ -79,7 +79,7 @@ export function isChallengerAction(action: WalletAction): action is ChallengerAc
     action.type === "WALLET.DISPUTE.CHALLENGER.CHALLENGE_DENIED" ||
     action.type === "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED" ||
     action.type === "WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT" ||
-    action.type === "WALLET.ADJUDICATOR.REFUTED_EVENT" ||
+    action.type === WalletActionType.WALLET_ADJUDICATOR_REFUTED_EVENT ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET ||
     action.type === "WALLET.DISPUTE.CHALLENGER.ACKNOWLEDGED" ||
     action.type === "WALLET.DISPUTE.CHALLENGER.EXIT_CHALLENGE"

--- a/packages/wallet/src/redux/protocols/dispute/challenger/actions.ts
+++ b/packages/wallet/src/redux/protocols/dispute/challenger/actions.ts
@@ -77,7 +77,7 @@ export function isChallengerAction(action: WalletAction): action is ChallengerAc
     isTransactionAction(action) ||
     action.type === "WALLET.DISPUTE.CHALLENGER.CHALLENGE_APPROVED" ||
     action.type === "WALLET.DISPUTE.CHALLENGER.CHALLENGE_DENIED" ||
-    action.type === "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED" ||
+    action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRED ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_RESPOND_WITH_MOVE_EVENT ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_REFUTED_EVENT ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET ||

--- a/packages/wallet/src/redux/protocols/dispute/challenger/actions.ts
+++ b/packages/wallet/src/redux/protocols/dispute/challenger/actions.ts
@@ -3,7 +3,8 @@ import {
   RefutedEvent,
   RespondWithMoveEvent,
   ChallengeExpirySetEvent,
-  WalletAction
+  WalletAction,
+  WalletActionType
 } from "../../../actions";
 import {isTransactionAction, TransactionAction} from "../../transaction-submission/actions";
 import {ActionConstructor} from "../../../utils";
@@ -79,7 +80,7 @@ export function isChallengerAction(action: WalletAction): action is ChallengerAc
     action.type === "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED" ||
     action.type === "WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT" ||
     action.type === "WALLET.ADJUDICATOR.REFUTED_EVENT" ||
-    action.type === "WALLET.ADJUDICATOR.CHALLENGE_EXPIRY_TIME_SET" ||
+    action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET ||
     action.type === "WALLET.DISPUTE.CHALLENGER.ACKNOWLEDGED" ||
     action.type === "WALLET.DISPUTE.CHALLENGER.EXIT_CHALLENGE"
   );

--- a/packages/wallet/src/redux/protocols/dispute/challenger/reducer.ts
+++ b/packages/wallet/src/redux/protocols/dispute/challenger/reducer.ts
@@ -59,7 +59,7 @@ export function challengerReducer(state: NonTerminalCState, sharedData: SharedDa
       return challengeApproved(state, sharedData);
     case "WALLET.DISPUTE.CHALLENGER.CHALLENGE_DENIED":
       return challengeDenied(state, sharedData);
-    case "WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT":
+    case WalletActionType.WALLET_ADJUDICATOR_RESPOND_WITH_MOVE_EVENT:
       return challengeResponseReceived(state, sharedData, action.responseCommitment, action.responseSignature);
     case WalletActionType.WALLET_ADJUDICATOR_REFUTED_EVENT:
       return refuteReceived(state, sharedData);

--- a/packages/wallet/src/redux/protocols/dispute/challenger/reducer.ts
+++ b/packages/wallet/src/redux/protocols/dispute/challenger/reducer.ts
@@ -63,7 +63,7 @@ export function challengerReducer(state: NonTerminalCState, sharedData: SharedDa
       return challengeResponseReceived(state, sharedData, action.responseCommitment, action.responseSignature);
     case WalletActionType.WALLET_ADJUDICATOR_REFUTED_EVENT:
       return refuteReceived(state, sharedData);
-    case "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED":
+    case WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRED:
       return challengeTimedOut(state, sharedData);
     case WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET:
       return handleChallengeCreatedEvent(state, sharedData, action.expiryTime);

--- a/packages/wallet/src/redux/protocols/dispute/challenger/reducer.ts
+++ b/packages/wallet/src/redux/protocols/dispute/challenger/reducer.ts
@@ -61,7 +61,7 @@ export function challengerReducer(state: NonTerminalCState, sharedData: SharedDa
       return challengeDenied(state, sharedData);
     case "WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT":
       return challengeResponseReceived(state, sharedData, action.responseCommitment, action.responseSignature);
-    case "WALLET.ADJUDICATOR.REFUTED_EVENT":
+    case WalletActionType.WALLET_ADJUDICATOR_REFUTED_EVENT:
       return refuteReceived(state, sharedData);
     case "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED":
       return challengeTimedOut(state, sharedData);

--- a/packages/wallet/src/redux/protocols/dispute/challenger/reducer.ts
+++ b/packages/wallet/src/redux/protocols/dispute/challenger/reducer.ts
@@ -14,7 +14,8 @@ import {
 } from "./states";
 import {unreachable} from "../../../../utils/reducer-utils";
 import {SharedData, registerChannelToMonitor, checkAndStore, getPrivatekey} from "../../../state";
-import * as actions from "./actions";
+import {isChallengerAction} from "./actions";
+import {WalletActionType} from "../../../actions";
 import {TransactionAction} from "../../transaction-submission/actions";
 import {isTransactionAction, ProtocolAction} from "../../../actions";
 import {transactionReducer, initialize as initializeTransaction} from "../../transaction-submission";
@@ -41,7 +42,7 @@ export interface ReturnVal {
 }
 
 export function challengerReducer(state: NonTerminalCState, sharedData: SharedData, action: ProtocolAction): ReturnVal {
-  if (!actions.isChallengerAction(action)) {
+  if (!isChallengerAction(action)) {
     console.warn(`Challenging reducer received non-challenging action ${action.type}.`);
     return {state, sharedData};
   }
@@ -64,7 +65,7 @@ export function challengerReducer(state: NonTerminalCState, sharedData: SharedDa
       return refuteReceived(state, sharedData);
     case "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED":
       return challengeTimedOut(state, sharedData);
-    case "WALLET.ADJUDICATOR.CHALLENGE_EXPIRY_TIME_SET":
+    case WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET:
       return handleChallengeCreatedEvent(state, sharedData, action.expiryTime);
     case "WALLET.DISPUTE.CHALLENGER.ACKNOWLEDGED":
       switch (state.type) {

--- a/packages/wallet/src/redux/protocols/dispute/responder/actions.ts
+++ b/packages/wallet/src/redux/protocols/dispute/responder/actions.ts
@@ -72,7 +72,7 @@ export function isResponderAction(action: WalletAction): action is ResponderActi
     action.type === "WALLET.DISPUTE.RESPONDER.RESPOND_APPROVED" ||
     action.type === "WALLET.DISPUTE.RESPONDER.RESPONSE_PROVIDED" ||
     action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET ||
-    action.type === "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED" ||
+    action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRED ||
     action.type === "WALLET.DISPUTE.RESPONDER.ACKNOWLEDGED" ||
     action.type === "WALLET.DISPUTE.CHALLENGER.EXIT_CHALLENGE"
   );

--- a/packages/wallet/src/redux/protocols/dispute/responder/actions.ts
+++ b/packages/wallet/src/redux/protocols/dispute/responder/actions.ts
@@ -1,3 +1,4 @@
+import {WalletActionType} from "../../../actions";
 import {BaseProcessAction} from "../../actions";
 import {Commitment} from "../../../../domain";
 import {TransactionAction} from "../../transaction-submission/actions";
@@ -70,7 +71,7 @@ export function isResponderAction(action: WalletAction): action is ResponderActi
     isTransactionAction(action) ||
     action.type === "WALLET.DISPUTE.RESPONDER.RESPOND_APPROVED" ||
     action.type === "WALLET.DISPUTE.RESPONDER.RESPONSE_PROVIDED" ||
-    action.type === "WALLET.ADJUDICATOR.CHALLENGE_EXPIRY_TIME_SET" ||
+    action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRY_TIME_SET ||
     action.type === "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED" ||
     action.type === "WALLET.DISPUTE.RESPONDER.ACKNOWLEDGED" ||
     action.type === "WALLET.DISPUTE.CHALLENGER.EXIT_CHALLENGE"

--- a/packages/wallet/src/redux/protocols/dispute/responder/reducer.ts
+++ b/packages/wallet/src/redux/protocols/dispute/responder/reducer.ts
@@ -19,7 +19,7 @@ import {
   sendChallengeComplete,
   sendOpponentConcluded
 } from "../../reducer-helpers";
-import {ProtocolAction} from "../../../actions";
+import {ProtocolAction, WalletActionType} from "../../../actions";
 import * as _ from "lodash";
 export const initialize = (
   processId: string,
@@ -79,7 +79,7 @@ const waitForTransactionReducer = (
   sharedData: SharedData,
   action: actions.ResponderAction
 ): ProtocolStateWithSharedData<states.ResponderState> => {
-  if (action.type === "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED") {
+  if (action.type === WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRED) {
     return {
       protocolState: states.acknowledgeTimeout({...protocolState}),
       sharedData: sendOpponentConcluded(sharedData)
@@ -130,7 +130,7 @@ const waitForResponseReducer = (
       );
 
       return transitionToWaitForTransaction(transaction, protocolState, signResult.store);
-    case "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED":
+    case WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRED:
       return {
         protocolState: states.acknowledgeTimeout({...protocolState}),
         sharedData: showWallet(sendOpponentConcluded(sharedData))
@@ -175,7 +175,7 @@ const waitForApprovalReducer = (
 
         return transitionToWaitForTransaction(transaction, protocolState, sharedData);
       }
-    case "WALLET.ADJUDICATOR.CHALLENGE_EXPIRED":
+    case WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_EXPIRED:
       return {
         protocolState: states.acknowledgeTimeout({...protocolState}),
         sharedData: sendOpponentConcluded(sharedData)

--- a/packages/wallet/src/redux/reducer.ts
+++ b/packages/wallet/src/redux/reducer.ts
@@ -17,6 +17,7 @@ import {ethers} from "ethers";
 import * as closeLedgerChannelProtocol from "./protocols/close-ledger-channel";
 import _ from "lodash";
 const initialState = states.waitForLogin();
+const Action = actions.Action;
 
 export const walletReducer = (
   state: states.WalletState = initialState,
@@ -191,7 +192,7 @@ function routeToNewProcessInitializer(state: states.Initialized, action: NewProc
 
 const waitForLoginReducer = (state: states.WaitForLogin, action: actions.WalletAction): states.WalletState => {
   switch (action.type) {
-    case "WALLET.LOGGED_IN":
+    case Action.WALLET_LOGGED_IN:
       let {address, privateKey} = state;
       if (!address || !privateKey) {
         ({privateKey, address} = ethers.Wallet.createRandom());

--- a/packages/wallet/src/redux/reducer.ts
+++ b/packages/wallet/src/redux/reducer.ts
@@ -17,7 +17,7 @@ import {ethers} from "ethers";
 import * as closeLedgerChannelProtocol from "./protocols/close-ledger-channel";
 import _ from "lodash";
 const initialState = states.waitForLogin();
-const Action = actions.Action;
+const Action = actions.WalletActionType;
 
 export const walletReducer = (
   state: states.WalletState = initialState,

--- a/packages/wallet/src/redux/sagas/__tests__/multiple-action-dispatcher.test.ts
+++ b/packages/wallet/src/redux/sagas/__tests__/multiple-action-dispatcher.test.ts
@@ -1,19 +1,19 @@
 import {put, take} from "redux-saga/effects";
 
-import * as actions from "../../actions";
+import {multipleWalletActions, WalletActionType} from "../../actions";
 import {multipleActionDispatcher} from "../multiple-action-dispatcher";
 import {closeLedgerChannel} from "../../protocols/actions";
 import {exitChallenge} from "../../protocols/dispute/challenger/actions";
 
 describe("multiple action dispatcher", () => {
   const saga = multipleActionDispatcher();
-  const mockMultipleActions = actions.multipleWalletActions({
+  const mockMultipleActions = multipleWalletActions({
     actions: [closeLedgerChannel({channelId: "0xchannelId"}), exitChallenge({processId: "Process-0x"})]
   });
 
   it("waits for multiple actions to arrive", () => {
     expect(saga.next().value).toEqual(
-      take([actions.Action.WALLET_MULTIPLE_ACTIONS, "WALLET.MULTIPLE_RELAYABLE_ACTIONS"])
+      take([WalletActionType.WALLET_MULTIPLE_ACTIONS, "WALLET.MULTIPLE_RELAYABLE_ACTIONS"])
     );
   });
 

--- a/packages/wallet/src/redux/sagas/__tests__/multiple-action-dispatcher.test.ts
+++ b/packages/wallet/src/redux/sagas/__tests__/multiple-action-dispatcher.test.ts
@@ -12,7 +12,9 @@ describe("multiple action dispatcher", () => {
   });
 
   it("waits for multiple actions to arrive", () => {
-    expect(saga.next().value).toEqual(take(["WALLET.MULTIPLE_ACTIONS", "WALLET.MULTIPLE_RELAYABLE_ACTIONS"]));
+    expect(saga.next().value).toEqual(
+      take([actions.Action.WALLET_MULTIPLE_ACTIONS, "WALLET.MULTIPLE_RELAYABLE_ACTIONS"])
+    );
   });
 
   it("puts the actions in order", () => {

--- a/packages/wallet/src/redux/sagas/challenge-response-initiator.ts
+++ b/packages/wallet/src/redux/sagas/challenge-response-initiator.ts
@@ -1,4 +1,4 @@
-import {ChallengeCreatedEvent} from "../actions";
+import {ChallengeCreatedEvent, WalletActionType} from "../actions";
 import {take, select, put} from "redux-saga/effects";
 import * as selectors from "../selectors";
 import {challengeDetected} from "../protocols/application/actions";
@@ -9,7 +9,7 @@ import {APPLICATION_PROCESS_ID} from "../protocols/application/reducer";
  */
 export function* challengeResponseInitiator() {
   while (true) {
-    const action: ChallengeCreatedEvent = yield take("WALLET.ADJUDICATOR.CHALLENGE_CREATED_EVENT");
+    const action: ChallengeCreatedEvent = yield take(WalletActionType.WALLET_ADJUDICATOR_CHALLENGE_CREATED_EVENT);
     const {commitment, channelId, finalizedAt: expiresAt} = action;
 
     const channelState = yield select(selectors.getOpenedChannelState, channelId);

--- a/packages/wallet/src/redux/sagas/multiple-action-dispatcher.ts
+++ b/packages/wallet/src/redux/sagas/multiple-action-dispatcher.ts
@@ -1,10 +1,10 @@
-import {MultipleWalletActions} from "../actions";
+import {Action, MultipleWalletActions} from "../actions";
 import {take, put} from "redux-saga/effects";
 
 export function* multipleActionDispatcher() {
   while (true) {
     const multipleWalletActions: MultipleWalletActions = yield take([
-      "WALLET.MULTIPLE_ACTIONS",
+      Action.WALLET_MULTIPLE_ACTIONS,
       "WALLET.MULTIPLE_RELAYABLE_ACTIONS"
     ]);
     yield multipleWalletActions.actions.map(action => put(action));

--- a/packages/wallet/src/redux/sagas/multiple-action-dispatcher.ts
+++ b/packages/wallet/src/redux/sagas/multiple-action-dispatcher.ts
@@ -1,10 +1,10 @@
-import {Action, MultipleWalletActions} from "../actions";
+import {MultipleWalletActions, WalletActionType} from "../actions";
 import {take, put} from "redux-saga/effects";
 
 export function* multipleActionDispatcher() {
   while (true) {
     const multipleWalletActions: MultipleWalletActions = yield take([
-      Action.WALLET_MULTIPLE_ACTIONS,
+      WalletActionType.WALLET_MULTIPLE_ACTIONS,
       "WALLET.MULTIPLE_RELAYABLE_ACTIONS"
     ]);
     yield multipleWalletActions.actions.map(action => put(action));


### PR DESCRIPTION
This is the first of a series of PRs that replaces the usage of string literals to refer to action types of various kinds across the wallet.