### PR TITLE
Update CounterfactualAdapterApp

### DIFF
--- a/packages/nitro-protocol/contracts/CountingAppWithAdapter.sol
+++ b/packages/nitro-protocol/contracts/CountingAppWithAdapter.sol
@@ -1,0 +1,47 @@
+pragma solidity ^0.5.11;
+pragma experimental ABIEncoderV2;
+
+import './interfaces/CounterfactualAdapterApp.sol';
+
+contract CountingAppWithAdapter is CounterfactualAdapterApp {
+    struct CountingAppData {
+        uint256 counter;
+        bytes outcome;
+    }
+
+    function appData(bytes memory appDataBytes) internal pure returns (CountingAppData memory) {
+        return abi.decode(appDataBytes, (CountingAppData));
+    }
+
+    function applyAction(
+        bytes memory prevState,
+        bytes memory /* action */
+    ) public pure returns (bytes memory) {
+        CountingAppData memory prevAppData = appData(prevState);
+        CountingAppData memory newAppData = CountingAppData(prevAppData.counter + 1);
+        return abi.encode(newAppData);
+    }
+
+    function computeOutcome(
+        bytes memory state
+    ) public pure returns (bytes memory) {
+        return appData(state).outcome;
+    }
+
+    function isStateTerminal(bytes calldata)
+        external
+        pure
+        returns (bool)
+    {
+        revert("The isStateTerminal method has no implementation for this App");
+    }
+
+    function getTurnTaker(bytes calldata, address[] calldata)
+        external
+        pure
+        returns (address)
+    {
+        revert("The getTurnTaker method has no implementation for this App");
+    }
+
+}

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -52,7 +52,7 @@
     "test": "yarn test:prepare && npx jest"
   },
   "dependencies": {
-    "@counterfactual/cf-adjudicator-contracts": "^0.0.8",
+    "@counterfactual/cf-adjudicator-contracts": "0.0.10",
     "@openzeppelin/contracts": "2.3.0",
     "ethers": "4.0.37",
     "openzeppelin-solidity": "2.3.0",


### PR DESCRIPTION
Makes `CounterfactualAdapterApp` an abstract contract that is expected to be inherited from. Thus, a `CounterfactualAdapterApp` must implement the `applyAction` and `computeOutcome` methods. Adds an example Counter application.

Blocked on https://github.com/counterfactual/monorepo/pull/2517