### PR TITLE
[embedded-wallet] [web3torrent] Use channel-provider@0.0.3

### DIFF
--- a/packages/channel-provider/package.json
+++ b/packages/channel-provider/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "prepublish": "webpack",
     "build": "webpack",
+    "postinstall": "yarn build",
     "test": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:ci": "CI=true jest",

--- a/packages/channel-provider/package.json
+++ b/packages/channel-provider/package.json
@@ -3,12 +3,13 @@
   "license": "MIT",
   "version": "0.0.3",
   "main": "dist/channel-provider.min.js",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "debug": "4.1.1",
     "eventemitter3": "4.0.0"
   },
   "scripts": {
-    "prepublishOnly": "webpack",
+    "prepublish": "webpack",
     "build": "webpack",
     "test": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/packages/channel-provider/package.json
+++ b/packages/channel-provider/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "prepublish": "webpack",
     "build": "webpack",
-    "postinstall": "yarn build",
+    "prepare": "yarn build",
     "test": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:ci": "CI=true jest",

--- a/packages/channel-provider/tsconfig.json
+++ b/packages/channel-provider/tsconfig.json
@@ -6,7 +6,6 @@
     "declarationDir": "dist",
     "strict": true,
     "jsx": "preserve",
-    "isolatedModules": false,
     "target": "es5"
   },
   "include": ["src"]

--- a/packages/channel-provider/tsconfig.json
+++ b/packages/channel-provider/tsconfig.json
@@ -1,11 +1,12 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": false,
-    "declarationMap": false,
+    "declaration": true,
+    "declarationMap": true,
+    "declarationDir": "dist",
     "strict": true,
     "jsx": "preserve",
-    "isolatedModules": true,
+    "isolatedModules": false,
     "target": "es5"
   },
   "include": ["src"]

--- a/packages/embedded-wallet/package.json
+++ b/packages/embedded-wallet/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "version": "0.0.1",
   "dependencies": {
-    "@statechannels/channel-provider": "0.0.3",
+    "@statechannels/channel-provider": "*",
     "debug": "4.1.1",
     "react": "16.9.0",
     "react-dom": "16.9.0",

--- a/packages/embedded-wallet/package.json
+++ b/packages/embedded-wallet/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "version": "0.0.1",
   "dependencies": {
-    "@statechannels/channel-provider": "0.0.2-rc0",
+    "@statechannels/channel-provider": "0.0.3",
     "debug": "4.1.1",
     "react": "16.9.0",
     "react-dom": "16.9.0",

--- a/packages/embedded-wallet/package.json
+++ b/packages/embedded-wallet/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "precommit": "lint-staged --quiet",
     "start": "react-scripts start",
-    "build": "react-scripts build && cp node_modules/@statechannels/channel-provider/dist/* ./build/",
+    "build": "react-scripts build && cp ../../node_modules/@statechannels/channel-provider/dist/* ./build/",
     "test": "react-scripts test",
     "test:ci": "react-scripts test",
     "test:coverage": "react-scripts test --coverage --watchAll=false",

--- a/packages/web3torrent/package.json
+++ b/packages/web3torrent/package.json
@@ -41,7 +41,7 @@
   },
   "main": "src/index.js",
   "dependencies": {
-    "@statechannels/channel-provider": "^0.0.2-rc0",
+    "@statechannels/channel-provider": "0.0.3",
     "bencode": "2.0.1",
     "debug": "4.1.1",
     "eventemitter3": "4.0.0",

--- a/packages/web3torrent/package.json
+++ b/packages/web3torrent/package.json
@@ -41,7 +41,7 @@
   },
   "main": "src/index.js",
   "dependencies": {
-    "@statechannels/channel-provider": "0.0.3",
+    "@statechannels/channel-provider": "*",
     "bencode": "2.0.1",
     "debug": "4.1.1",
     "eventemitter3": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,14 +2715,6 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
-"@statechannels/channel-provider@0.0.2-rc0", "@statechannels/channel-provider@^0.0.2-rc0":
-  version "0.0.2-rc0"
-  resolved "https://registry.yarnpkg.com/@statechannels/channel-provider/-/channel-provider-0.0.2-rc0.tgz#62665138b3a22266a04359b9514fdc09a056b28a"
-  integrity sha512-yHcbehhyIP0wbLHIjPmsUc8L5rVp50GjdtX/HE/U3jZHzLaJGaEVLpPhXLBZpr+Y4SS2jaG/KcmWi3PeZn3a5g==
-  dependencies:
-    debug "4.1.1"
-    eventemitter3 "4.0.0"
-
 "@storybook/addon-actions@5.2.1":
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-5.2.1.tgz#2096e7f938b289be48af6f0adfd620997e7a420c"


### PR DESCRIPTION
We're not publishing packages automatically in CI, so the deploy preview for Web3Torrent got broken due to a non-published package reference. 

This problem made the checks fail in #293 and #294.

Once we merge this PR, the ones mentioned above should be mergeable again.

Also resolves #303.