### PR TITLE
[nitro-protocol] Introduce website:deploy script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # dependencies
 node_modules
 packages/**/yarn.lock
+# need this in order for netlify to use yarn
+!packages/nitro-protocol/yarn.lock 
 
 # production
 build/

--- a/packages/nitro-protocol/.yarnrc
+++ b/packages/nitro-protocol/.yarnrc
@@ -1,0 +1,1 @@
+ignore-scripts true

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -50,12 +50,17 @@
     "test:ci": "yarn contract:compile && yarn test:prepare && npx jest --ci --bail --runInBand",
     "test:prepare": "yarn deploy:test",
     "test:typescript": "npx jest --testPathIgnorePatterns='test/contracts' --reporters='default'",
-    "test": "yarn test:prepare && npx jest"
+    "test": "yarn test:prepare && npx jest",
+    "website:deploy": "npx etherlime compile --buildDirectory=./build/contracts && yarn docgen && cd website && yarn install && yarn build"
   },
   "dependencies": {
     "@counterfactual/cf-adjudicator-contracts": "^0.0.8",
     "@openzeppelin/contracts": "2.3.0",
     "ethers": "4.0.37",
+    "etherlime": "2.2.4",
+    "etherlime-lib": "1.1.5",
+    "solc": "0.5.11",
+    "solidoc": "https://github.com/statechannels/solidoc.git",
     "web3-eth-accounts": "1.2.1"
   },
   "devDependencies": {
@@ -65,8 +70,6 @@
     "@types/node": "12.7.5",
     "@types/web3": "1.0.19",
     "dotenv": "8.1.0",
-    "etherlime": "2.2.4",
-    "etherlime-lib": "1.1.5",
     "ganache-cli": "6.6.0",
     "jest": "24.9.0",
     "lint-staged": "9.4.0",
@@ -74,8 +77,6 @@
     "npm-run-all": "4.1.5",
     "prettier": "1.18.2",
     "prettier-plugin-solidity": "1.0.0-alpha.34",
-    "solc": "0.5.11",
-    "solidoc": "https://github.com/statechannels/solidoc.git",
     "truffle": "5.0.37",
     "ts-jest": "24.1.0",
     "tslint": "5.20.0",

--- a/packages/nitro-protocol/website/package.json
+++ b/packages/nitro-protocol/website/package.json
@@ -8,10 +8,9 @@
     "version": "docusaurus-version",
     "rename-version": "docusaurus-rename-version"
   },
-  "devDependencies": {
-    "docusaurus": "1.11.1"
-  },
+  "devDependencies": {},
   "dependencies": {
+    "docusaurus": "1.11.1",
     "highlightjs-solidity": "https://github.com/highlightjs/highlightjs-solidity",
     "remarkable-admonitions": "0.2.1"
   }

--- a/packages/nitro-protocol/yarn.lock
+++ b/packages/nitro-protocol/yarn.lock
@@ -1,0 +1,1 @@
+// This is a dummy file so triggers install of yarn on netlify


### PR DESCRIPTION
Coupled with a change to our netlify config (see below), this will allow website builds to be triggered only when files have changed in the `nitro-protocol` package (including for PRs), as well as cutting the build time roughly to a quarter of what it was (decoupling it from the building of other packages). 

![Screenshot 2019-10-29 at 14 03 09](https://user-images.githubusercontent.com/1833419/67774217-da68aa00-fa54-11e9-80c0-1dbae966ac9a.png)

Closes #259 (although any change to the package triggers a build, rather than just the contracts or docs).
