### PR TITLE
[nitro-protocol] Make etherlime a regular dependency

### DIFF
--- a/packages/nitro-protocol/bin/compile.js
+++ b/packages/nitro-protocol/bin/compile.js
@@ -1,9 +1,11 @@
 process.env.NODE_ENV = process.env.NODE_ENV || 'test';
 
-const { configureEnvVariables } = require('@statechannels/devtools');
-const { spawn } = require('child_process');
+if (process.env.NODE_ENV !== 'production') {
+  const { configureEnvVariables } = require('@statechannels/devtools');
+  configureEnvVariables();
+}
 
-configureEnvVariables();
+const { spawn } = require('child_process');
 
 const cmd = 'yarn';
 const args = ['run', 'etherlime', 'compile', '--buildDirectory=./build/contracts'];

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@counterfactual/cf-adjudicator-contracts": "^0.0.8",
     "@openzeppelin/contracts": "2.3.0",
+    "etherlime": "2.2.4",
     "ethers": "4.0.37",
     "solc": "0.5.11",
     "solidoc": "https://github.com/statechannels/solidoc.git",
@@ -68,7 +69,6 @@
     "@types/node": "12.7.5",
     "@types/web3": "1.0.19",
     "dotenv": "8.1.0",
-    "etherlime": "2.2.4",
     "etherlime-lib": "1.1.5",
     "ganache-cli": "6.6.0",
     "jest": "24.9.0",

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -51,7 +51,7 @@
     "test:prepare": "yarn deploy:test",
     "test:typescript": "npx jest --testPathIgnorePatterns='test/contracts' --reporters='default'",
     "test": "yarn test:prepare && npx jest",
-    "website:deploy": "npx etherlime compile --buildDirectory=./build/contracts && yarn docgen && cd website && yarn install && yarn build"
+    "website:deploy": "yarn contract:compile && yarn docgen && cd website && yarn install && yarn build"
   },
   "dependencies": {
     "@counterfactual/cf-adjudicator-contracts": "^0.0.8",


### PR DESCRIPTION
As a devDependency, etherlime was not being installed in production environments, causing the API side of our docs site to break.

