### PR TITLE
[embedded-wallet] Implements simplified Budget Allocation view

### DIFF
--- a/packages/embedded-wallet/src/dialogs/budget-allocation/BudgetAllocation.tsx
+++ b/packages/embedded-wallet/src/dialogs/budget-allocation/BudgetAllocation.tsx
@@ -4,6 +4,8 @@ import {Redirect, RouteComponentProps} from 'react-router';
 import {OnboardingFlowPaths, useOnboardingFlowContext} from '../../flows';
 import {closeWallet} from '../../message-dispatchers';
 import {Dialog, Slider} from '../../ui';
+import {Expandable} from '../../ui/expandable/Expandable';
+
 const log = debug('wallet:budget-allocation');
 
 const allow = (amountToAllocate: number, useRedirect: Dispatch<SetStateAction<boolean>>) => () => {
@@ -39,14 +41,16 @@ const BudgetAllocation: React.FC<RouteComponentProps> = () => {
       <div>
         Recommended amount: <strong>0.2 ETH</strong> of your send.
       </div>
-      <Slider
-        initialValue={0.2}
-        min={0}
-        max={2}
-        unit="ETH"
-        step={0.01}
-        onChange={setAmountToAllocate}
-      />
+      <Expandable title="Customize">
+        <Slider
+          initialValue={0.2}
+          min={0}
+          max={2}
+          unit="ETH"
+          step={0.01}
+          onChange={setAmountToAllocate}
+        />
+      </Expandable>
     </Dialog>
   );
 };

--- a/packages/embedded-wallet/src/ui/chevron/Chevron.module.css
+++ b/packages/embedded-wallet/src/ui/chevron/Chevron.module.css
@@ -1,0 +1,32 @@
+.chevron::before {
+  border-style: solid;
+  border-width: 2px 2px 0 0;
+  border-color: var(--primary-color);
+  content: '';
+  display: inline-block;
+  height: 0.45em;
+  position: relative;
+  vertical-align: top;
+  width: 0.45em;
+  left: 0.15em;
+  top: 0.15em;
+}
+
+.chevron.up::before {
+  transform: rotate(-45deg);
+  top: 0.55em;
+}
+
+.chevron.right::before {
+  left: 0;
+  transform: rotate(45deg);
+}
+
+.chevron.down::before {
+  transform: rotate(135deg);
+}
+
+.chevron.left::before {
+  left: 0.25em;
+  transform: rotate(-135deg);
+}

--- a/packages/embedded-wallet/src/ui/chevron/Chevron.test.tsx
+++ b/packages/embedded-wallet/src/ui/chevron/Chevron.test.tsx
@@ -1,0 +1,19 @@
+import Enzyme, {mount} from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import React from 'react';
+import {Chevron, ChevronDirection, ChevronProps} from './Chevron';
+import css from './Chevron.module.css';
+
+Enzyme.configure({adapter: new Adapter()});
+
+const mockChevron = ({direction}: ChevronProps) =>
+  mount(<Chevron direction={direction} />).find('span');
+
+describe('UI - Chevron', () => {
+  it.each(['up', 'down', 'left', 'right'])('can show a chevron facing %s', direction => {
+    const chevron = mockChevron({direction: direction as ChevronDirection});
+    expect(chevron.exists()).toEqual(true);
+    expect(chevron.hasClass(css.chevron)).toEqual(true);
+    expect(chevron.hasClass(css[direction])).toEqual(true);
+  });
+});

--- a/packages/embedded-wallet/src/ui/chevron/Chevron.tsx
+++ b/packages/embedded-wallet/src/ui/chevron/Chevron.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import css from './Chevron.module.css';
+
+export type ChevronDirection = 'up' | 'right' | 'down' | 'left';
+
+export type ChevronProps = {
+  direction: ChevronDirection;
+};
+
+const Chevron: React.FC<ChevronProps> = ({direction}) => (
+  <span className={`${css.chevron} ${css[direction]}`}></span>
+);
+
+export {Chevron};

--- a/packages/embedded-wallet/src/ui/expandable/Expandable.module.css
+++ b/packages/embedded-wallet/src/ui/expandable/Expandable.module.css
@@ -1,0 +1,20 @@
+.expandable {
+  display: block;
+  margin-top: 15px;
+}
+
+.label {
+  color: var(--primary-color);
+  font: 16px/20px 'Karla';
+  margin-right: 5px;
+}
+
+.labelContainer {
+  display: flex;
+  align-content: center;
+}
+
+.label,
+.labelContainer {
+  cursor: pointer;
+}

