### PR TITLE
[nitro-protocol] Fix broken links on docs website

### DIFF
--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -58,7 +58,7 @@
     "@openzeppelin/contracts": "2.3.0",
     "ethers": "4.0.37",
     "solc": "0.5.11",
-    "solidoc": "https://github.com/statechannels/solidoc.git",
+    "solidoc": "https://github.com/statechannels/solidoc.git#master",
     "web3-eth-accounts": "1.2.1"
   },
   "devDependencies": {

--- a/packages/nitro-protocol/solidoc.json
+++ b/packages/nitro-protocol/solidoc.json
@@ -1,8 +1,8 @@
 {
-    "pathToRoot": "./",
-    "pathToRepo": "https://github.com/statechannels/monorepo/tree/master/packages/nitro-protocol/",
-    "outputPath": "./docs/natspec",
-    "noCompilation": true,
-    "compiler": "etherlime compile",
-    "language": "en"
+  "pathToRoot": "./",
+  "repoUrl": "https://github.com/statechannels/monorepo/tree/master/packages/nitro-protocol/",
+  "outputPath": "./docs/natspec",
+  "noCompilation": true,
+  "compiler": "etherlime compile",
+  "language": "en"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -21173,9 +21173,9 @@ solidity-parser-antlr@^0.4.11, solidity-parser-antlr@^0.4.2:
   resolved "https://registry.yarnpkg.com/solidity-parser-antlr/-/solidity-parser-antlr-0.4.11.tgz#af43e1f13b3b88309a875455f5d6e565b05ee5f1"
   integrity sha512-4jtxasNGmyC0midtjH/lTFPZYvTTUMy6agYcF+HoMnzW8+cqo3piFrINb4ZCzpPW+7tTVFCGa5ubP34zOzeuMg==
 
-"solidoc@https://github.com/statechannels/solidoc.git":
+"solidoc@https://github.com/statechannels/solidoc.git#master":
   version "1.0.4"
-  resolved "https://github.com/statechannels/solidoc.git#e3825a41e3e99e317b490f735c83ef344555ce88"
+  resolved "https://github.com/statechannels/solidoc.git#5b56501bad7b585a96f3a7fa5f3e05267674e97c"
   dependencies:
     fs-extra "^7.0.0"
     glob "^7.1.3"


### PR DESCRIPTION
Our fork of `solidoc` has been updated to join relative paths for our contracts with a URL for our repo properly.  This PR pulls in those changes and exposes a `repoUrl` as required.

Will fix broken links labelled "View Source" on e.g. https://nitro-protocol.netlify.com/docs/natspec/iforcemove .