### PR TITLE
[monorepo] Add netlify-ignore script

### DIFF
--- a/netlify-ignore.sh
+++ b/netlify-ignore.sh
@@ -1,0 +1,22 @@
+# Set this environment variable as appropriate in netlify UI config
+case $TARGET_PACKAGE in
+
+    web3torrent)
+        echo "Checking for changes across web3torrent, embedded-wallet and channel-provider packages..."
+        git diff --quiet HEAD^ HEAD ./packages/web3torrent ./packages/embedded-wallet ./packages/channel-provider 
+        ;;
+
+    embedded-wallet)
+        echo "Checking for changes across web3torrent, embedded-wallet and channel-provider packages..."
+        git diff --quiet HEAD^ HEAD ./packages/web3torrent ./packages/embedded-wallet ./packages/channel-provider
+        ;;
+
+    nitro-protocol)
+        echo "Checking for changes in nitro-protocol package..."
+        git diff --quiet HEAD^ HEAD ./packages/nitro-protocol
+        ;;
+
+esac
+status=$?
+[ $status eq 0 ] || echo "No changes detected" && exit 0
+[ $status -eq 0 ] || echo "Changes detected" && exit 1

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
- ignore = "git diff --quiet HEAD^ HEAD ./packages/web3torrent ./packages/embedded-wallet ./packages/channel-provider"
+ ignore = "bash ./netlify-ignore.sh"

--- a/packages/nitro-protocol/yarn.lock
+++ b/packages/nitro-protocol/yarn.lock
@@ -1,1 +1,0 @@
-// This is a dummy file so triggers install of yarn on netlify


### PR DESCRIPTION
This change enables any netlify site to target the base directory of the monorepo (which makes dependency installation smoother), but also to skip a build based on changes to a `TARGET_PACKAGE` env variable. 