--- a/packages/embedded-wallet/src/ui/expandable/Expandable.test.tsx
+++ b/packages/embedded-wallet/src/ui/expandable/Expandable.test.tsx
@@ -1,0 +1,99 @@
+import Enzyme, {mount, ReactWrapper} from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import React from 'react';
+import {Chevron, ChevronProps} from '../chevron/Chevron';
+import {Expandable, ExpandableProps} from './Expandable';
+import css from './Expandable.module.css';
+
+Enzyme.configure({adapter: new Adapter()});
+
+type MockExpandable = {
+  expandableWrapper: ReactWrapper;
+  sectionElement: ReactWrapper;
+  labelContainer: ReactWrapper;
+  labelTextElement: ReactWrapper;
+  chevronElement: ReactWrapper<ChevronProps>;
+  contentWrapper: ReactWrapper;
+};
+
+const mockExpandableContents = <label>I'm hidden</label>;
+
+const mockExpandable = ({
+  shouldShowContent = false,
+  title = 'More details'
+}: Partial<ExpandableProps> = {}): MockExpandable => {
+  const expandableWrapper = mount(
+    <Expandable shouldShowContent={shouldShowContent} title={title}>
+      {mockExpandableContents}
+    </Expandable>
+  );
+
+  return refreshExpandableFrom(expandableWrapper);
+};
+
+const refreshExpandableFrom = (expandableWrapper: ReactWrapper) => {
+  expandableWrapper.update();
+
+  return {
+    expandableWrapper,
+    sectionElement: expandableWrapper.find(`section.${css.expandable}`),
+    labelContainer: expandableWrapper.find(`div.${css.labelContainer}`),
+    labelTextElement: expandableWrapper.find(`label.${css.label}`),
+    chevronElement: expandableWrapper.find(Chevron),
+    contentWrapper: expandableWrapper.find("[data-test-selector='expandable-content']")
+  };
+};
+
+describe('UI - Expandable', () => {
+  let expandable: MockExpandable;
+
+  beforeEach(() => {
+    expandable = mockExpandable();
+  });
+
+  it('can be instantiated', () => {
+    const {
+      chevronElement,
+      contentWrapper,
+      labelContainer,
+      labelTextElement,
+      sectionElement
+    } = expandable;
+
+    expect(sectionElement.exists()).toEqual(true);
+    expect(labelContainer.exists()).toEqual(true);
+    expect(labelTextElement.exists()).toEqual(true);
+    expect(chevronElement.exists()).toEqual(true);
+    expect(contentWrapper.exists()).toEqual(true);
+
+    expect(chevronElement.prop('direction')).toEqual('down');
+    expect(labelTextElement.text()).toEqual('More details');
+    expect(contentWrapper.children().length).toEqual(0);
+  });
+
+  it('can be expanded, showing content', () => {
+    const {expandableWrapper, labelContainer} = expandable;
+    labelContainer.simulate('click');
+
+    const {chevronElement, contentWrapper} = refreshExpandableFrom(expandableWrapper);
+
+    expect(contentWrapper.exists()).toEqual(true);
+    expect(contentWrapper.children().length).toEqual(1);
+    expect(contentWrapper.find('label').text()).toEqual("I'm hidden");
+
+    expect(chevronElement.prop('direction')).toEqual('up');
+  });
+
+  it('can be collapsed, hiding content', () => {
+    const {expandableWrapper, labelContainer} = mockExpandable({shouldShowContent: true});
+    labelContainer.simulate('click');
+
+    const {chevronElement, contentWrapper} = refreshExpandableFrom(expandableWrapper);
+
+    expect(contentWrapper.exists()).toEqual(true);
+    expect(contentWrapper.children().length).toEqual(0);
+    expect(contentWrapper.find('label').exists()).toEqual(false);
+
+    expect(chevronElement.prop('direction')).toEqual('down');
+  });
+});

--- a/packages/embedded-wallet/src/ui/expandable/Expandable.tsx
+++ b/packages/embedded-wallet/src/ui/expandable/Expandable.tsx
@@ -1,0 +1,28 @@
+import React, {useState} from 'react';
+import {Chevron} from '../chevron/Chevron';
+import css from './Expandable.module.css';
+
+export type ExpandableProps = {
+  shouldShowContent?: boolean;
+  title: string;
+};
+
+const Expandable: React.FC<ExpandableProps> = ({shouldShowContent = false, title, children}) => {
+  const [showContent, setShowContent] = useState<boolean>(shouldShowContent);
+
+  return (
+    <section className={css.expandable}>
+      <div
+        data-test-selector="expandable-title"
+        className={css.labelContainer}
+        onClick={() => setShowContent(!showContent)}
+      >
+        <label className={css.label}>{title}</label>
+        <Chevron direction={showContent ? 'up' : 'down'}></Chevron>
+      </div>
+      <div data-test-selector="expandable-content">{showContent && children}</div>
+    </section>
+  );
+};
+
+export {Expandable};

--- a/packages/embedded-wallet/src/ui/index.ts
+++ b/packages/embedded-wallet/src/ui/index.ts
@@ -1,5 +1,7 @@
 export * from './button/Button';
+export * from './chevron/Chevron';
 export * from './dialog/Dialog';
+export * from './expandable/Expandable';
 export * from './flow-process/FlowProcess';
 export * from './flow-process/FlowStep';
 export * from './icon/Icon';


### PR DESCRIPTION
Resolves #265.

Adds `Chevron` and `Expandable` components, with its corresponding tests.

**Initial view**
![image](https://user-images.githubusercontent.com/118913/67716128-f9f6c880-f9a9-11e9-8769-a3d2d755f721.png)

**Expanded view**
![image](https://user-images.githubusercontent.com/118913/67716141-ffeca980-f9a9-11e9-90b4-3fdff58c23e9.png)
