### PR TITLE
Remove _recoverSigner() from AssetHolder contract

### DIFF
--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -293,19 +293,4 @@ contract AssetHolder is IAssetHolder {
     function _bytes32ToAddress(bytes32 destination) internal pure returns (address payable) {
         return address(uint160(uint256(destination)));
     }
-
-    function recoverSigner(bytes memory _d, uint8 _v, bytes32 _r, bytes32 _s)
-        internal
-        pure
-        returns (address)
-    {
-        bytes memory prefix = '\x19Ethereum Signed Message:\n32';
-        bytes32 h = keccak256(_d);
-
-        bytes32 prefixedHash = keccak256(abi.encodePacked(prefix, h));
-
-        address a = ecrecover(prefixedHash, _v, _r, _s);
-
-        return (a);
-    }
 }


### PR DESCRIPTION
This method is unused (and a carbon copy of one that *is* used in the ForceMove contract).