### PR TITLE
[engine] Clean up remaining commitment references

### DIFF
--- a/packages/hub/src/hub/handlers/handle-wallet-message.ts
+++ b/packages/hub/src/hub/handlers/handle-wallet-message.ts
@@ -1,5 +1,5 @@
 import {
-  CommitmentsReceived,
+  SignedStatesReceived,
   ConcludeInstigated,
   RelayableAction,
   StrategyProposed
@@ -24,30 +24,30 @@ export async function handleWalletMessage(
 // TODO: We should define types for NewProcessAction and ProtocolAction
 
 async function shouldHandleAsNewProcessAction(
-  action: ConcludeInstigated | CommitmentsReceived
+  action: ConcludeInstigated | SignedStatesReceived
 ): Promise<boolean> {
   if (action.type === 'WALLET.NEW_PROCESS.CONCLUDE_INSTIGATED') {
     return true;
   }
-  if (action.type === 'WALLET.COMMON.COMMITMENTS_RECEIVED') {
+  if (action.type === 'WALLET.COMMON.SIGNED_STATES_RECEIVED') {
     return !(await getProcess(action.processId));
   }
 }
 
 function isNewProcessAction(
   action: RelayableAction
-): action is ConcludeInstigated | CommitmentsReceived {
+): action is ConcludeInstigated | SignedStatesReceived {
   return (
     action.type === 'WALLET.NEW_PROCESS.CONCLUDE_INSTIGATED' ||
-    action.type === 'WALLET.COMMON.COMMITMENTS_RECEIVED'
+    action.type === 'WALLET.COMMON.SIGNED_STATES_RECEIVED'
   );
 }
 
 function isProtocolAction(
   action: RelayableAction
-): action is StrategyProposed | CommitmentsReceived {
+): action is StrategyProposed | SignedStatesReceived {
   return (
     action.type === 'WALLET.FUNDING_STRATEGY_NEGOTIATION.STRATEGY_PROPOSED' ||
-    action.type === 'WALLET.COMMON.COMMITMENTS_RECEIVED'
+    action.type === 'WALLET.COMMON.SIGNED_STATES_RECEIVED'
   );
 }

--- a/packages/wallet/notes/actions.md
+++ b/packages/wallet/notes/actions.md
@@ -52,21 +52,19 @@ NewProcessAction --> WALLET.NEW_PROCESS.CREATE_CHALLENGE_REQUESTED
 NewProcessAction --> WALLET.NEW_PROCESS.CHALLENGE_CREATED
 end
 
-subgraph ChannelAction
-ChannelAction --> WALLET.CHANNEL.OPPONENT_COMMITMENT_RECEIVED
-ChannelAction --> WALLET.CHANNEL.OWN_COMMITMENT_RECEIVED
+
 end
 
 subgraph RelayableAction
 RelayableAction --> WALLET.FUNDING_STRATEGY_NEGOTIATION.STRATEGY_PROPOSED
 RelayableAction --> WALLET.FUNDING_STRATEGY_NEGOTIATION.STRATEGY_APPROVED
 RelayableAction --> WALLET.NEW_PROCESS.CONCLUDE_INSTIGATED
-RelayableAction --> WALLET.COMMON.COMMITMENT_RECEIVED
+RelayableAction --> WALLET.COMMON.SIGNED_STATES_RECEIVED
 end
 
 subgraph CommonAction
-CommonAction --> WALLET.COMMON.COMMITMENT_RECEIVED
-CommonAction --> WALLET.COMMON.COMMITMENTS_RECEIVED
+CommonAction --> WALLET.COMMON.SIGNED_STATES_RECEIVED
+CommonAction --> WALLET.COMMON.SIGNED_STATES_RECEIVED
 end
 
 subgraph FundingAction
@@ -123,7 +121,7 @@ end
 subgraph DirectFundingAction
 DirectFundingAction --> WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT
 DirectFundingAction --> WALLET.DIRECT_FUNDING.DIRECT_FUNDING_REQUESTED
-DirectFundingAction --> WALLET.COMMON.COMMITMENT_RECEIVED
+DirectFundingAction --> WALLET.COMMON.SIGNED_STATES_RECEIVED
 DirectFundingAction --> TransactionAction
 end
 
@@ -142,8 +140,8 @@ WithdrawalAction --> WALLET.WITHDRAWING.WITHDRAWAL_REJECTED
 end
 
 subgraph ApplicationAction
-ApplicationAction --> WALLET.APPLICATION.OPPONENT_COMMITMENT_RECEIVED
-ApplicationAction --> WALLET.APPLICATION.OWN_COMMITMENT_RECEIVED
+ApplicationAction --> WALLET.APPLICATION.OPPONENT_SIGNED_STATES_RECEIVED
+ApplicationAction --> WALLET.APPLICATION.OWN_SIGNED_STATES_RECEIVED
 ApplicationAction --> WALLET.APPLICATION.CONCLUDE_REQUESTED
 end
 
@@ -178,7 +176,7 @@ class DisputeAction,FundingAction,ApplicationAction,ConcludingAction TopLevelPro
 
 Hopefully `ProtocolAction` is self explanatory: it is the union of top level protocol actions, each consumed by their respective protocol reducer.
 
-`CommonAction` is the union of `MessageReceived` and `CommitmentReceived` action. These actions are used in several protocols, although mostly the CommitmentReceived action, which is often included in the `MyProtocolAction` union on its own, while the `isMyProtocolAction` guard (somewhat inconsistently) uses `isCommonAction`.
+`CommonAction` is the union of `MessageReceived` and `SignedStateReceived` action. These actions are used in several protocols, although mostly the SignedStateReceived action, which is often included in the `MyProtocolAction` union on its own, while the `isMyProtocolAction` guard (somewhat inconsistently) uses `isCommonAction`.
 
 `RelayableAction` is the union of those actions that are whitelisted for communication to the opponent, who will dispatch that action.
 

--- a/packages/wallet/notes/channel-opening.md
+++ b/packages/wallet/notes/channel-opening.md
@@ -9,11 +9,11 @@ sequenceDiagram
     participant F2 as Funding Reducer2
     participant R2 as RPS2
 
-    R1->>C1: W.FUNDING_REQUESTED, prefund commitment: prefund1 A1
+    R1->>C1: W.FUNDING_REQUESTED, prefund state: prefund1 A1
 
     Note right of C1: Fund application <br> channel A1
     C1->>R2: prefund1 A1
-    R2->>C2: W.FUNDING_REQUESTED, prefund commitment: prefund2 A1
+    R2->>C2: W.FUNDING_REQUESTED, prefund state: prefund2 A1
     C2->>C1: prefund2 A1
     C1->>F1: W.I.FUND_CHANNEL A1
     C2->>F2: W.I.FUND_CHANNEL A1

--- a/packages/wallet/notes/indirect-funding-proposal.md
+++ b/packages/wallet/notes/indirect-funding-proposal.md
@@ -5,24 +5,25 @@
 The goal of this proposal is to sketch out a possible approach to funding an application channel, `X`, via a ledger channel, `L`.
 It is deliberately high-level and hand-wavy, designed to start a discussion rather than finish one.
 
-
 ## Out of Scope
 
-* Running the full funding algorithm
-  * Instead we'll assume the simple case of one app channel `X`, funded by a directly-funded ledger channel `L`.
-* Storing the funding table / funding relationships
-  * We'll just focus on opening an `L` that funds `X`, without worrying about how to remember that `X` is funded by `L`.
-
+- Running the full funding algorithm
+  - Instead we'll assume the simple case of one app channel `X`, funded by a directly-funded ledger channel `L`.
+- Storing the funding table / funding relationships
+  - We'll just focus on opening an `L` that funds `X`, without worrying about how to remember that `X` is funded by `L`.
 
 ## Proposed Operation
 
 We start in a position where both parties are at the funding point and have approved funding for application channel `X`. The channel state is in a new `DETERMINE_STRATEGY` state:
+
 ```json
 {
   channels: { X: { channelId: X, state: DETERMINE_STRATEGY, ... } },
 }
 ```
+
 The following interaction then occurs:
+
 ```mermaid
 sequenceDiagram
     participant wltA as A's wallet
@@ -36,17 +37,21 @@ sequenceDiagram
 
     Note over wltA, wltB: channels.X in WAIT_FOR_FUNDING
 ```
+
 After this the wallet state updates as follows:
+
 ```json
 {
   channels: { X: { channelId: X, state: WAIT_FOR_FUNDING, strategy: 'indirect', ... } },
   indirectFundings: { X: { id: X, state: START } },
 }
 ```
+
 Note: from the information stored in channel `X`, you have enough to locate the appropriate `indirectFunding` (i.e. look for entry under `X` in `indirectFunding`).
 This can be used by the channel container do figure out what to display.
 
 The indirectFunding state is a state machine with (something like) the following states:
+
 ```mermaid
 graph LR
   S(start) --> W(WaitForPreFS)
@@ -55,6 +60,7 @@ graph LR
   WFC --> WFCon(WaitForConsensus)
   WFCon(WaitForConsensus) --> WFCon(WaitForConsensus)
 ```
+
 This state machine drives the creation of the ledger channel and generation of its states -
 analogous to how the RPS app drives the creation of a RPS channel and the generation of its states.
 
@@ -72,8 +78,10 @@ sequenceDiagram
 
     Note over wltA, wltB: IndirectFundings.X in WAIT_FOR_FUNDING
 ```
-Note that the `PreFundSetup` commitments update the state of `L` so that it now allocates to `X`.
+
+Note that the `PreFundSetup` states update the state of `L` so that it now allocates to `X`.
 When the `indirectFundings.X` is in the `WAIT_FOR_FUNDING` state, the wallet state will look something like:
+
 ```json
 {
   channels: {
@@ -88,11 +96,13 @@ When the `indirectFundings.X` is in the `WAIT_FOR_FUNDING` state, the wallet sta
   }
 }
 ```
+
 Note: like before, the info in the `indirectFundings.X` record can be used to find the corresponding `directFunding`.
 
 The `directFunding` state tracks the direct funding state machine as found currently in the codebase.
 
 The interaction proceeds as follows:
+
 ```mermaid
 sequenceDiagram
     participant wltA as A's wallet
@@ -125,6 +135,7 @@ sequenceDiagram
 ```
 
 At this point, we've opened an `L` that funds `X`. The wallet state might look something like:
+
 ```json
 {
   channels: {

--- a/packages/wallet/notes/protocol-conventions.md
+++ b/packages/wallet/notes/protocol-conventions.md
@@ -118,7 +118,7 @@ Try and reuse components in `/src/redux/protocols/shared-components` as far as p
 ## Scenarios
 
 <a name="scenarios"></a>
-Objects containing the states, actions and commitments necessary to simulate each scenario described in the readme. May import triggers from child reducers. The format should be:
+Objects containing the states, actions and states necessary to simulate each scenario described in the readme. May import triggers from child reducers. The format should be:
 
 ```typescript
 // -------
@@ -136,7 +136,7 @@ export const scenarioName = {
     state: secondProtocolState,
     sharedData: sharedDataAtTimeOfSecondProtocolState,
     action: actionTriggeredWhenInSecondState,
-    commitment: optional
+    state: optional
   },
   andSoOn...
 };
@@ -152,13 +152,13 @@ Jest tests for each scenario. Helper functions should be imported and not replic
 
 - State transitions
 - Display side effects
-- Commitment side effects
+- SignedState side effects
   <!-- TODO -->
 
 Use
 
 ```typescript
-import { describeScenarioStep } from '../../../../__tests__/helpers';
+import {describeScenarioStep} from "../../../../__tests__/helpers";
 ```
 
 This will print out the state and action in a unified format.
@@ -169,7 +169,7 @@ This will print out the state and action in a unified format.
 Screens should be added from each scenario, using the helper function
 
 ```typescript
-import { addStoriesFromScenario as addStories } from '../../../../../__stories__';
+import {addStoriesFromScenario as addStories} from "../../../../../__stories__";
 ```
 
 which builds a full wallet dummy state around each `protocolState` in the scenario, and renders that into the top level wallet container. The function should automatically exclude terminal states (todo).

--- a/packages/wallet/src/communication/actions.ts
+++ b/packages/wallet/src/communication/actions.ts
@@ -67,12 +67,8 @@ export const concludeInstigated: ActionConstructor<ConcludeInstigated> = p => ({
 // Actions
 // -------
 
-// Protocols should switch to CommitmentsReceived, as we will in general
-// need to support n-party channels, and that is easiest to manage by
-// sending a full round of commitments when possible ie. when not in PreFundSetup
-
-export interface CommitmentsReceived extends BaseProcessAction {
-  type: "WALLET.COMMON.COMMITMENTS_RECEIVED";
+export interface SignedStatesReceived extends BaseProcessAction {
+  type: "WALLET.COMMON.SIGNED_STATES_RECEIVED";
   protocolLocator: ProtocolLocator;
   signedStates: SignedState[];
 }
@@ -85,9 +81,9 @@ export const signedStatesReceived = (p: {
   protocolLocator: ProtocolLocator;
   signedStates: SignedState[];
   processId: string;
-}): CommitmentsReceived => ({
+}): SignedStatesReceived => ({
   ...p,
-  type: "WALLET.COMMON.COMMITMENTS_RECEIVED"
+  type: "WALLET.COMMON.SIGNED_STATES_RECEIVED"
 });
 
 // -------
@@ -98,7 +94,7 @@ export type RelayableAction =
   | StrategyProposed
   | StrategyApproved
   | ConcludeInstigated
-  | CommitmentsReceived
+  | SignedStatesReceived
   | CloseLedgerChannel
   | MultipleRelayableActions
   | ConcludeInstigated;
@@ -109,15 +105,15 @@ export function isRelayableAction(action: WalletAction): action is RelayableActi
     action.type === "WALLET.FUNDING_STRATEGY_NEGOTIATION.STRATEGY_APPROVED" ||
     action.type === "WALLET.NEW_PROCESS.CONCLUDE_INSTIGATED" ||
     action.type === "WALLET.NEW_PROCESS.CLOSE_LEDGER_CHANNEL" ||
-    action.type === "WALLET.COMMON.COMMITMENTS_RECEIVED" ||
+    action.type === "WALLET.COMMON.SIGNED_STATES_RECEIVED" ||
     action.type === "WALLET.MULTIPLE_RELAYABLE_ACTIONS"
   );
 }
 
-export type CommonAction = CommitmentsReceived;
+export type CommonAction = SignedStatesReceived;
 export function isCommonAction(action: WalletAction, protocol?: EmbeddedProtocol): action is CommonAction {
   return (
-    action.type === "WALLET.COMMON.COMMITMENTS_RECEIVED" &&
+    action.type === "WALLET.COMMON.SIGNED_STATES_RECEIVED" &&
     // When passed a protocol, check that it's got the protocol in the protocol locator
     (!protocol || (action.protocolLocator && action.protocolLocator.indexOf(protocol) >= 0))
   );

--- a/packages/wallet/src/contract-tests/eth-asset-holder-events.test.ts
+++ b/packages/wallet/src/contract-tests/eth-asset-holder-events.test.ts
@@ -69,7 +69,7 @@ describe("ETHAssetHolder listener", () => {
     });
 
     // TODO: this 0x05 is hardcoded as it's the same value being used for
-    // constructing the commitments for the `conclude` call. Refactor this
+    // constructing the states for the `conclude` call. Refactor this
     // to not be hardcoded
     const depositAmount = bigNumberify("0x05");
     // deposit double so that 0x05 can be transferred to each participant
@@ -79,7 +79,7 @@ describe("ETHAssetHolder listener", () => {
 
     const {turnNumRecord, finalizesAt} = await getOnChainChannelStorage(provider, channelId);
     // This is the outcome that gets used to set the outcomeHash on the adjudicator
-    // and is copied from the state that gets used from the commitment
+    // and is copied from the state that gets used from the state
     // construction referred to above. This will also be refactored as part of the
     // TODO above.
 

--- a/packages/wallet/src/redux/__tests__/helpers.ts
+++ b/packages/wallet/src/redux/__tests__/helpers.ts
@@ -100,17 +100,11 @@ function transformStateToMatcher(ss: {state: Partial<State>; signature?: Signatu
 export const itSendsTheseStates = (
   state: SideEffectState,
   states: PartialStates,
-  type = "WALLET.COMMON.COMMITMENTS_RECEIVED",
+  type = "WALLET.COMMON.SIGNED_STATES_RECEIVED",
   idx = 0
 ) => {
   const messageOutbox = getOutboxState(state, "messageOutbox");
-  // TODO: Something in the conversion between nitro states and commitments is messing up the signature
-  // so we'll ignore them for now
-  states = states.map(s => {
-    return {
-      state: s.state
-    };
-  });
+
   it("sends states", () => {
     try {
       // Passes when at least one message matches
@@ -135,7 +129,7 @@ export const itSendsTheseStates = (
         // multiple messages are queued.
 
         // To help with debugging, you can change the idx variable when running tests to 'search'
-        // for the correct commitment
+        // for the correct state
         console.warn(`Message not found: inspecting mismatched message in position ${idx}`);
         expect(messageOutbox[idx]).toMatchObject({
           messagePayload: {

--- a/packages/wallet/src/redux/__tests__/state-helpers.ts
+++ b/packages/wallet/src/redux/__tests__/state-helpers.ts
@@ -62,14 +62,14 @@ export const addressAndPrivateKeyLookup: {
   [ThreePartyPlayerIndex.Hub]: {address: hubAddress, privateKey: hubPrivateKey}
 };
 
-interface AppCommitmentParams {
+interface AppStateParams {
   turnNum: number;
   isFinal?: boolean;
   balances?: Balance[];
   appAttributes?: string;
 }
 
-export function appState(params: AppCommitmentParams): SignedState {
+export function appState(params: AppStateParams): SignedState {
   const turnNum = params.turnNum;
   const balances = params.balances || twoThree;
   const isFinal = params.isFinal || false;
@@ -95,16 +95,15 @@ export function appState(params: AppCommitmentParams): SignedState {
 
   return Signatures.signState(state, privateKey);
 }
-interface LedgerCommitmentParams {
+interface LedgerStateParams {
   turnNum: number;
   isFinal?: boolean;
   balances?: Balance[];
   proposedBalances?: Balance[];
 }
 
-interface ThreeWayLedgerCommitmentParams extends LedgerCommitmentParams {
+interface ThreeWayLedgerStateParams extends LedgerStateParams {
   isVote?: boolean;
-  commitmentCount?: number;
 }
 
 const LEDGER_CHANNEL_NONCE = 0;
@@ -136,7 +135,7 @@ export const threeWayLedgerChannel = {
   participants: threeParticipants
 };
 
-export function threeWayLedgerState(params: ThreeWayLedgerCommitmentParams): SignedState {
+export function threeWayLedgerState(params: ThreeWayLedgerStateParams): SignedState {
   const turnNum = params.turnNum;
   const isFinal = params.isFinal || false;
   const balances = params.balances || twoThreeTwo;
@@ -174,7 +173,7 @@ export function threeWayLedgerState(params: ThreeWayLedgerCommitmentParams): Sig
   }
 }
 
-export function ledgerState(params: LedgerCommitmentParams): SignedState {
+export function ledgerState(params: LedgerStateParams): SignedState {
   const turnNum = params.turnNum;
   const isFinal = params.isFinal || false;
   const balances = params.balances || twoThree;

--- a/packages/wallet/src/redux/channel-store/channel-state/__tests__/index.ts
+++ b/packages/wallet/src/redux/channel-store/channel-state/__tests__/index.ts
@@ -1,4 +1,3 @@
-// import {SignedCommitment} from "../../../../domain";
 import {SignedState, getChannelId} from "@statechannels/nitro-protocol";
 
 export function channelFromStates(states: SignedState[], ourAddress: string, ourPrivateKey: string) {
@@ -13,7 +12,7 @@ export function channelFromStates(states: SignedState[], ourAddress: string, our
   }
   const ourIndex = participants.indexOf(ourAddress);
   if (ourIndex === -1) {
-    throw new Error("Address provided is not a participant according to the lastCommitment.");
+    throw new Error("Address provided is not a participant according to the lastState.");
   }
 
   return {

--- a/packages/wallet/src/redux/channel-store/channel-state/states.ts
+++ b/packages/wallet/src/redux/channel-store/channel-state/states.ts
@@ -54,12 +54,12 @@ export function initializeChannel(signedState: SignedState, privateKey: string):
   };
 }
 
-// Pushes a commitment onto the state, updating penultimate/last commitments and the turn number
+// Pushes a state onto the state, updating penultimate/last states and the turn number
 export function pushState(state: ChannelState, signedState: SignedState): ChannelState {
   const signedStates = [...state.signedStates];
   const numParticipants = state.participants.length;
   if (signedStates.length === numParticipants) {
-    // We've got a full round of commitments, and should therefore drop the first one
+    // We've got a full round of states, and should therefore drop the first one
     signedStates.shift();
   }
 

--- a/packages/wallet/src/redux/channel-store/reducer.ts
+++ b/packages/wallet/src/redux/channel-store/reducer.ts
@@ -82,10 +82,10 @@ interface CheckFailure {
 
 type CheckResult = CheckSuccess | CheckFailure;
 
-// For use with a signed commitment received from an opponent.
+// For use with a signed state received from an opponent.
 export function checkAndStore(store: ChannelStore, signedState: SignedState): CheckResult {
   if (!hasValidSignature(signedState)) {
-    console.log("Failed to validate commitment signature");
+    console.log("Failed to validate state signature");
     return {isSuccess: false};
   }
   const channelId = getChannelId(signedState.state.channel);

--- a/packages/wallet/src/redux/protocols/advance-channel/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/__tests__/scenarios.ts
@@ -33,18 +33,15 @@ const signedState4 = scenarios.threeWayLedgerState({turnNum: 4});
 const signedState5 = scenarios.threeWayLedgerState({turnNum: 5});
 const signedState6 = scenarios.threeWayLedgerState({
   turnNum: 6,
-  isFinal: true,
-  commitmentCount: 0
+  isFinal: true
 });
 const signedState7 = scenarios.threeWayLedgerState({
   turnNum: 7,
-  isFinal: true,
-  commitmentCount: 1
+  isFinal: true
 });
 const signedState8 = scenarios.threeWayLedgerState({
   turnNum: 8,
-  isFinal: true,
-  commitmentCount: 2
+  isFinal: true
 });
 const appData = signedState0.state.appData;
 const participants = signedState0.state.channel.participants;

--- a/packages/wallet/src/redux/protocols/advance-channel/actions.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/actions.ts
@@ -1,5 +1,5 @@
 import {
-  CommitmentsReceived,
+  SignedStatesReceived,
   BaseProcessAction,
   isCommonAction,
   ProtocolLocator,
@@ -14,7 +14,7 @@ export interface ClearedToSend extends BaseProcessAction {
   protocolLocator: ProtocolLocator;
 }
 
-export type AdvanceChannelAction = CommitmentsReceived | ClearedToSend;
+export type AdvanceChannelAction = SignedStatesReceived | ClearedToSend;
 
 export const clearedToSend: ActionConstructor<ClearedToSend> = p => {
   const {processId, protocolLocator} = p;

--- a/packages/wallet/src/redux/protocols/advance-channel/reducer.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/reducer.ts
@@ -11,7 +11,7 @@ import {ProtocolStateWithSharedData, ProtocolReducer} from "..";
 import {getChannel, ChannelState, getLastState, getPenultimateState, getStates} from "../../channel-store";
 import {WalletAction} from "../../actions";
 import * as selectors from "../../selectors";
-import {CommitmentsReceived} from "../../../communication";
+import {SignedStatesReceived} from "../../../communication";
 import {isAdvanceChannelAction} from "./actions";
 import {unreachable} from "../../../utils/reducer-utils";
 import {Properties} from "../../utils";
@@ -47,14 +47,14 @@ export const reducer: ProtocolReducer<states.AdvanceChannelState> = (
   action: WalletAction
 ) => {
   if (!isAdvanceChannelAction(action)) {
-    console.error("Invalid action: expected WALLET.COMMON.COMMITMENTS_RECEIVED");
+    console.error("Invalid action: expected WALLET.COMMON.SIGNED_STATES_RECEIVED");
     return {protocolState, sharedData};
   }
 
   switch (action.type) {
     case "WALLET.ADVANCE_CHANNEL.CLEARED_TO_SEND":
       return clearedToSendReducer(protocolState, sharedData);
-    case "WALLET.COMMON.COMMITMENTS_RECEIVED":
+    case "WALLET.COMMON.SIGNED_STATES_RECEIVED":
       switch (protocolState.type) {
         case "AdvanceChannel.ChannelUnknown": {
           return channelUnknownReducer(protocolState, sharedData, action);
@@ -223,7 +223,7 @@ function attemptToAdvanceChannel(
   }
 }
 
-const channelUnknownReducer = (protocolState: states.ChannelUnknown, sharedData, action: CommitmentsReceived) => {
+const channelUnknownReducer = (protocolState: states.ChannelUnknown, sharedData, action: SignedStatesReceived) => {
   const {privateKey} = protocolState;
   const channelId = getChannelId(action.signedStates[0].state.channel);
   const checkResult = checkAndInitialize(sharedData, action.signedStates[0], privateKey);
@@ -248,7 +248,7 @@ const channelUnknownReducer = (protocolState: states.ChannelUnknown, sharedData,
   return {protocolState: nextProtocolState, sharedData};
 };
 
-const notSafeToSendReducer = (protocolState: states.NotSafeToSend, sharedData, action: CommitmentsReceived) => {
+const notSafeToSendReducer = (protocolState: states.NotSafeToSend, sharedData, action: SignedStatesReceived) => {
   const {channelId} = protocolState;
 
   const channel = getChannel(sharedData.channelStore, channelId);
@@ -257,7 +257,7 @@ const notSafeToSendReducer = (protocolState: states.NotSafeToSend, sharedData, a
   return attemptToAdvanceChannel(sharedData, protocolState, channelId);
 };
 
-const stateSentReducer = (protocolState: states.StateSent, sharedData, action: CommitmentsReceived) => {
+const stateSentReducer = (protocolState: states.StateSent, sharedData, action: SignedStatesReceived) => {
   const {channelId, stateType} = protocolState;
 
   let channel = getChannel(sharedData.channelStore, channelId);

--- a/packages/wallet/src/redux/protocols/consensus-update/actions.ts
+++ b/packages/wallet/src/redux/protocols/consensus-update/actions.ts
@@ -1,6 +1,6 @@
 import {WalletAction} from "../../actions";
 import {
-  CommitmentsReceived,
+  SignedStatesReceived,
   BaseProcessAction,
   isCommonAction,
   ProtocolLocator,
@@ -21,7 +21,7 @@ export const clearedToSend: ActionConstructor<ClearedToSend> = p => {
   };
 };
 
-export type ConsensusUpdateAction = CommitmentsReceived | ClearedToSend;
+export type ConsensusUpdateAction = SignedStatesReceived | ClearedToSend;
 
 export const isConsensusUpdateAction = (action: WalletAction): action is ConsensusUpdateAction => {
   return (

--- a/packages/wallet/src/redux/protocols/consensus-update/readme.md
+++ b/packages/wallet/src/redux/protocols/consensus-update/readme.md
@@ -3,7 +3,7 @@
 The purpose of the protocol is to handle updating the allocation and destination of channels running the consensus app to reach an outcome specified on initialization.
 
 The protocol stores every new state it receives that represents a valid transition from the most recent state.
-States received in `COMMITMENTS_RECEIVED` are processed in order, and are ignored when they are an invalid transition.
+States received in `SIGNED_STATES_RECEIVED` are processed in order, and are ignored when they are an invalid transition.
 
 When it is the participant's turn, and the protocol has been cleared to send,
 

--- a/packages/wallet/src/redux/protocols/consensus-update/reducer.ts
+++ b/packages/wallet/src/redux/protocols/consensus-update/reducer.ts
@@ -4,7 +4,7 @@ import {ProtocolStateWithSharedData} from "..";
 import {ConsensusUpdateAction} from "./actions";
 import * as helpers from "../reducer-helpers";
 
-import {CommitmentsReceived, ProtocolLocator} from "../../../communication";
+import {SignedStatesReceived, ProtocolLocator} from "../../../communication";
 import {unreachable} from "../../../utils/reducer-utils";
 import {ChannelState} from "../../channel-store";
 import {Outcome, State, encodeOutcome} from "@statechannels/nitro-protocol";
@@ -54,7 +54,7 @@ export const consensusUpdateReducer = (
   }
 
   switch (action.type) {
-    case "WALLET.COMMON.COMMITMENTS_RECEIVED":
+    case "WALLET.COMMON.SIGNED_STATES_RECEIVED":
       return handleStateReceived(protocolState, sharedData, action);
     case "WALLET.CONSENSUS_UPDATE.CLEARED_TO_SEND":
       return handleClearedToSend(protocolState, sharedData);
@@ -79,7 +79,7 @@ const handleClearedToSend = (
 const handleStateReceived = (
   protocolState: states.NonTerminalConsensusUpdateState,
   sharedData: SharedData,
-  action: CommitmentsReceived
+  action: SignedStatesReceived
 ): ProtocolStateWithSharedData<states.ConsensusUpdateState> => {
   const {channelId} = protocolState;
 

--- a/packages/wallet/src/redux/protocols/direct-funding/actions.ts
+++ b/packages/wallet/src/redux/protocols/direct-funding/actions.ts
@@ -1,5 +1,5 @@
 import * as actions from "../../actions";
-import {isCommonAction, EmbeddedProtocol, routerFactory, CommitmentsReceived} from "../../../communication";
+import {isCommonAction, EmbeddedProtocol, routerFactory, SignedStatesReceived} from "../../../communication";
 
 // -------
 // Actions
@@ -14,7 +14,7 @@ import {isCommonAction, EmbeddedProtocol, routerFactory, CommitmentsReceived} fr
 
 type EmbeddedAction = actions.advanceChannel.AdvanceChannelAction | actions.TransactionAction;
 
-export type DirectFundingAction = CommitmentsReceived | actions.FundingReceivedEvent | EmbeddedAction;
+export type DirectFundingAction = SignedStatesReceived | actions.FundingReceivedEvent | EmbeddedAction;
 
 function isEmbeddedAction(action: actions.WalletAction): action is EmbeddedAction {
   return actions.advanceChannel.isAdvanceChannelAction(action) || actions.isTransactionAction(action);

--- a/packages/wallet/src/redux/protocols/direct-funding/readme.md
+++ b/packages/wallet/src/redux/protocols/direct-funding/readme.md
@@ -14,11 +14,11 @@ linkStyle default interpolate basis
     ST-->WFDT
     WFDT-->|TransactionSubmission succeeded|WFFCPF(WaitForFundingConfirmationAndPostFund)
     WFDT-->|FUNDING_RECEIVED|WFFCPF
-    WFDT-->|COMMITMENT_RECEIVED|WFFCPF
+    WFDT-->|SIGNED_STATES_RECEIVED|WFFCPF
     WFDT-->|TransactionSubmission failed|F((Failure))
     WFFCPF-->|FUNDING_RECEIVED|WFFCPF
-    WFFCPF-->|COMMITMENT_RECEIVED|WFFCPF
-    WFFCPF-->|FUNDING_RECEIVED + COMMITMENT_RECEIVED|CF((ChannelFunded))
+    WFFCPF-->|SIGNED_STATES_RECEIVED|WFFCPF
+    WFFCPF-->|FUNDING_RECEIVED + SIGNED_STATES_RECEIVED|CF((ChannelFunded))
     ST-->WFFCPF
 
   classDef logic fill:#efdd20;

--- a/packages/wallet/src/redux/protocols/dispute/challenger/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/dispute/challenger/__tests__/reducer.test.ts
@@ -1,7 +1,12 @@
 import * as scenarios from "./scenarios";
 import {challengerReducer, initialize, ReturnVal} from "../reducer";
 import {FailureReason, ChallengerStateType, WaitForTransaction, WaitForResponseOrTimeout} from "../states";
-import {itSendsThisMessage, itSendsThisDisplayEventType, describeScenarioStep} from "../../../../__tests__/helpers";
+import {
+  itSendsThisMessage,
+  itSendsThisDisplayEventType,
+  describeScenarioStep,
+  itStoresThisState
+} from "../../../../__tests__/helpers";
 import {
   HIDE_WALLET,
   CHALLENGE_COMPLETE,
@@ -52,12 +57,12 @@ describe("OPPONENT RESPONDS", () => {
     });
   });
   describeScenarioStep(scenario.waitForResponseOrTimeoutReceiveResponse, () => {
-    const {state, action} = scenario.waitForResponseOrTimeoutReceiveResponse;
+    const {state, action, signedState} = scenario.waitForResponseOrTimeoutReceiveResponse;
     const result = challengerReducer(state, sharedData, action);
 
     itSendsThisMessage(result.sharedData, CHALLENGE_STATE_RECEIVED);
-    // TODO: Get this passing
-    // itStoresThisCommitment(result.sharedData, commitment);
+
+    itStoresThisState(result.sharedData, signedState);
     itTransitionsTo(result, "Challenging.AcknowledgeResponse");
   });
 

--- a/packages/wallet/src/redux/protocols/dispute/challenger/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/dispute/challenger/__tests__/scenarios.ts
@@ -92,12 +92,12 @@ export const opponentResponds = {
   waitForResponseOrTimeoutReceiveResponse: {
     state: waitForResponseOrTimeout,
     action: responseReceived,
-    commitment: signedState21
+    signedState: signedState21
   },
   waitForResponseOrTimeoutExpirySet: {
     state: waitForResponseOrTimeout,
     action: challengeExpirySet,
-    commitment: signedState21
+    signedState: signedState21
   },
   acknowledgeResponse: {
     state: acknowledgeResponse,

--- a/packages/wallet/src/redux/protocols/dispute/challenger/readme.md
+++ b/packages/wallet/src/redux/protocols/dispute/challenger/readme.md
@@ -8,8 +8,8 @@ This protocol handles launching a challenge on the blockchain. It includes:
 
 Out of scope (for now)
 
-- Halting the challenge in the case where the opponent's commitment arrives between approval and transaction submission.
-- Interrupting the "ApproveChallenge" screen if the opponent's commitment arrives during approval. (Instead, the user will be informed after they approve the challenge.)
+- Halting the challenge in the case where the opponent's state arrives between approval and transaction submission.
+- Interrupting the "ApproveChallenge" screen if the opponent's state arrives during approval. (Instead, the user will be informed after they approve the challenge.)
 - Chain reorgs (e.g. timeout on one fork vs. response on another)
 
 ## State machine
@@ -21,7 +21,7 @@ graph TD
 linkStyle default interpolate basis
   S((start)) --> CE{Can<br/>challenge?}
   CE --> |Yes| WFA(ApproveChallenge)
-  WFA --> |CommitmentArrives| AF
+  WFA --> |StateArrives| AF
   WFA --> |WALLET.DISPUTE.CHALLENGER.CHALLENGE_APPROVED| WFT(WaitForTransaction)
   CE --> |No| AF
   WFA --> |WALLET.DISPUTE.CHALLENGER.CHALLENGE_DENIED| AF(AcknowledgeFailure)
@@ -48,7 +48,7 @@ linkStyle default interpolate basis
 
 Note:
 
-- "Can challenge?" = "channel exists" && "has two commitments" && "not our turn"
+- "Can challenge?" = "channel exists" && "has two states" && "not our turn"
 - We don't currently give the option to retry in the case that the transaction fails.
 - The `MyTurn` check is performed after approval, just in case the opponent's move has arrived in the meantime.
 
@@ -86,15 +86,15 @@ To test all paths through the state machine we will the following scenarios:
    - `AcknowledgeFailure`
    - `Failure`
 
-6. **Already have latest commitment**:
+6. **Already have latest state**:
    - `AcknowledgeFailure`
    - `Failure`
 7. **User declines challenge**:
    - `ApproveChallenge`
    - `AcknowledgeFailure`
    - `Failure`
-8. **Receive commitment while approving**:
-   The opponent's commitment arrives while the user is approving the challenge - `ApproveChallenge` - `AcknowledgeFailure`
+8. **Receive state while approving**:
+   The opponent's state arrives while the user is approving the challenge - `ApproveChallenge` - `AcknowledgeFailure`
 9. **Transaction fails**:
    - `WaitForTransaction`
    - `AcknowledgeFailure`

--- a/packages/wallet/src/redux/protocols/reducer-helpers.ts
+++ b/packages/wallet/src/redux/protocols/reducer-helpers.ts
@@ -20,7 +20,7 @@ export function sendFundingComplete(sharedData: SharedData, appChannelId: string
   const channelState = selectors.getOpenedChannelState(sharedData, appChannelId);
   const s = getLastState(channelState);
   if (s.turnNum !== 3) {
-    throw new Error(`Expected a post fund setup B commitment. Instead received ${JSON.stringify(s)}.`);
+    throw new Error(`Expected a post fund setup B state. Instead received ${JSON.stringify(s)}.`);
   }
   return queueMessage(sharedData, fundingSuccess(appChannelId, s));
 }

--- a/packages/wallet/src/redux/protocols/virtual-funding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/virtual-funding/__tests__/reducer.test.ts
@@ -43,7 +43,7 @@ describe("happyPath", () => {
 
     itTransitionsTo(protocolState, "VirtualFunding.WaitForJointChannel");
     itTransitionsSubstateTo(protocolState, "jointChannel", preFund.preSuccess.state.type);
-    // Even though there should only be two commitments in the guarantor channel round,
+    // Even though there should only be two states in the guarantor channel round,
     // since we're using the preSuccess scenarios from advance-channel, which sets up a joint
     // 3-party channel, three get sent out.
     // TODO: Fix this by constructing appropriate test data
@@ -86,7 +86,7 @@ describe("happyPath", () => {
 
     itTransitionsTo(protocolState, "VirtualFunding.WaitForGuarantorChannel");
     itTransitionsSubstateTo(protocolState, "guarantorChannel", postFund.preSuccess.state.type);
-    // Even though there should only be two commitments in the guarantor channel round,
+    // Even though there should only be two states in the guarantor channel round,
     // since we're using the preSuccess scenarios from advance-channel, which sets up a joint
     // 3-party channel, three get sent out.
     // TODO: Fix this by constructing appropriate test data

--- a/packages/wallet/src/redux/protocols/virtual-funding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/virtual-funding/__tests__/scenarios.ts
@@ -43,7 +43,7 @@ const initializeArgs = {
   processId,
   clearedToSend: true,
   // To properly test the embedded advanceChannel protocols, it's useful to be playerA
-  // to make sure that the commitments get sent.
+  // to make sure that the states get sent.
   address: asAddress,
   privateKey: asPrivateKey,
   ourIndex: 0,

--- a/packages/wallet/src/redux/sagas/__tests__/challenge-watcher.test.ts
+++ b/packages/wallet/src/redux/sagas/__tests__/challenge-watcher.test.ts
@@ -3,7 +3,7 @@
 // import {AdjudicatorState} from "../../adjudicator-state/state";
 // import * as actions from "../../actions";
 // import {put} from "redux-saga/effects";
-// import {channelId, appCommitment} from "../../__tests__/state-helpers";
+// import {channelId, appState} from "../../__tests__/state-helpers";
 
 describe("challenge-watcher", () => {
   // TODO: Implment this
@@ -29,7 +29,7 @@ describe("challenge-watcher", () => {
     //     finalized: false,
     //     channelId,
     //     balance: "0x0",
-    //     challenge: {expiresAt: 1, challengeCommitment: appCommitment({turnNum: 20}).commitment}
+    //     challenge: {expiresAt: 1, challengeState: appState({turnNum: 20}).state}
     //   }
     // };
     // // Select adjudicator state

--- a/packages/wallet/src/redux/sagas/__tests__/message-listener.test.ts
+++ b/packages/wallet/src/redux/sagas/__tests__/message-listener.test.ts
@@ -21,7 +21,7 @@ describe("message listener", () => {
     expect(output).toEqual(put(actions.loggedIn({uid: "abc123"})));
   });
 
-  // TODO: these tests need to be updated once message listening is updated with commitments
+  // TODO: these tests need to be updated once message listening is updated with states
 
   // todo: is OWN_POSITION_RECEIVED actually easier to think about than SIGNATURE_REQUEST?
   it("converts SIGNATURE_REQUEST into OWN_POSITION_RECEIVED", () => {

--- a/packages/wallet/src/redux/sagas/message-listener.ts
+++ b/packages/wallet/src/redux/sagas/message-listener.ts
@@ -88,7 +88,7 @@ export function* messageListener() {
       case incoming.RECEIVE_MESSAGE:
         const messageAction = handleIncomingMessage(action);
 
-        if (messageAction.type === "WALLET.COMMON.COMMITMENTS_RECEIVED") {
+        if (messageAction.type === "WALLET.COMMON.SIGNED_STATES_RECEIVED") {
           yield validateTransitionForSignedStates(messageAction.signedStates);
         }
 
@@ -107,10 +107,10 @@ function* validateTransitionForSignedStates(signedStates: SignedState[]) {
 
   const storedStateExists = yield select(selectors.doesAStateExistForChannel, channelId);
   if (storedStateExists) {
-    const latestStoredCommitment: State = yield select(selectors.getLastStateForChannel, channelId);
-    const newStates = signedStates.filter(signedState => signedState.state.turnNum > latestStoredCommitment.turnNum);
+    const latestStoredState: State = yield select(selectors.getLastStateForChannel, channelId);
+    const newStates = signedStates.filter(signedState => signedState.state.turnNum > latestStoredState.turnNum);
     if (newStates.length > 0) {
-      let fromState = latestStoredCommitment;
+      let fromState = latestStoredState;
       let toState = newStates[0].state;
       yield validateTransition(fromState, toState);
 

--- a/packages/wallet/src/utils/transaction-generator.ts
+++ b/packages/wallet/src/utils/transaction-generator.ts
@@ -44,8 +44,8 @@ export function createConcludeAndWithdrawTransaction(args: ConcludeAndWithdrawAr
   // const splitFromSignature = splitSignature(args.fromSignature);
   // const splitToSignature = splitSignature(args.toSignature);
   // const conclusionProof = {
-  //   penultimateCommitment: asEthersObject(args.fromCommitment),
-  //   ultimateCommitment: asEthersObject(args.toCommitment),
+  //   penultimateState: asEthersObject(args.fromState),
+  //   ultimateState: asEthersObject(args.toState),
   //   penultimateSignature: splitFromSignature,
   //   ultimateSignature: splitToSignature
   // };


### PR DESCRIPTION
Updates `CommitmentsReceived` to `SignedStatesReceived` and updates comments that still refer to commitments.