### PR TITLE
Change padding of external addresses in AssetHolder to left-pad

### DIFF
--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -102,7 +102,7 @@ contract AssetHolder is IAssetHolder {
             } else {
                 payoutAmount = allocation[m].amount;
             }
-            if (_isExternalAddress(allocation[m].destination)) {
+            if (_isExternalDestination(allocation[m].destination)) {
                 _transferAsset(_bytes32ToAddress(allocation[m].destination), payoutAmount);
                 emit AssetTransferred(allocation[m].destination, payoutAmount);
             } else {
@@ -226,7 +226,7 @@ contract AssetHolder is IAssetHolder {
                 k++;
             }
             if (payouts[j] > 0) {
-                if (_isExternalAddress(allocation[j].destination)) {
+                if (_isExternalDestination(allocation[j].destination)) {
                     _transferAsset(_bytes32ToAddress(allocation[j].destination), payouts[j]);
                     emit AssetTransferred(allocation[j].destination, payouts[j]);
                 } else {
@@ -282,7 +282,7 @@ contract AssetHolder is IAssetHolder {
 
     function _transferAsset(address payable destination, uint256 amount) internal {}
 
-    function _isExternalAddress(bytes32 destination) internal pure returns (bool) {
+    function _isExternalDestination(bytes32 destination) internal pure returns (bool) {
         return uint96(bytes12(destination)) == 0;
     }
 

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -283,15 +283,15 @@ contract AssetHolder is IAssetHolder {
     function _transferAsset(address payable destination, uint256 amount) internal {}
 
     function _isExternalAddress(bytes32 destination) internal pure returns (bool) {
-        return (destination == bytes32(bytes20(destination)));
+        return uint96(bytes12(destination)) == 0;
     }
 
     function _addressToBytes32(address participant) internal pure returns (bytes32) {
-        return bytes32(bytes20(participant));
+        return bytes32(uint256(participant));
     }
 
     function _bytes32ToAddress(bytes32 destination) internal pure returns (address payable) {
-        return address(bytes20(destination));
+        return address(uint160(uint256(destination)));
     }
 
     function recoverSigner(bytes memory _d, uint8 _v, bytes32 _r, bytes32 _s)

--- a/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
@@ -24,7 +24,7 @@ contract ERC20AssetHolder is AssetHolder {
     }
 
     function deposit(bytes32 destination, uint256 expectedHeld, uint256 amount) public {
-        require(!_isExternalAddress(destination), 'Cannot deposit to external address');
+        require(!_isExternalDestination(destination), 'Cannot deposit to external destination');
         uint256 amountDeposited;
         // this allows participants to reduce the wait between deposits, while protecting them from losing funds by depositing too early. Specifically it protects against the scenario:
         // 1. Participant A deposits

--- a/packages/nitro-protocol/contracts/ETHAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ETHAssetHolder.sol
@@ -15,7 +15,7 @@ contract ETHAssetHolder is AssetHolder {
     }
 
     function deposit(bytes32 destination, uint256 expectedHeld, uint256 amount) public payable {
-        require(!_isExternalAddress(destination), 'Cannot deposit to external address');
+        require(!_isExternalDestination(destination), 'Cannot deposit to external destination');
         require(msg.value == amount, 'Insufficient ETH for ETH deposit');
         uint256 amountDeposited;
         // this allows participants to reduce the wait between deposits, while protecting them from losing funds by depositing too early. Specifically it protects against the scenario:

--- a/packages/nitro-protocol/contracts/Outcome.sol
+++ b/packages/nitro-protocol/contracts/Outcome.sol
@@ -9,7 +9,7 @@ library Outcome {
     // Allocation = AllocationItem[]
     // AllocationItem = (Destination, Amount)
     // Guarantee = (ChannelAddress, Destination[])
-    // Destination = ChannelAddress | ExternalAddress
+    // Destination = ChannelAddress | ExternalDestination
 
     struct OutcomeItem {
         address assetHolderAddress;

--- a/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.11;
 pragma experimental ABIEncoderV2;
 
 /**
-  * @dev An AssetHolder contract escrows eth or tokens against state channels. It allows assets to be deposited, and ultimately transferred from one channel to other channel and/or external addresses.
+  * @dev An AssetHolder contract escrows eth or tokens against state channels. It allows assets to be deposited, and ultimately transferred from one channel to other channel and/or external destinations.
 */
 interface IAssetHolder {
     /**
@@ -39,8 +39,8 @@ interface IAssetHolder {
     );
 
     /**
-    * @dev Indicates that `amount` assets have been transferred to the external address denoted by `destination`.
-    * @param destination An external address, right-padded with zeros.
+    * @dev Indicates that `amount` assets have been transferred to the external destination denoted by `destination`.
+    * @param destination An external destination, right-padded with zeros.
     * @param amount Number of assets transferred (wei or tokens).
     */
     event AssetTransferred(bytes32 indexed destination, uint256 amount);

--- a/packages/nitro-protocol/contracts/test/TESTAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/test/TESTAssetHolder.sol
@@ -17,8 +17,8 @@ contract TESTAssetHolder is AssetHolder {
         return true;
     }
 
-    function isExternalAddress(bytes32 destination) public pure returns (bool) {
-        return _isExternalAddress(destination);
+    function isExternalDestination(bytes32 destination) public pure returns (bool) {
+        return _isExternalDestination(destination);
     }
 
     function addressToBytes32(address participant) public pure returns (bytes32) {

--- a/packages/nitro-protocol/docs/adjudicator/state-format.md
+++ b/packages/nitro-protocol/docs/adjudicator/state-format.md
@@ -40,7 +40,7 @@ Since updates must ultimately be interpreted by smart contracts, the encoding of
 
 ## ChannelId
 
-The address of a channel is the hash of the abi encoded `chainId`, `participants` and `channelNonce`.
+The id of a channel is the hash of the abi encoded `chainId`, `participants` and `channelNonce`.
 
 By choosing a new `channelNonce` each time the same participants execute a state channel supported by the same chain, they can avoid replay attacks.
 

--- a/packages/nitro-protocol/docs/asset-holder/claim.md
+++ b/packages/nitro-protocol/docs/asset-holder/claim.md
@@ -5,7 +5,7 @@ title: claimAll
 
 The claimAll method takes the funds escrowed against a guarantor channel, and attempts to transfer them to the beneficiaries of the target channel specified by the guarantor. The transfers are first attempted in a nonstandard priority order given by the guarantor, so that beneficiaries of underfunded channels may not receive a transfer, depending on their nonstandard priority. Full or partial transfers to a beneficiary results in deletion or reduction of that beneficiary's allocation (respectively). Surplus funds are then subject to another attempt to transfer them to the beneficiaries of the target channel, but this time with the standard priority order given by the target channel. Any funds that still remain after this step remain in escrow against the guarantor.
 
-As with `transferAll`, a transfer to another channel results in explicit escrow of funds against that channel. A transfer to an external address results in ETH or ERC20 tokens being transferred out of the AssetHolder contract.
+As with `transferAll`, a transfer to another channel results in explicit escrow of funds against that channel. A transfer to an external destination results in ETH or ERC20 tokens being transferred out of the AssetHolder contract.
 
 Signature:
 

--- a/packages/nitro-protocol/docs/asset-holder/deposit.md
+++ b/packages/nitro-protocol/docs/asset-holder/deposit.md
@@ -14,7 +14,7 @@ function deposit(bytes32 destination, uint256 expectedHeld, uint256 amount) publ
 
 ## Checks:
 
-- `destination` must be an external address
+- `destination` must be an [external destination](./outcomes#destinations).
 - The holdings for `destination` must be greater than or equal to `expectedHeld`.
 - The holdings for `destination` must be less than the sum of the amount expected to be held and the amount declared in the deposit.
 
@@ -35,7 +35,7 @@ Increase holdings for `destination` to the sum of the amount expected to be held
 Emit a `Deposited` event with `indexed` parameter `destination`.
 
 :::warning
-You may only deposit to a channel address. This is currently enforced at the contract level, but this may change in future. Do not attempt to deposit into external addresses.
+You may only deposit to a channel address. This is currently enforced at the contract level, but this may change in future. Do not attempt to deposit into external destinations.
 :::
 
 :::caution

--- a/packages/nitro-protocol/docs/asset-holder/outcomes.md
+++ b/packages/nitro-protocol/docs/asset-holder/outcomes.md
@@ -15,21 +15,21 @@ The adjudicator stores (the hash of) an encoded `outcome` for each finalized cha
 
 ## Implementation
 
-In `Outcome2.sol`:
+In `Outcome.sol`:
 
 ```solidity
 pragma solidity ^0.5.11;
 pragma experimental ABIEncoderV2;
 
 library Outcome {
-  //An outcome is an array of OutcomeItems
+  // An outcome is an array of OutcomeItems
   // Outcome = OutcomeItem[]
   // OutcomeItem = (AssetHolderAddress, AssetOutcome)
   // AssetOutcome = (AssetOutcomeType, Allocation | Guarantee)
   // Allocation = AllocationItem[]
   // AllocationItem = (Destination, Amount)
-  // Guarantee = (ChannelAddress, Destination[])
-  // Destination = ChannelAddress | ExternalAddress
+  // Guarantee = (ChannelId, Destination[])
+  // Destination = ChannelId | ExternalDestination
 
   struct OutcomeItem {
     address assetHolderAddress;
@@ -59,13 +59,29 @@ library Outcome {
 
 ## Example of an outcome data structure
 
-| >                                                                                               | 0xETHAssetHolder                                 | 0                                                                                                     | 0xAlice | 5   | 0xBob | 2   | 0xDAIAssetHolder | ... |
+| >                                                                                               | 0xETHAssetHolder                                 | 0                                                                                                     | 0xDestA | 5   | 0xDestB | 2   | 0xDAIAssetHolder | ... |
 | ----------------------------------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ------- | --- | ----- | --- | ---------------- | --- |
-|                                                                                                 |                                                  | <td colspan="2" align="center">AllocationItem</td> <td colspan="2" align="center">AllocationItem</td> |
+|                                                                                                 |                                                  | | Destination  | Amount | Destination | Amount | | | 
+|                                                                                                 |                                                  | <td colspan="2" align="center">AllocationItem</td> <td colspan="2" align="center">AllocationItem</td> | | | 
 |                                                                                                 |                                                  | <td colspan="4" align="center">Allocation</td>                                                        |         |     |
 |                                                                                                 | <td colspan="5" align="center">AssetOutcome</td> |                                                                                                       |         |
 | <td colspan="6" align="center">OutcomeItem</td> <td colspan="6" align="center">OutcomeItem</td> |
 | <td colspan="8" align="center">Outcome</td>                                                     |
+
+## Destinations
+
+A `Destination` is a `bytes32` and either:
+
+1. A `ChannelId` (see the article on [state format](../adjudicator/state-format#channelid)), or
+2. An `ExternalDestination`, which is an ethereum address left-padded with zeros.
+
+
+:::tip
+In JavaScript, the `ExternalDestination` corresponding to `address` may be computed as
+```
+'0x' + address.padStart(64, '0')
+```
+:::
 
 ## Storage
 

--- a/packages/nitro-protocol/docs/asset-holder/set-outcome.md
+++ b/packages/nitro-protocol/docs/asset-holder/set-outcome.md
@@ -3,12 +3,12 @@ id: set-outcome
 title: setAssetOutcomeHash
 ---
 
-The `setAssetOutcomeHash` method allows an outcome (more strictly, an outcomeHash) to be registered against a channel. It may only be called by the Nitro Adjudicator.
+The `setAssetOutcomeHash` method allows an outcome (more strictly, an `outcomeHash`) to be registered against a channel. It may only be called by the Nitro Adjudicator.
 
 Signature:
 
 ```solidity
-    function seAssetOutcomeHash(bytes32 channelId, bytes32 assetOutcomeHash)
+    function setAssetOutcomeHash(bytes32 channelId, bytes32 assetOutcomeHash)
         external
         AdjudicatorOnly
         returns (bool success)

--- a/packages/nitro-protocol/docs/asset-holder/transfer.md
+++ b/packages/nitro-protocol/docs/asset-holder/transfer.md
@@ -3,7 +3,7 @@ id: transfer
 title: transferAll
 ---
 
-The transferAll method takes the funds escrowed against a channel, and attempts to transfer them to the beneficiaries of that channel. The transfers are attempted in priority order, so that beneficiaries of underfunded channels may not receive a transfer, depending on their priority. Surplus funds remain in escrow against the channel. Full or partial transfers to a beneficiary results in deletion or reduction of that beneficiary's allocation (respectively). A transfer to another channel results in explicit escrow of funds against that channel. A transfer to an external address results in ETH or ERC20 tokens being transferred out of the AssetHolder contract.
+The transferAll method takes the funds escrowed against a channel, and attempts to transfer them to the beneficiaries of that channel. The transfers are attempted in priority order, so that beneficiaries of underfunded channels may not receive a transfer, depending on their priority. Surplus funds remain in escrow against the channel. Full or partial transfers to a beneficiary results in deletion or reduction of that beneficiary's allocation (respectively). A transfer to another channel results in explicit escrow of funds against that channel. A transfer to an external destination results in ETH or ERC20 tokens being transferred out of the AssetHolder contract.
 
 ```solidity
 function transferAll(bytes32 channelId, bytes calldata allocationBytes) external

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
@@ -10,7 +10,7 @@ import {
   guaranteeToParams,
   newAssetTransferredEvent,
   randomChannelId,
-  randomExternalAddress,
+  randomExternalDestination,
   replaceAddresses,
   setupContracts,
 } from '../../test-helpers';
@@ -21,9 +21,9 @@ const addresses = {
   t: undefined, // target
   g: undefined, // guarantor
   // externals
-  I: randomExternalAddress(),
-  A: randomExternalAddress(),
-  B: randomExternalAddress(),
+  I: randomExternalDestination(),
+  A: randomExternalDestination(),
+  B: randomExternalDestination(),
 };
 let AssetHolder: Contract;
 

--- a/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/claimAll.test.ts
@@ -1,5 +1,5 @@
 import {expectRevert} from '@statechannels/devtools';
-import {Contract, Wallet} from 'ethers';
+import {Contract} from 'ethers';
 import {bigNumberify, id} from 'ethers/utils';
 // @ts-ignore
 import AssetHolderArtifact from '../../../build/contracts/TESTAssetHolder.json';
@@ -10,24 +10,20 @@ import {
   guaranteeToParams,
   newAssetTransferredEvent,
   randomChannelId,
+  randomExternalAddress,
   replaceAddresses,
   setupContracts,
 } from '../../test-helpers';
 
 const provider = getTestProvider();
-
-const newAddress = () =>
-  Wallet.createRandom()
-    .address.padEnd(66, '0')
-    .toLowerCase();
 const addresses = {
   // channels
   t: undefined, // target
   g: undefined, // guarantor
   // externals
-  I: newAddress(),
-  A: newAddress(),
-  B: newAddress(),
+  I: randomExternalAddress(),
+  A: randomExternalAddress(),
+  B: randomExternalAddress(),
 };
 let AssetHolder: Contract;
 

--- a/packages/nitro-protocol/test/contracts/AssetHolder/isExternalAddress.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/isExternalAddress.test.ts
@@ -23,12 +23,12 @@ beforeAll(async () => {
 describe('isExternalAddress', () => {
   it('verifies an external address', async () => {
     const zerosPaddedExternalAddress =
-      '0x' + 'eb89373c708B40fAeFA76e46cda92f801FAFa288'.padEnd(64, '0');
+      '0x' + 'eb89373c708B40fAeFA76e46cda92f801FAFa288'.padStart(64, '0');
     expect(await AssetHolder.isExternalAddress(zerosPaddedExternalAddress)).toBe(true);
   });
   it('rejects a non-external-address', async () => {
     const onesPaddedExternalAddress =
-      '0x' + 'eb89373c708B40fAeFA76e46cda92f801FAFa288'.padEnd(64, '1');
+      '0x' + 'eb89373c708B40fAeFA76e46cda92f801FAFa288'.padStart(64, '1');
     expect(await AssetHolder.isExternalAddress(onesPaddedExternalAddress)).toBe(false);
   });
 });

--- a/packages/nitro-protocol/test/contracts/AssetHolder/isExternalDestination.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/isExternalDestination.test.ts
@@ -20,15 +20,15 @@ beforeAll(async () => {
   AssetHolder = await setupContracts(provider, AssetHolderArtifact);
 });
 
-describe('isExternalAddress', () => {
-  it('verifies an external address', async () => {
-    const zerosPaddedExternalAddress =
+describe('isExternalDestination', () => {
+  it('verifies an external destination', async () => {
+    const zerosPaddedExternalDestination =
       '0x' + 'eb89373c708B40fAeFA76e46cda92f801FAFa288'.padStart(64, '0');
-    expect(await AssetHolder.isExternalAddress(zerosPaddedExternalAddress)).toBe(true);
+    expect(await AssetHolder.isExternalDestination(zerosPaddedExternalDestination)).toBe(true);
   });
   it('rejects a non-external-address', async () => {
-    const onesPaddedExternalAddress =
+    const onesPaddedExternalDestination =
       '0x' + 'eb89373c708B40fAeFA76e46cda92f801FAFa288'.padStart(64, '1');
-    expect(await AssetHolder.isExternalAddress(onesPaddedExternalAddress)).toBe(false);
+    expect(await AssetHolder.isExternalDestination(onesPaddedExternalDestination)).toBe(false);
   });
 });

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
@@ -5,11 +5,12 @@ import {
   allocationToParams,
   getTestProvider,
   randomChannelId,
+  randomExternalAddress,
   replaceAddresses,
   setupContracts,
 } from '../../test-helpers';
 
-import {Contract, Wallet} from 'ethers';
+import {Contract} from 'ethers';
 import {bigNumberify, id} from 'ethers/utils';
 import {encodeAllocation} from '../../../src/contract/outcome';
 
@@ -23,8 +24,8 @@ const addresses = {
   C: randomChannelId(),
   X: randomChannelId(),
   // externals
-  A: Wallet.createRandom().address.padEnd(66, '0'),
-  B: Wallet.createRandom().address.padEnd(66, '0'),
+  A: randomExternalAddress(),
+  B: randomExternalAddress(),
 };
 
 beforeAll(async () => {

--- a/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
+++ b/packages/nitro-protocol/test/contracts/AssetHolder/transferAll.test.ts
@@ -5,7 +5,7 @@ import {
   allocationToParams,
   getTestProvider,
   randomChannelId,
-  randomExternalAddress,
+  randomExternalDestination,
   replaceAddresses,
   setupContracts,
 } from '../../test-helpers';
@@ -24,8 +24,8 @@ const addresses = {
   C: randomChannelId(),
   X: randomChannelId(),
   // externals
-  A: randomExternalAddress(),
-  B: randomExternalAddress(),
+  A: randomExternalDestination(),
+  B: randomExternalDestination(),
 };
 
 beforeAll(async () => {

--- a/packages/nitro-protocol/test/contracts/examples/SingleAssetPayments/validTransition.test.ts
+++ b/packages/nitro-protocol/test/contracts/examples/SingleAssetPayments/validTransition.test.ts
@@ -1,11 +1,16 @@
 // @ts-ignore
 import {expectRevert} from '@statechannels/devtools';
-import {Contract, Wallet} from 'ethers';
+import {Contract} from 'ethers';
 import {AddressZero, HashZero} from 'ethers/constants';
 import SingleAssetPaymentsArtifact from '../../../../build/contracts/SingleAssetPayments.json';
 import {Allocation, encodeOutcome} from '../../../../src/contract/outcome';
 import {VariablePart} from '../../../../src/contract/state.js';
-import {getTestProvider, replaceAddresses, setupContracts} from '../../../test-helpers';
+import {
+  getTestProvider,
+  randomExternalAddress,
+  replaceAddresses,
+  setupContracts,
+} from '../../../test-helpers';
 
 const provider = getTestProvider();
 let singleAssetPayments: Contract;
@@ -13,9 +18,9 @@ let singleAssetPayments: Contract;
 const numParticipants = 3;
 const addresses = {
   // participants
-  A: Wallet.createRandom().address.padEnd(66, '0'),
-  B: Wallet.createRandom().address.padEnd(66, '0'),
-  C: Wallet.createRandom().address.padEnd(66, '0'),
+  A: randomExternalAddress(),
+  B: randomExternalAddress(),
+  C: randomExternalAddress(),
 };
 const guarantee = {
   targetChannelId: HashZero,

--- a/packages/nitro-protocol/test/contracts/examples/SingleAssetPayments/validTransition.test.ts
+++ b/packages/nitro-protocol/test/contracts/examples/SingleAssetPayments/validTransition.test.ts
@@ -7,7 +7,7 @@ import {Allocation, encodeOutcome} from '../../../../src/contract/outcome';
 import {VariablePart} from '../../../../src/contract/state.js';
 import {
   getTestProvider,
-  randomExternalAddress,
+  randomExternalDestination,
   replaceAddresses,
   setupContracts,
 } from '../../../test-helpers';
@@ -18,9 +18,9 @@ let singleAssetPayments: Contract;
 const numParticipants = 3;
 const addresses = {
   // participants
-  A: randomExternalAddress(),
-  B: randomExternalAddress(),
-  C: randomExternalAddress(),
+  A: randomExternalDestination(),
+  B: randomExternalDestination(),
+  C: randomExternalDestination(),
 };
 const guarantee = {
   targetChannelId: HashZero,

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -183,6 +183,13 @@ export function randomChannelId(channelNonce = 0) {
   return channelId;
 }
 
+export const randomExternalAddress = () =>
+  '0x' +
+  ethers.Wallet.createRandom()
+    .address.slice(2, 42)
+    .padStart(64, '0')
+    .toLowerCase();
+
 export async function sendTransaction(
   provider: ethers.providers.JsonRpcProvider,
   contractAddress: string,

--- a/packages/nitro-protocol/test/test-helpers.ts
+++ b/packages/nitro-protocol/test/test-helpers.ts
@@ -183,7 +183,7 @@ export function randomChannelId(channelNonce = 0) {
   return channelId;
 }
 
-export const randomExternalAddress = () =>
+export const randomExternalDestination = () =>
   '0x' +
   ethers.Wallet.createRandom()
     .address.slice(2, 42)

--- a/packages/wallet/src/contract-tests/transactions.test.ts
+++ b/packages/wallet/src/contract-tests/transactions.test.ts
@@ -90,7 +90,8 @@ describe("transactions", () => {
   })
 
   it("should deposit into the contract", async () => {
-    const depositTransactionData = createDepositTransaction(participantA.address, "0x5", "0x0");
+    const someChannelId = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+    const depositTransactionData = createDepositTransaction(someChannelId, "0x5", "0x0");
     await testTransactionSender({
       ...depositTransactionData,
       to: ETH_ASSET_HOLDER_ADDRESS,
@@ -104,9 +105,6 @@ describe("transactions", () => {
       nonce: getNextNonce(),
       participants: [participantA.address, participantB.address]
     };
-
-    await depositContract(provider, participantA.address);
-    await depositContract(provider, participantB.address);
 
     const fromCommitment: Commitment = {
       channel,
@@ -144,9 +142,6 @@ describe("transactions", () => {
       participants: [participantA.address, participantB.address]
     };
     const { nonce: channelNonce } = channel;
-
-    await depositContract(provider, participantA.address);
-    await depositContract(provider, participantB.address);
 
     await createChallenge(provider, channelNonce, participantA, participantB);
 
@@ -187,8 +182,6 @@ describe("transactions", () => {
       participants: [participantA.address, participantB.address]
     };
     const { nonce: channelNonce } = channel;
-    await depositContract(provider, participantA.address);
-    await depositContract(provider, participantB.address);
 
     await createChallenge(provider, channelNonce, participantA, participantB);
 
@@ -229,9 +222,6 @@ describe("transactions", () => {
       nonce: getNextNonce(),
       participants: [participantA.address, participantB.address]
     };
-
-    await depositContract(provider, participantA.address);
-    await depositContract(provider, participantB.address);
 
     const fromCommitment: Commitment = {
       channel,

--- a/packages/wallet/src/utils/transaction-generator.ts
+++ b/packages/wallet/src/utils/transaction-generator.ts
@@ -8,7 +8,7 @@ import {
   Transactions as nitroTrans,
   SignedState
 } from "@statechannels/nitro-protocol";
-import {convertAddressToBytes32, convertCommitmentToState} from "./nitro-converter";
+import {convertCommitmentToState} from "./nitro-converter";
 
 export function createForceMoveTransaction(
   fromCommitment: SignedCommitment,
@@ -120,10 +120,9 @@ export function createTransferAndWithdrawTransaction(
 }
 
 export function createDepositTransaction(destination: string, depositAmount: string, expectedHeld: string) {
-  let normalizedDestinationAddress = destination;
-  // If the address is not already left-padded to be of type byte32
-  if (normalizedDestinationAddress.length !== 66) {
-    normalizedDestinationAddress = convertAddressToBytes32(destination);
+  // If a legacy fmg-core channelId
+  if (destination.length === 42) {
+    destination = `0x${destination.substr(2).padStart(64, "1")}`; // note we do not pad with zeros, since that would imply an external destination (which we may not deposit to)
   }
-  return createNitroDepositTransaction(normalizedDestinationAddress, expectedHeld, depositAmount);
+  return createNitroDepositTransaction(destination, expectedHeld, depositAmount);
 }


### PR DESCRIPTION
Addressing an inconsistency noticed in #175 (see https://github.com/statechannels/monorepo/pull/175#issuecomment-538711824).