### PR TITLE
[Web3Torrent] POC of buffer-based payment system

### DIFF
--- a/packages/web3torrent/src/clients/web3torrent-client.ts
+++ b/packages/web3torrent/src/clients/web3torrent-client.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ClientEvents, WebTorrentAddInput, WebTorrentSeedInput} from '../library/types';
+import {WebTorrentAddInput, WebTorrentSeedInput} from '../library/types';
 import WebTorrentPaidStreamingClient from '../library/web3torrent-lib';
 import {Status, Torrent} from '../types';
 export const web3torrent = new WebTorrentPaidStreamingClient();
@@ -8,32 +8,12 @@ export const WebTorrentContext = React.createContext(web3torrent);
 export const getTorrentPeers = infoHash => web3torrent.allowedPeers[infoHash];
 
 export const download: (torrent: WebTorrentAddInput) => Promise<Torrent> = torrentData => {
-  web3torrent.on(
-    // TODO: Remove when protocol is defined
-    ClientEvents.PEER_STATUS_CHANGED,
-    ({torrentPeers, torrentInfoHash, peerAccount}) => {
-      if (!torrentPeers[peerAccount].allowed) {
-        web3torrent.togglePeer(torrentInfoHash, peerAccount);
-      }
-    }
-  );
-
   return new Promise(resolve =>
     web3torrent.add(torrentData, (torrent: any) => resolve({...torrent, status: Status.Connecting}))
   );
 };
 
 export const upload: (files: WebTorrentSeedInput) => Promise<Torrent> = files => {
-  web3torrent.on(
-    // TODO: Remove when protocol is defined
-    ClientEvents.PEER_STATUS_CHANGED,
-    ({torrentPeers, torrentInfoHash, peerAccount}) => {
-      if (!torrentPeers[peerAccount].allowed) {
-        web3torrent.togglePeer(torrentInfoHash, peerAccount);
-      }
-    }
-  );
-
   return new Promise(resolve =>
     web3torrent.seed(files as FileList, (torrent: any) => {
       resolve({

--- a/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.stories.tsx
+++ b/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.stories.tsx
@@ -25,6 +25,7 @@ storiesOf('Web3Torrent', module)
             wire: {
               uploaded: number('Uploaded bytes for Peer 9720534187', 3533366, {step: 1000}, 'Peers')
             },
+            funds: '50',
             allowed: true
           },
           '9202959009': {
@@ -32,6 +33,7 @@ storiesOf('Web3Torrent', module)
             wire: {
               uploaded: number('Uploaded bytes for Peer 9202959009', 5611625, {step: 1000}, 'Peers')
             },
+            funds: '50',
             allowed: true
           },
           '2190352424': {
@@ -39,6 +41,7 @@ storiesOf('Web3Torrent', module)
             wire: {
               uploaded: number('Uploaded bytes for Peer 2190352424', 5051532, {step: 1000}, 'Peers')
             },
+            funds: '50',
             allowed: true
           }
         } as TorrentPeers

--- a/packages/web3torrent/src/library/paid-streaming-extension.ts
+++ b/packages/web3torrent/src/library/paid-streaming-extension.ts
@@ -85,6 +85,10 @@ export abstract class PaidStreamingExtension implements Extension {
     this.executeExtensionCommand(PaidStreamingExtensionNotices.ACK);
   }
 
+  payment(hash: string) {
+    this.executeExtensionCommand(PaidStreamingExtensionNotices.PAYMENT, {hash});
+  }
+
   onMessage(buffer: Buffer) {
     try {
       const jsonData = bencode.decode(buffer, undefined, undefined, 'utf8');

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -34,6 +34,7 @@ export enum PaidStreamingExtensionEvents {
 }
 
 export enum PaidStreamingExtensionNotices {
+  PAYMENT = 'payment',
   START = 'start',
   STOP = 'stop',
   ACK = 'ack'
@@ -120,6 +121,7 @@ export type PeerByTorrent = {
   id: string;
   wire: PaidStreamingWire | PeerWire;
   allowed: boolean;
+  funds: string;
 };
 
 export type TorrentPeers = {

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -23,6 +23,8 @@ export type TorrentCallback = (torrent: Torrent) => any;
 
 export * from './types';
 
+export const REQUEST_RATE = 10;
+
 export default class WebTorrentPaidStreamingClient extends WebTorrent {
   allowedPeers: PeersByTorrent;
   pseAccount: string;
@@ -122,20 +124,25 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
 
     wire.on(WireEvents.REQUEST, () => {
       const peerAccount = wire.paidStreamingExtension.peerAccount as string;
-      const knownPeerAccount = peerAccount in this.allowedPeers[torrent.infoHash];
+      const knownPeerAccount = this.allowedPeers[torrent.infoHash][peerAccount];
 
-      if (knownPeerAccount && !this.allowedPeers[torrent.infoHash][peerAccount].allowed) {
-        this.blockPeer(torrent.infoHash, wire, peerAccount);
-      } else if (!knownPeerAccount) {
-        this.allowedPeers[torrent.infoHash][peerAccount] = {id: peerAccount, wire, allowed: false};
+      if (!knownPeerAccount) {
+        this.allowedPeers[torrent.infoHash][peerAccount] = {id: peerAccount, wire, funds: "0", allowed: false};
         this.blockPeer(torrent.infoHash, wire, peerAccount);
         this.emit(ClientEvents.PEER_STATUS_CHANGED, {
           torrentPeers: this.allowedPeers[torrent.infoHash],
           torrentInfoHash: torrent.infoHash,
           peerAccount
         });
+      } else if (!knownPeerAccount.allowed || Number(knownPeerAccount.funds) < REQUEST_RATE) {
+        this.blockPeer(torrent.infoHash, wire, peerAccount);
       } else {
-        this.allowedPeers[torrent.infoHash][peerAccount] = {id: peerAccount, wire, allowed: true};
+        this.allowedPeers[torrent.infoHash][peerAccount] = {
+          id: peerAccount,
+          wire,
+          funds: (Number(knownPeerAccount.funds) - 10).toString(),
+          allowed: true
+        };
       }
     });
 
@@ -148,6 +155,18 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     wire.paidStreamingExtension.on(PaidStreamingExtensionEvents.NOTICE, notice =>
       torrent.emit(PaidStreamingExtensionEvents.NOTICE, wire, notice)
     );
+  }
+  
+  protected loadFunds(infoHash:string, peerId:string, paymentHash:string){
+    const {funds} = this.allowedPeers[infoHash][peerId];
+    this.allowedPeers[infoHash][peerId].funds = (Number(funds) + Number(paymentHash)).toString();
+  }
+  
+  protected transferFunds(wire: PaidStreamingWire) {
+    // INFO: Assumed payment. This could emit an event on the UI to ask for more funds, or be automatic. Dunno.
+    setTimeout(() => {
+      wire.paidStreamingExtension.payment('50');
+    }, 500);
   }
 
   protected setupTorrent(torrent: PaidStreamingTorrent) {
@@ -167,10 +186,15 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
         case PaidStreamingExtensionNotices.STOP:
           wire.paidStreamingExtension.ack();
           wire.choke();
+          this.transferFunds(wire);
           break;
         case PaidStreamingExtensionNotices.START:
           wire.paidStreamingExtension.ack();
           this.jumpStart(torrent, wire);
+          break;
+        case PaidStreamingExtensionNotices.PAYMENT:
+          this.loadFunds(torrent.infoHash, wire.peerExtendedHandshake.pseAccount, data.hash);
+          this.unblockPeer(torrent.infoHash, wire, wire.peerExtendedHandshake.pseAccount);
           break;
         default:
           break;

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -127,7 +127,12 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
       const knownPeerAccount = this.allowedPeers[torrent.infoHash][peerAccount];
 
       if (!knownPeerAccount) {
-        this.allowedPeers[torrent.infoHash][peerAccount] = {id: peerAccount, wire, funds: "0", allowed: false};
+        this.allowedPeers[torrent.infoHash][peerAccount] = {
+          id: peerAccount,
+          wire,
+          funds: '0',
+          allowed: false
+        };
         this.blockPeer(torrent.infoHash, wire, peerAccount);
         this.emit(ClientEvents.PEER_STATUS_CHANGED, {
           torrentPeers: this.allowedPeers[torrent.infoHash],
@@ -156,12 +161,12 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
       torrent.emit(PaidStreamingExtensionEvents.NOTICE, wire, notice)
     );
   }
-  
-  protected loadFunds(infoHash:string, peerId:string, paymentHash:string){
+
+  protected loadFunds(infoHash: string, peerId: string, paymentHash: string) {
     const {funds} = this.allowedPeers[infoHash][peerId];
     this.allowedPeers[infoHash][peerId].funds = (Number(funds) + Number(paymentHash)).toString();
   }
-  
+
   protected transferFunds(wire: PaidStreamingWire) {
     // INFO: Assumed payment. This could emit an event on the UI to ask for more funds, or be automatic. Dunno.
     setTimeout(() => {

--- a/packages/web3torrent/src/utils/test-utils.ts
+++ b/packages/web3torrent/src/utils/test-utils.ts
@@ -1,6 +1,6 @@
-import {EmptyTorrent} from '../constants';
-import {TorrentPeers} from '../library/types';
-import {Torrent} from '../types';
+import { EmptyTorrent } from '../constants';
+import { TorrentPeers } from '../library/types';
+import { Torrent } from '../types';
 
 export function testSelector(name: string): string {
   return `[data-test-selector='${name}']`;
@@ -26,11 +26,13 @@ export function createMockTorrentPeers(): TorrentPeers {
       allowed: true,
       wire: {
         uploaded: 4225
-      }
+      },
+      funds: '50'
     },
     '5589113806923374': {
       id: '5589113806923374',
       allowed: true,
+      funds: '50',
       wire: {
         uploaded: 52923
       }

--- a/packages/web3torrent/src/utils/test-utils.ts
+++ b/packages/web3torrent/src/utils/test-utils.ts
@@ -1,6 +1,6 @@
-import { EmptyTorrent } from '../constants';
-import { TorrentPeers } from '../library/types';
-import { Torrent } from '../types';
+import {EmptyTorrent} from '../constants';
+import {TorrentPeers} from '../library/types';
+import {Torrent} from '../types';
 
 export function testSelector(name: string): string {
   return `[data-test-selector='${name}']`;


### PR DESCRIPTION
### Description

This PR implements a buffer-based payment model for the file transfering of Web3Torrent (in which the Seeder maintains a buffer or balance of each Leecher, and answers each request accordingly, after deducing the data cost).
![image](https://user-images.githubusercontent.com/10502605/68624747-49fb8200-04b6-11ea-8f54-9ee5e09924f8.png)


In this PoC, I make several assumptions:
- Each request is worth the same (which isn't true, as some requests are smaller than average).
- The Leecher always pays after being blocked, a predefined amount ($50, or 5 requests).
- The amount of funds is assumed valid (I just pass a stringified number, though I'm counting that at some point it's going to be a transaction hash to verify).

Furthermore, the UI has not been updated to reflect the changes, this change has been done at the **library** layer.

### Related issues

#325 