### PR TITLE
[Web3Torrent] TorrentInfoComponent Refactoring - Buttons Improvements

### DIFF
--- a/packages/web3torrent/src/components/torrent-info/TorrentInfo.test.tsx
+++ b/packages/web3torrent/src/components/torrent-info/TorrentInfo.test.tsx
@@ -6,12 +6,8 @@ import {TorrentPeers} from '../../library/types';
 import {Status, Torrent} from '../../types';
 import {createMockTorrent, createMockTorrentPeers} from '../../utils/test-utils';
 import {DownloadInfo, DownloadInfoProps} from './download-info/DownloadInfo';
-import {
-  MagnetLinkButton,
-  MagnetLinkButtonProps,
-  TorrentInfo,
-  TorrentInfoProps
-} from './TorrentInfo';
+import {MagnetLinkButton, MagnetLinkButtonProps} from './magnet-link-button/MagnetLinkButton';
+import {TorrentInfo, TorrentInfoProps} from './TorrentInfo';
 import {UploadInfo, UploadInfoProps} from './upload-info/UploadInfo';
 
 Enzyme.configure({adapter: new Adapter()});
@@ -73,10 +69,10 @@ describe('<TorrentInfo />', () => {
     expect(sectionElement.exists()).toEqual(true);
     expect(fileNameElement.exists()).toEqual(true);
     expect(fileSizeElement.exists()).toEqual(true);
-    expect(fileStatusElement.exists()).toEqual(false);
+    expect(fileStatusElement.exists()).toEqual(true);
     expect(fileCostElement.exists()).toEqual(true);
     expect(magnetLinkButtonElement.exists()).toEqual(true);
-    expect(downloadInfoElement.exists()).toEqual(true);
+    expect(downloadInfoElement.exists()).toEqual(false);
     expect(uploadInfoElement.exists()).toEqual(false);
 
     expect(sectionElement.hasClass('with-link')).toEqual(true);
@@ -114,41 +110,9 @@ describe('<TorrentInfo />', () => {
 
   it("can show the UploadInfo component when the client is the torrent's author", () => {
     const {downloadInfoElement, uploadInfoElement} = mockTorrentInfo({
-      createdBy: 'Foo',
-      ready: false
+      status: Status.Seeding
     });
     expect(downloadInfoElement.exists()).toEqual(false);
     expect(uploadInfoElement.exists()).toEqual(true);
-  });
-
-  describe('<MagnetLinkButton />', () => {
-    let magnetLinkButtonElement: ReactWrapper<MagnetLinkButtonProps>;
-
-    beforeAll(() => {
-      document.execCommand = jest.fn(() => true);
-    });
-
-    beforeEach(() => {
-      magnetLinkButtonElement = torrentInfo.magnetLinkButtonElement;
-    });
-
-    it('should show a tooltip instruting to copy the link', () => {
-      const tooltip = magnetLinkButtonElement.find('.tooltiptext');
-      expect(tooltip.exists()).toEqual(true);
-      expect(tooltip.text()).toEqual('Copy to clipboard');
-    });
-
-    it('should copy the link to the clipboard when clicking', () => {
-      magnetLinkButtonElement.simulate('click');
-      expect(document.execCommand).toHaveBeenCalledWith('copy');
-
-      const tooltip = magnetLinkButtonElement.find('.tooltiptext');
-      expect(tooltip.exists()).toEqual(true);
-      expect(tooltip.text()).toEqual('Great! Copied to your clipboard');
-    });
-
-    afterAll(() => {
-      delete document.execCommand;
-    });
   });
 });

--- a/packages/web3torrent/src/components/torrent-info/TorrentInfo.tsx
+++ b/packages/web3torrent/src/components/torrent-info/TorrentInfo.tsx
@@ -1,67 +1,37 @@
 import prettier from 'prettier-bytes';
-import React, {useState} from 'react';
+import React from 'react';
 import {TorrentPeers} from '../../library/types';
 import {Status, Torrent} from '../../types';
-import {clipboardCopy} from '../../utils/copy-to-clipboard';
-import {generateMagnetURL} from '../../utils/magnet';
 import {DownloadInfo} from './download-info/DownloadInfo';
+import {DownloadLink} from './download-link/DownloadLink';
+import {MagnetLinkButton} from './magnet-link-button/MagnetLinkButton';
 import './TorrentInfo.scss';
 import {UploadInfo} from './upload-info/UploadInfo';
 
-export type MagnetLinkButtonProps = {torrent: Torrent};
-
-const MagnetLinkButton: React.FC<MagnetLinkButtonProps> = ({torrent}) => {
-  const [magnetInfo, setMagnetInfo] = useState({
-    copied: false,
-    magnet: generateMagnetURL(torrent)
-  });
-  return (
-    <a
-      href={magnetInfo.magnet}
-      className="fileLink"
-      type="button"
-      onClick={event => {
-        event.preventDefault();
-        clipboardCopy(magnetInfo.magnet);
-        setMagnetInfo({...magnetInfo, copied: true});
-        setTimeout(() => setMagnetInfo({...magnetInfo, copied: false}), 3000);
-      }}
-    >
-      <span className={'tooltiptext ' + magnetInfo.copied}>
-        {magnetInfo.copied ? 'Great! Copied to your clipboard' : 'Copy to clipboard'}
-      </span>
-      Share Link
-    </a>
-  );
-};
-
 export type TorrentInfoProps = {torrent: Torrent; peers?: TorrentPeers};
+const DownloadingStatuses = [Status.Connecting, Status.Downloading, Status.Completed];
+const UploadingStatuses = [Status.Seeding];
 
 const TorrentInfo: React.FC<TorrentInfoProps> = ({torrent, peers}) => {
   return (
     <>
       <section className={`torrentInfo ${torrent.magnetURI ? ' with-link' : ''}`}>
         <span className="fileName">{torrent.name}</span>
-        {/* @todo Check if webtorrent allows for torrent.length to be undefined */}
-        <span className="fileSize">{!torrent.length ? '? Mb' : prettier(torrent.length)}</span>
-        {torrent.status ? <span className="fileStatus">{torrent.status}</span> : false}
+        <span className="fileSize">{torrent.length === 0 ? '? Mb' : prettier(torrent.length)}</span>
+        {torrent.status && <span className="fileStatus">{torrent.status}</span>}
         <span className="fileCost">
           Est. cost {!torrent.cost ? 'Unknown' : `$${Number(torrent.cost).toFixed(2)}`}
         </span>
-        {torrent.magnetURI ? <MagnetLinkButton torrent={torrent} /> : false}
+        {torrent.magnetURI && <MagnetLinkButton torrent={torrent} />}
       </section>
-      {/* @todo Shouldn't we use Status.Download only? */}
-      {torrent.status !== Status.Idle && torrent.status !== Status.Seeding && torrent.ready ? (
+      {DownloadingStatuses.includes(torrent.status) ? (
         <DownloadInfo torrent={torrent} />
-      ) : /* @todo Why torrent.ready must be set to false for this to happen? */
-      torrent.createdBy ? (
-        <UploadInfo torrent={torrent} peers={peers} />
       ) : (
-        /* @todo Why would there be a condition where nothing should be shown? */
-        false
+        UploadingStatuses.includes(torrent.status) && <UploadInfo torrent={torrent} peers={peers} />
       )}
+      {!torrent.createdBy && <DownloadLink torrent={torrent} />}
     </>
   );
 };
 
-export {TorrentInfo, MagnetLinkButton};
+export {TorrentInfo};

--- a/packages/web3torrent/src/components/torrent-info/TorrentInfo.tsx
+++ b/packages/web3torrent/src/components/torrent-info/TorrentInfo.tsx
@@ -18,7 +18,6 @@ const MagnetLinkButton: React.FC<MagnetLinkButtonProps> = ({torrent}) => {
   return (
     <a
       href={magnetInfo.magnet}
-      target="blank"
       className="fileLink"
       type="button"
       onClick={event => {

--- a/packages/web3torrent/src/components/torrent-info/TorrentInfo.tsx
+++ b/packages/web3torrent/src/components/torrent-info/TorrentInfo.tsx
@@ -16,21 +16,23 @@ const MagnetLinkButton: React.FC<MagnetLinkButtonProps> = ({torrent}) => {
     magnet: generateMagnetURL(torrent)
   });
   return (
-    <button
+    <a
+      href={magnetInfo.magnet}
+      target="blank"
       className="fileLink"
       type="button"
-      onClick={() => {
+      onClick={event => {
+        event.preventDefault();
         clipboardCopy(magnetInfo.magnet);
         setMagnetInfo({...magnetInfo, copied: true});
         setTimeout(() => setMagnetInfo({...magnetInfo, copied: false}), 3000);
       }}
     >
-      {/* @todo: This shouldn't be called "myTooltip" by ID */}
-      <span className={'tooltiptext ' + magnetInfo.copied} id="myTooltip">
+      <span className={'tooltiptext ' + magnetInfo.copied}>
         {magnetInfo.copied ? 'Great! Copied to your clipboard' : 'Copy to clipboard'}
       </span>
       Share Link
-    </button>
+    </a>
   );
 };
 

--- a/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.tsx
@@ -1,28 +1,27 @@
 import prettier from 'prettier-bytes';
-import React, {useEffect, useState} from 'react';
+import React from 'react';
+import {remove} from '../../../clients/web3torrent-client';
 import {Torrent} from '../../../types';
-import {FormButton} from '../../form';
 import './DownloadInfo.scss';
 import {ProgressBar} from './progress-bar/ProgressBar';
 
 export type DownloadInfoProps = {torrent: Torrent};
 
 const DownloadInfo: React.FC<DownloadInfoProps> = ({torrent}: DownloadInfoProps) => {
-  const [fileURL, setURL] = useState('');
-  useEffect(() => {
-    if (torrent.done && torrent.files[0] && torrent.files[0].getBlobURL) {
-      torrent.files[0].getBlobURL((_, url) => setURL(url as string));
-    }
-  }, [torrent.done, torrent.files]);
-
   return (
     <section className="downloadingInfo">
       <ProgressBar
         downloaded={torrent.downloaded}
         length={torrent.length}
         status={torrent.status}
-        infoHash={torrent.infoHash}
       />
+      {!torrent.done ? (
+        <button type="button" className="button cancel" onClick={() => remove(torrent.infoHash)}>
+          Cancel Download
+        </button>
+      ) : (
+        false
+      )}
       <p>
         {torrent.parsedTimeRemaining}.{' '}
         {prettier(torrent.done || !torrent.downloadSpeed ? 0 : torrent.downloadSpeed)}
@@ -30,19 +29,6 @@ const DownloadInfo: React.FC<DownloadInfoProps> = ({torrent}: DownloadInfoProps)
         <br />
         Connected to <strong>{torrent.numPeers}</strong> peers.
       </p>
-      {torrent.downloaded !== torrent.length ? (
-        false
-      ) : (
-        /**
-         * @todo This should be a link with the button's styles,
-         * using FormButton seems a bit of an overkill
-         */
-        <a href={fileURL} download={torrent.name}>
-          <FormButton name="save-download" onClick={() => null}>
-            Save Download
-          </FormButton>
-        </a>
-      )}
     </section>
   );
 };

--- a/packages/web3torrent/src/components/torrent-info/download-info/progress-bar/ProgressBar.scss
+++ b/packages/web3torrent/src/components/torrent-info/download-info/progress-bar/ProgressBar.scss
@@ -19,33 +19,6 @@
   text-align: right;
 }
 
-.bar-cancelButton {
-  position: absolute;
-  top: 10px;
-  width: 30px;
-  left: 630px;
-  right: 10px;
-  text-align: right;
-  margin-top: 0px;
-  font-size: 26px;
-  font-weight: 100;
-  color: $c-orange;
-  background: none;
-  border: none;
-  svg {
-    cursor: pointer;
-    height: 20px;
-    width: 30px;
-  }
-  svg > path {
-    stroke: $c-orange;
-    stroke-width: 2px;
-  }
-
-  svg:hover > path {
-    stroke: red;
-  }
-}
 .positive {
   background: $c-orange;
   transition: width 0.2s ease-in;
@@ -53,7 +26,6 @@
   height: 100%;
   z-index: 1;
   overflow: hidden;
-  .bar-cancelButton svg path,
   .bar-status,
   .bar-progress {
     color: white;
@@ -80,7 +52,6 @@
   height: 100%;
   width: 100%;
   margin-top: -50px;
-  .bar-cancelButton,
   .bar-status,
   .bar-progress {
     color: $c-black;

--- a/packages/web3torrent/src/components/torrent-info/download-info/progress-bar/ProgressBar.test.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-info/progress-bar/ProgressBar.test.tsx
@@ -2,7 +2,6 @@ import Enzyme, {mount, ReactWrapper} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import prettier from 'prettier-bytes';
 import React from 'react';
-import * as Web3TorrentClient from '../../../../clients/web3torrent-client';
 import {Status} from '../../../../types';
 import {ProgressBar, ProgressBarProps} from './ProgressBar';
 
@@ -15,13 +14,9 @@ type MockProgressBar = {
   positiveElement: ReactWrapper;
   positiveBarProgressElement: ReactWrapper;
   positiveBarStatusElement: ReactWrapper;
-  positiveButtonElement: ReactWrapper;
-  positiveButtonIconElement: ReactWrapper;
   negativeElement: ReactWrapper;
   negativeBarProgressElement: ReactWrapper;
   negativeBarStatusElement: ReactWrapper;
-  negativeButtonElement: ReactWrapper;
-  negativeButtonIconElement: ReactWrapper;
 };
 
 const mockProgressBar = (props?: Partial<ProgressBarProps>): MockProgressBar => {
@@ -42,13 +37,9 @@ const mockProgressBar = (props?: Partial<ProgressBarProps>): MockProgressBar => 
     positiveElement: progressBarWrapper.find('.positive'),
     positiveBarProgressElement: progressBarWrapper.find('.positive .bar-progress'),
     positiveBarStatusElement: progressBarWrapper.find('.positive .bar-status'),
-    positiveButtonElement: progressBarWrapper.find('.positive .bar-cancelButton'),
-    positiveButtonIconElement: progressBarWrapper.find('.positive .bar-cancelButton svg'),
     negativeElement: progressBarWrapper.find('.negative'),
     negativeBarProgressElement: progressBarWrapper.find('.negative .bar-progress'),
-    negativeBarStatusElement: progressBarWrapper.find('.negative .bar-status'),
-    negativeButtonElement: progressBarWrapper.find('.negative .bar-cancelButton'),
-    negativeButtonIconElement: progressBarWrapper.find('.negative .bar-cancelButton svg')
+    negativeBarStatusElement: progressBarWrapper.find('.negative .bar-status')
   };
 };
 
@@ -64,13 +55,9 @@ describe('<ProgressBar />', () => {
       progressBarContainer,
       negativeBarProgressElement,
       negativeBarStatusElement,
-      negativeButtonElement,
-      negativeButtonIconElement,
       negativeElement,
       positiveBarProgressElement,
       positiveBarStatusElement,
-      positiveButtonElement,
-      positiveButtonIconElement,
       positiveElement,
       progressBarProps
     } = progressBar;
@@ -81,50 +68,26 @@ describe('<ProgressBar />', () => {
     expect(positiveElement.exists()).toEqual(true);
     expect(positiveBarProgressElement.exists()).toEqual(true);
     expect(positiveBarStatusElement.exists()).toEqual(true);
-    expect(positiveButtonElement.exists()).toEqual(true);
-    expect(positiveButtonIconElement.exists()).toEqual(true);
     expect(negativeElement.exists()).toEqual(true);
     expect(negativeBarProgressElement.exists()).toEqual(true);
     expect(negativeBarStatusElement.exists()).toEqual(true);
-    expect(negativeButtonElement.exists()).toEqual(true);
-    expect(negativeButtonIconElement.exists()).toEqual(true);
 
     expect(positiveBarProgressElement.text()).toEqual(
       `${prettier(downloaded)}/${prettier(length)}`
     );
     expect(positiveElement.prop('style')).toEqual({width: '10%'});
     expect(positiveBarStatusElement.text()).toEqual(Status.Downloading);
-    expect(positiveButtonElement.prop('onClick')).toBeUndefined();
 
     expect(negativeBarProgressElement.text()).toEqual(
       `${prettier(downloaded)}/${prettier(length)}`
     );
     expect(negativeElement.prop('style')).toBeUndefined();
     expect(negativeBarStatusElement.text()).toEqual(Status.Downloading);
-    expect(negativeButtonElement.prop('onClick')).not.toBeUndefined();
   });
 
   it('can show the `complete` class once it reached 100%', () => {
     const {positiveElement, negativeElement} = mockProgressBar({downloaded: 128913});
     expect(positiveElement.hasClass('complete')).toEqual(true);
     expect(negativeElement.hasClass('complete')).toEqual(false);
-  });
-
-  it('can call Web3TorrentClient.remove() when clicking the Cancel button', () => {
-    const removeSpy = jest
-      .spyOn(Web3TorrentClient, 'remove')
-      .mockImplementation(async (_?: string) => {
-        /* nothing to see here */
-      });
-
-    const {positiveButtonElement, negativeButtonElement, progressBarProps} = progressBar;
-
-    positiveButtonElement.simulate('click');
-    expect(removeSpy).not.toHaveBeenCalled();
-
-    negativeButtonElement.simulate('click');
-    expect(removeSpy).toHaveBeenCalledWith(progressBarProps.infoHash);
-
-    removeSpy.mockRestore();
   });
 });

--- a/packages/web3torrent/src/components/torrent-info/download-info/progress-bar/ProgressBar.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-info/progress-bar/ProgressBar.tsx
@@ -1,12 +1,11 @@
 import prettier from 'prettier-bytes';
 import React from 'react';
-import {remove} from '../../../../clients/web3torrent-client';
 import {Torrent} from '../../../../types';
 import './ProgressBar.scss';
 
-export type ProgressBarProps = Pick<Torrent, 'downloaded' | 'length' | 'status' | 'infoHash'>;
+export type ProgressBarProps = Pick<Torrent, 'downloaded' | 'length' | 'status'>;
 
-export const ProgressBar: React.FC<ProgressBarProps> = ({downloaded, length, status, infoHash}) => {
+export const ProgressBar: React.FC<ProgressBarProps> = ({downloaded, length, status}) => {
   return (
     <div className="progress-bar">
       <div
@@ -17,24 +16,12 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({downloaded, length, sta
           {prettier(downloaded)}/{prettier(length)}
         </span>
         <span className="bar-status">{status}</span>
-        <button type="button" className="bar-cancelButton">
-          <svg>
-            <path d="M0,20,20,0" />
-            <path d="M0,0,20,20" />
-          </svg>
-        </button>
       </div>
       <div className="negative">
         <span className="bar-progress">
           {prettier(downloaded)}/{prettier(length)}
         </span>
         <span className="bar-status">{status}</span>
-        <button type="button" className="bar-cancelButton" onClick={() => remove(infoHash)}>
-          <svg>
-            <path d="M0,20,20,0" />
-            <path d="M0,0,20,20" />
-          </svg>
-        </button>
       </div>
     </div>
   );

--- a/packages/web3torrent/src/components/torrent-info/download-link/DownloadLink.test.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-link/DownloadLink.test.tsx
@@ -1,0 +1,40 @@
+import Enzyme, {mount} from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import React from 'react';
+import {TorrentFile} from 'webtorrent';
+import {createMockTorrent} from '../../../utils/test-utils';
+import {DownloadLink} from './DownloadLink';
+
+Enzyme.configure({adapter: new Adapter()});
+
+describe('<DownloadLink />', () => {
+  let component: Enzyme.ReactWrapper;
+
+  beforeAll(() => {
+    document.execCommand = jest.fn(() => true);
+    component = mount(<DownloadLink torrent={createMockTorrent()} />);
+  });
+
+  it('by default should be hidden', () => {
+    expect(component.find('.button').exists()).toBe(false);
+  });
+
+  it('by default should be hidden', () => {
+    expect(component.find('.button').exists()).toBe(false);
+  });
+
+  it('can show a Save Download link when finished', () => {
+    const mockTorrent = createMockTorrent({
+      downloaded: 128913,
+      done: true,
+      files: [({getBlobURL: resolve => resolve(null, 'blob')} as unknown) as TorrentFile]
+    });
+    component = mount(<DownloadLink torrent={mockTorrent} />);
+
+    const downloadLink = component.find('.button');
+    expect(downloadLink.exists()).toEqual(true);
+    expect(downloadLink.prop('href')).toEqual('blob');
+    expect(downloadLink.prop('download')).toEqual(mockTorrent.name);
+    expect(downloadLink.text()).toEqual('Save Download');
+  });
+});

--- a/packages/web3torrent/src/components/torrent-info/download-link/DownloadLink.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-link/DownloadLink.tsx
@@ -1,0 +1,24 @@
+import React, {useEffect, useState} from 'react';
+import {Torrent} from '../../../types';
+
+export type DownloadLinkProps = {torrent: Torrent};
+
+export const DownloadLink: React.FC<DownloadLinkProps> = ({torrent}) => {
+  const [fileURL, setURL] = useState('');
+
+  useEffect(() => {
+    if (torrent.done && torrent.files[0] && torrent.files[0].getBlobURL) {
+      torrent.files[0].getBlobURL((_, url) => setURL(url as string));
+    }
+  }, [torrent.done, torrent.files]);
+
+  return (
+    <>
+      {fileURL && (
+        <a href={fileURL} className="button" download={torrent.name}>
+          Save Download
+        </a>
+      )}
+    </>
+  );
+};

--- a/packages/web3torrent/src/components/torrent-info/magnet-link-button/MagnetLinkButton.test.tsx
+++ b/packages/web3torrent/src/components/torrent-info/magnet-link-button/MagnetLinkButton.test.tsx
@@ -1,0 +1,43 @@
+import Enzyme, {mount} from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import React from 'react';
+import {createMockTorrent} from '../../../utils/test-utils';
+import {MagnetLinkButton} from './MagnetLinkButton';
+
+Enzyme.configure({adapter: new Adapter()});
+
+describe('<MagnetLinkButton />', () => {
+  let component: Enzyme.ReactWrapper;
+
+  beforeAll(() => {
+    document.execCommand = jest.fn(() => true);
+    component = mount(<MagnetLinkButton torrent={createMockTorrent()} />);
+  });
+
+  it('renders without crashing', () => {
+    expect(component.find('.fileLink').exists()).toBe(true);
+  });
+
+  it('renders a button with default properties', () => {
+    expect(component.find('.fileLink').exists()).toBe(true);
+  });
+
+  it('should show a tooltip instruting to copy the link', () => {
+    const tooltip = component.find('.tooltiptext');
+    expect(tooltip.exists()).toEqual(true);
+    expect(tooltip.text()).toEqual('Copy to clipboard');
+  });
+
+  it('should copy the link to the clipboard when clicking', () => {
+    component.simulate('click');
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+
+    const tooltip = component.find('.tooltiptext');
+    expect(tooltip.exists()).toEqual(true);
+    expect(tooltip.text()).toEqual('Great! Copied to your clipboard');
+  });
+
+  afterAll(() => {
+    delete document.execCommand;
+  });
+});

--- a/packages/web3torrent/src/components/torrent-info/magnet-link-button/MagnetLinkButton.tsx
+++ b/packages/web3torrent/src/components/torrent-info/magnet-link-button/MagnetLinkButton.tsx
@@ -1,0 +1,32 @@
+import React, {useState} from 'react';
+import {Torrent} from '../../../types';
+import {clipboardCopy} from '../../../utils/copy-to-clipboard';
+import {generateMagnetURL} from '../../../utils/magnet';
+
+export type MagnetLinkButtonProps = {torrent: Torrent};
+
+export const MagnetLinkButton: React.FC<MagnetLinkButtonProps> = ({torrent}) => {
+  const [magnetInfo, setMagnetInfo] = useState({
+    copied: false,
+    magnet: generateMagnetURL(torrent)
+  });
+
+  return (
+    <a
+      href={magnetInfo.magnet}
+      className="fileLink"
+      type="button"
+      onClick={event => {
+        event.preventDefault();
+        clipboardCopy(magnetInfo.magnet);
+        setMagnetInfo({...magnetInfo, copied: true});
+        setTimeout(() => setMagnetInfo({...magnetInfo, copied: false}), 3000);
+      }}
+    >
+      <span className={'tooltiptext ' + magnetInfo.copied}>
+        {magnetInfo.copied ? 'Great! Copied to your clipboard' : 'Copy to clipboard'}
+      </span>
+      Share Link
+    </a>
+  );
+};

--- a/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.test.tsx
+++ b/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.test.tsx
@@ -28,12 +28,9 @@ type MockUploadInfo = {
   leechersInfo: ElementsByLeecher;
 };
 
-const mockUploadInfo = (torrentProps?: Partial<Torrent>): MockUploadInfo => {
-  const peers = createMockTorrentPeers();
-  const torrent = createMockTorrent({
-    numPeers: Object.keys(peers).length,
-    ...torrentProps
-  }) as Torrent;
+const mockUploadInfo = (noPeers = false): MockUploadInfo => {
+  const peers = noPeers ? {} : createMockTorrentPeers();
+  const torrent = createMockTorrent({numPeers: Object.keys(peers).length}) as Torrent;
 
   const uploadInfoWrapper = mount(<UploadInfo torrent={torrent} peers={peers} />);
 
@@ -68,14 +65,7 @@ describe('<UploadInfo />', () => {
   });
 
   it('can be instantiated', () => {
-    const {
-      leechersInfo,
-      leechersSectionElement,
-      numPeersElement,
-      torrent,
-      peers,
-      uploadingSectionElement
-    } = uploadInfo;
+    const {leechersSectionElement, numPeersElement, torrent, uploadingSectionElement} = uploadInfo;
 
     expect(uploadingSectionElement.exists()).toEqual(true);
     expect(numPeersElement.exists()).toEqual(true);
@@ -83,6 +73,14 @@ describe('<UploadInfo />', () => {
 
     expect(numPeersElement.text()).toEqual(`${torrent.numPeers}`);
     expect(leechersSectionElement.children().length).toEqual(torrent.numPeers);
+  });
+
+  it('shows no peer info when no peers exist', () => {
+    const {leechersSectionElement, uploadingSectionElement} = mockUploadInfo(true);
+
+    expect(uploadingSectionElement.exists()).toEqual(true);
+    expect(leechersSectionElement.exists()).toEqual(true);
+    expect(leechersSectionElement.children().length).toEqual(0);
   });
 
   it.each([Object.keys(createMockTorrentPeers())])(

--- a/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.tsx
+++ b/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.tsx
@@ -6,8 +6,7 @@ import './UploadInfo.scss';
 
 export type UploadInfoProps = {torrent: Torrent; peers?: TorrentPeers};
 
-const UploadInfo: React.FC<UploadInfoProps> = ({torrent, peers}) => {
-  const peersArray = Object.values(peers || {});
+const UploadInfo: React.FC<UploadInfoProps> = ({torrent, peers = {}}) => {
   return (
     <>
       <section className="uploadingInfo">
@@ -18,19 +17,17 @@ const UploadInfo: React.FC<UploadInfoProps> = ({torrent, peers}) => {
         </p>
       </section>
       <section className="leechersInfo">
-        {peersArray.length
-          ? peersArray.map(leecher => (
-              <div className="leecherInfo" key={leecher.id}>
-                <span className="leecher-id">#{leecher.id}</span>
-                <span className="leecher-downloaded">
-                  {leecher.wire && prettier(leecher.wire.uploaded)}
-                </span>
-                <span className="leecher-paid">
-                  ${leecher.wire && (leecher.wire.uploaded * 0.000005).toFixed(2)}
-                </span>
-              </div>
-            ))
-          : false}
+        {Object.values(peers).map(leecher => (
+          <div className="leecherInfo" key={leecher.id}>
+            <span className="leecher-id">#{leecher.id}</span>
+            <span className="leecher-downloaded">
+              {leecher.wire && prettier(leecher.wire.uploaded)}
+            </span>
+            <span className="leecher-paid">
+              ${leecher.wire && (leecher.wire.uploaded * 0.000005).toFixed(2)}
+            </span>
+          </div>
+        ))}
       </section>
     </>
   );

--- a/packages/web3torrent/src/types.ts
+++ b/packages/web3torrent/src/types.ts
@@ -6,8 +6,7 @@ export enum Status {
   Seeding = 'Seeding',
   Completed = 'Completed',
   Idle = 'Idle',
-  Connecting = 'Connecting',
-  Stopped = 'Stopped'
+  Connecting = 'Connecting'
 }
 
 export type Torrent = ExtendedTorrent & {

--- a/packages/web3torrent/src/utils/test-utils.ts
+++ b/packages/web3torrent/src/utils/test-utils.ts
@@ -1,11 +1,13 @@
+import {EmptyTorrent} from '../constants';
 import {TorrentPeers} from '../library/types';
 import {Torrent} from '../types';
 
 export function testSelector(name: string): string {
   return `[data-test-selector='${name}']`;
 }
-export function createMockTorrent(props?: Partial<Torrent>): Partial<Torrent> {
+export function createMockTorrent(props?: Partial<Torrent>): Torrent {
   return {
+    ...EmptyTorrent,
     magnetURI:
       'magnet:?xt=urn%3Abtih%3A0303b8f867f4377ef4a25eba8836cc5f7fdd992b&dn=on-the-shortness-of-life-1.jpg&xl=128864&cost=0',
     name: 'on-the-shortness-of-life-1.jpg',

--- a/packages/web3torrent/src/utils/torrent-status-checker.test.ts
+++ b/packages/web3torrent/src/utils/torrent-status-checker.test.ts
@@ -70,8 +70,8 @@ describe('Torrent Status Checker', () => {
       });
 
       // TODO: Correct behaviour should be ETA 0s.
-      it("should return 'ETA 0' if timeRemaining is empty", () => {
-        expect(getFormattedETA({done: false} as ExtendedTorrent)).toEqual('ETA 0');
+      it("should return 'ETA 0s' if timeRemaining is empty", () => {
+        expect(getFormattedETA({done: false} as ExtendedTorrent)).toEqual('ETA 0s');
       });
 
       it("should return 'ETA Unknown' if timeRemaining is Infinity", () => {
@@ -92,15 +92,15 @@ describe('Torrent Status Checker', () => {
         );
       });
 
-      it('should return time in hours, minutes and seconds', () => {
+      it('should return time in hours and minutes', () => {
         expect(getFormattedETA({done: false, timeRemaining: 25923813} as ExtendedTorrent)).toEqual(
-          'ETA 7h 12m 3s'
+          'ETA 7h 12m'
         );
       });
 
-      it('should return time in days, hours, minutes and seconds', () => {
+      it('should return time in days, hours and minutes', () => {
         expect(getFormattedETA({done: false, timeRemaining: 482949274} as ExtendedTorrent)).toEqual(
-          'ETA 5d 14h 9m 9s'
+          'ETA 5d 14h 9m'
         );
       });
     });

--- a/packages/web3torrent/src/utils/torrent-status-checker.ts
+++ b/packages/web3torrent/src/utils/torrent-status-checker.ts
@@ -2,11 +2,7 @@ import {web3torrent} from '../clients/web3torrent-client';
 import {ExtendedTorrent} from '../library/types';
 import {Status, Torrent} from '../types';
 
-export const getStatus = (torrent: ExtendedTorrent, previousStatus: Status): Status => {
-  /**
-   * @todo Maybe `previousStatus` could be marked as optional, since it's
-   * only used to check for the Seeding status.
-   */
+export const getStatus = (torrent: ExtendedTorrent, previousStatus?: Status): Status => {
   const {uploadSpeed, downloadSpeed, progress, done} = torrent;
   if (previousStatus === Status.Seeding) {
     return Status.Seeding;
@@ -25,24 +21,23 @@ export const getFormattedETA = (torrent: ExtendedTorrent) => {
   if (done) {
     return 'Done';
   }
+  if (timeRemaining === Infinity) {
+    return 'ETA Unknown';
+  }
+
   const remaining = timeRemaining || 0;
+
   const days = Math.floor(remaining / (1000 * 60 * 60 * 24));
   const hours = Math.floor((remaining % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
   const minutes = Math.floor((remaining % (1000 * 60 * 60)) / (1000 * 60));
   const seconds = Math.floor((remaining % (1000 * 60)) / 1000);
-
-  /**
-   * @todo This returns `ETA 0` if `timeRemaining` is 0 or undefined.
-   * It should return `ETA 0s`.
-   *
-   * @todo The check for Infinity could be done before doing any other math
-   * to save some time.
-   */
-  return timeRemaining === Infinity
-    ? 'ETA Unknown'
-    : `ETA ${(days && days + 'd ') || ''}${(hours && hours + 'h ') || ''}${(minutes &&
-        minutes + 'm ') ||
-        ''}${seconds && seconds + 's'}`;
+  return [
+    'ETA',
+    (days && ' ' + days + 'd') || '',
+    (hours && ' ' + hours + 'h') || '',
+    (minutes && ' ' + minutes + 'm') || '',
+    !days && !hours ? ' ' + seconds + 's' : ''
+  ].join('');
 };
 
 export default (previousData: Torrent, infoHash): Torrent => {


### PR DESCRIPTION
### Description

So... what started as a simple change (the first commit, a couple of lines), ended up as a refactor with 17 files affected :-P.
#### So, this PR, when merged:

- Replaces the share button with an anchor link. See #241 for more details.
- Moves the cancel button from the progress bar into a page level button (#246 ).
![image](https://user-images.githubusercontent.com/10502605/67446865-60fe3100-f5e8-11e9-8593-e5685ad455cc.png)
- And most of all, refactors several components into their own files, and fixes a lot of things that @joelalejandro had commented that could be improved, this will pave the way for me tomorrow to work on the routing improvements, and implementing #245.

### Related issues
closes #241
closes #246 
affects #245 
