### PR TITLE
[Web3Torrent] Fix Seeding after Leeching

### DIFF
--- a/packages/web3torrent/src/clients/web3torrent-client.ts
+++ b/packages/web3torrent/src/clients/web3torrent-client.ts
@@ -7,10 +7,21 @@ export const WebTorrentContext = React.createContext(web3torrent);
 
 export const getTorrentPeers = infoHash => web3torrent.allowedPeers[infoHash];
 
-export const download: (torrent: WebTorrentAddInput) => Promise<Torrent> = torrentData =>
-  new Promise(resolve =>
+export const download: (torrent: WebTorrentAddInput) => Promise<Torrent> = torrentData => {
+  web3torrent.on(
+    // TODO: Remove when protocol is defined
+    ClientEvents.PEER_STATUS_CHANGED,
+    ({torrentPeers, torrentInfoHash, peerAccount}) => {
+      if (!torrentPeers[peerAccount].allowed) {
+        web3torrent.togglePeer(torrentInfoHash, peerAccount);
+      }
+    }
+  );
+
+  return new Promise(resolve =>
     web3torrent.add(torrentData, (torrent: any) => resolve({...torrent, status: Status.Connecting}))
   );
+};
 
 export const upload: (files: WebTorrentSeedInput) => Promise<Torrent> = files => {
   web3torrent.on(

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -5,7 +5,7 @@ import {download, getTorrentPeers} from '../../clients/web3torrent-client';
 import {FormButton} from '../../components/form';
 import {TorrentInfo} from '../../components/torrent-info/TorrentInfo';
 import {TorrentPeers} from '../../library/types';
-import {IdleStatuses, Status, Torrent} from '../../types';
+import {Status, Torrent} from '../../types';
 import {parseMagnetURL} from '../../utils/magnet';
 import torrentStatusChecker from '../../utils/torrent-status-checker';
 import {useInterval} from '../../utils/useInterval';
@@ -37,7 +37,7 @@ const File: React.FC<RouteComponentProps> = () => {
 
   useInterval(
     () => getLiveData(torrent),
-    (!IdleStatuses.includes(torrent.status) || !!torrent.createdBy) && 1000
+    (torrent.status !== Status.Idle || !!torrent.createdBy) && 1000
   );
 
   return (

--- a/packages/web3torrent/src/utils/torrent-status-checker.ts
+++ b/packages/web3torrent/src/utils/torrent-status-checker.ts
@@ -3,11 +3,14 @@ import {ExtendedTorrent} from '../library/types';
 import {Status, Torrent} from '../types';
 
 export const getStatus = (torrent: ExtendedTorrent): Status => {
-  const {uploadSpeed, downloadSpeed, progress, done, createdBy} = torrent;
+  const {uploadSpeed, downloadSpeed, progress, uploaded, done, createdBy} = torrent;
   if (createdBy) {
     return Status.Seeding;
   }
   if (progress && done) {
+    if (uploaded) {
+      return Status.Seeding;
+    }
     return Status.Completed;
   }
   if (uploadSpeed - downloadSpeed === 0) {
@@ -59,7 +62,7 @@ export default (previousData: Torrent, infoHash): Torrent => {
     ...{
       name: live.name || previousData.name,
       length: live.length || previousData.length,
-      downloaded: (live && live.downloaded) || 0,
+      downloaded: live.downloaded || 0,
       status: getStatus(live),
       uploadSpeed: live.uploadSpeed,
       downloadSpeed: live.downloadSpeed,


### PR DESCRIPTION
### Description

This PR will fix the behaviour in which, the leecher wouldn't seed the file after downloading it entirely, making magnet links useless if the original seeder wasn't connected.

[Here's a demo](https://drive.google.com/open?id=1cvga54IAwkshibvMvzSE_G9ZHEPyjyrO) of this working, I commented on the embedded wallet so the process is faster to look at.

### Related issues
closes #245
