### PR TITLE
[Web3Torrent] improve magnetURI generation & parsing

### DIFF
--- a/packages/web3torrent/src/components/torrent-info/TorrentInfo.tsx
+++ b/packages/web3torrent/src/components/torrent-info/TorrentInfo.tsx
@@ -1,5 +1,6 @@
 import prettier from 'prettier-bytes';
 import React, {useState} from 'react';
+import {generateMagnetURL} from '../../clients/web3torrent-client';
 import {TorrentPeers} from '../../library/types';
 import {Status, Torrent} from '../../types';
 import {clipboardCopy} from '../../utils/copy-to-clipboard';
@@ -7,8 +8,11 @@ import {DownloadInfo} from './download-info/DownloadInfo';
 import './TorrentInfo.scss';
 import {UploadInfo} from './upload-info/UploadInfo';
 
-const MagnetLinkButton: React.FC<{magnetURI: string}> = ({magnetURI}) => {
-  const [magnetInfo, setMagnetInfo] = useState({copied: false, magnet: magnetURI});
+const MagnetLinkButton: React.FC<{torrent: Torrent}> = ({torrent}) => {
+  const [magnetInfo, setMagnetInfo] = useState({
+    copied: false,
+    magnet: generateMagnetURL(torrent)
+  });
   return (
     <button
       className="fileLink"
@@ -37,7 +41,7 @@ const TorrentInfo: React.FC<{torrent: Torrent; peers?: TorrentPeers}> = ({torren
         <span className="fileCost">
           Est. cost {!torrent.cost ? 'Unknown' : `$${Number(torrent.cost).toFixed(2)}`}
         </span>
-        {torrent.magnetURI ? <MagnetLinkButton magnetURI={torrent.magnetURI} /> : false}
+        {torrent.magnetURI ? <MagnetLinkButton torrent={torrent} /> : false}
       </section>
       {torrent.status !== Status.Idle && torrent.status !== Status.Seeding && torrent.ready ? (
         <DownloadInfo torrent={torrent} />

--- a/packages/web3torrent/src/pages/download/Download.tsx
+++ b/packages/web3torrent/src/pages/download/Download.tsx
@@ -30,7 +30,7 @@ const DownloadStarter: React.FC<{torrent: Torrent; setTorrent: React.Dispatch<To
 };
 
 const Download: React.FC<RouteComponentProps> = () => {
-  const [torrent, setTorrent] = useState(parseMagnetURL(decodeURIComponent(useLocation().hash)));
+  const [torrent, setTorrent] = useState(parseMagnetURL(useLocation().hash));
 
   useInterval(
     () => setTorrent(getLiveTorrentData(torrent, torrent.infoHash)),

--- a/packages/web3torrent/src/types.ts
+++ b/packages/web3torrent/src/types.ts
@@ -9,6 +9,17 @@ export enum Status {
   Stopped = 'Stopped'
 }
 
+export const defaultTrackers = [
+  'udp://explodie.org:6969',
+  'udp://tracker.coppersurfer.tk:6969',
+  'udp://tracker.empire-js.us:1337',
+  'udp://tracker.leechers-paradise.org:6969',
+  'udp://tracker.opentrackr.org:1337',
+  'wss://tracker.btorrent.xyz',
+  'wss://tracker.fastcast.nz',
+  'wss://tracker.openwebtorrent.com'
+];
+
 export const EmptyTorrent = {
   name: 'unknown',
   magnetURI: '',


### PR DESCRIPTION
### Description

When merged, this PR will improve the magnet link parsing, and generation:

The sharing link will now have this structure (we assume that the trackers are always the same, so I hard coded them so that the sharing link is shorter):
http://localhost:3000/download/magnet#magnet:?xt=urn%3Abtih%3A148c62a7f7845c91e7d16ca9be85de6fbaed3a1f&dn=test.zip&xl=1398978&cost=0

Where 
- **xt** is the id of the torrent 
- **dn** is the name of the torrent/file
- **xl** is the length (size) of the torrent
and **cost**... well.. that's kind of obvious.
