### PR TITLE
Format line length

### DIFF
--- a/packages/devtools/.prettierrc.js
+++ b/packages/devtools/.prettierrc.js
@@ -2,7 +2,7 @@
 
 module.exports = {
     ...require('../../.prettierrc.js'),
-    "printWidth": 120,
+    "printWidth": 100,
     "singleQuote": false,
     "bracketSpacing": false,
 };

--- a/packages/devtools/src/utils/network-setup.ts
+++ b/packages/devtools/src/utils/network-setup.ts
@@ -5,7 +5,9 @@ const privateKeyWithEth = "0xf2f48ee19680706196e2e339e5da3491186e0c4c5030670656b
 
 export function getGanacheProvider() {
   const ethers = require("ethers");
-  return new ethers.providers.JsonRpcProvider(`http://${process.env.GANACHE_HOST}:${process.env.GANACHE_PORT}`);
+  return new ethers.providers.JsonRpcProvider(
+    `http://${process.env.GANACHE_HOST}:${process.env.GANACHE_PORT}`
+  );
 }
 
 export function getPrivateKeyWithEth() {

--- a/packages/nitro-protocol/.prettierrc.js
+++ b/packages/nitro-protocol/.prettierrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   ...require('../../.prettierrc.js'),
   "trailingComma": "es5",
+  "printWidth": 100,
   "overrides": [
     {
       "files": "*.sol",


### PR DESCRIPTION
Updates prettier config to set line length to 100 for `dev-tools` and `nitro-protocol` packages.