### PR TITLE
[monorepo] Prevent unnecessary netlify builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+ ignore = "git diff --quiet HEAD^ HEAD ./packages/web3torrent ./packages/embedded-wallet ./packages/channel-provider"


### PR DESCRIPTION
This should prevent any netlify sites that are linked to the root of the monorepo from triggering builds unless there is one or more changes across the

- `channel-provider`
- `web3torrent`
- `embedded-wallet`

packages.

