### PR TITLE
[wallet] Implement Create Channel API Call 

### DIFF
--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -59,7 +59,7 @@
 		"eventemitter2": "5.0.1",
 		"firebase": "^7.0.0",
 		"fs-extra": "8.1.0",
-		"jsonrpc-serializer": "0.2.1",
+		"jsonrpc-lite": "2.1.0",
 		"key-mirror": "^1.0.1",
 		"lodash": "^4.17.10",
 		"mini-css-extract-plugin": "^0.8.0",

--- a/packages/wallet/src/redux/__tests__/selectors.test.ts
+++ b/packages/wallet/src/redux/__tests__/selectors.test.ts
@@ -66,7 +66,7 @@ describe("getNextNonce", () => {
     channelId: "0x0",
     libraryAddress: "0x0",
     ourIndex: 0,
-    participants: ["0x0", "0x0"],
+    participants: [{signingAddress: "0x0"}, {signingAddress: "0x0"}],
     channelNonce: "0x00",
     funded: false,
     address: "address",

--- a/packages/wallet/src/redux/__tests__/state-helpers.ts
+++ b/packages/wallet/src/redux/__tests__/state-helpers.ts
@@ -16,6 +16,7 @@ import {NETWORK_ID, ETH_ASSET_HOLDER_ADDRESS, CONSENSUS_LIBRARY_ADDRESS} from ".
 import {convertAddressToBytes32} from "../../utils/data-type-utils";
 import {TwoPartyPlayerIndex, ThreePartyPlayerIndex} from "../types";
 import {unreachable} from "../../utils/reducer-utils";
+import {ChannelParticipant} from "../channel-store";
 
 export const asPrivateKey = "0xf2f48ee19680706196e2e339e5da3491186e0c4c5030670656b0e0164837257d";
 export const asAddress = "0x5409ED021D9299bf6814279A6A1411A7e866A631";
@@ -25,7 +26,10 @@ export const hubPrivateKey = "0xce442e75dd539bd632aca84efa0b7de5c5b48aa4bbf028c8
 export const hubAddress = "0xAbcdE1140bA6aE8e702b78f63A4eA1D1553144a1";
 
 export const threeParticipants: [string, string, string] = [asAddress, bsAddress, hubAddress];
-export const participants: [string, string] = [asAddress, bsAddress];
+export const participants: ChannelParticipant[] = [
+  {signingAddress: asAddress},
+  {signingAddress: bsAddress}
+];
 
 export const libraryAddress = "0x" + "1".repeat(40);
 export const channelNonce = "0x04";
@@ -37,7 +41,7 @@ export const channel = {
 
 export const nitroChannel: Channel = {
   channelNonce,
-  participants,
+  participants: participants.map(p => p.signingAddress),
   chainId: bigNumberify(NETWORK_ID).toHexString()
 };
 // Use Nitro protocol channel id so we're always using the same channel Id
@@ -135,7 +139,7 @@ export const ledgerChannel = {
 export const ledgerNitroChannel: Channel = {
   chainId: bigNumberify(NETWORK_ID).toHexString(),
   channelNonce: "0x00",
-  participants
+  participants: participants.map(p => p.signingAddress)
 };
 // Use Nitro protocol channel id so we're always using the same channel Id
 export const ledgerId = getChannelId(ledgerNitroChannel);

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -21,7 +21,6 @@ import {LedgerFundingAction} from "./protocols/ledger-funding";
 import {LOAD as LOAD_FROM_STORAGE} from "redux-storage";
 import {SignedState, State} from "@statechannels/nitro-protocol";
 import {BigNumber} from "ethers/utils";
-import {JsonRpcParticipant, JsonRpcAllocations} from "../utils/json-rpc-utils";
 export * from "./protocols/transaction-submission/actions";
 
 export type TransactionAction = TA;
@@ -309,13 +308,6 @@ export interface JsonRpcAction {
 }
 export interface CreateChannelResponse extends JsonRpcAction {
   type: "WALLET.CREATE_CHANNEL_RESPONSE";
-  participants: JsonRpcParticipant[];
-  allocations: JsonRpcAllocations;
-  appDefinition: string;
-  appData: string;
-  status: "Opening";
-  funding: [];
-  turnNum: 0;
   channelId: string;
 }
 export const createChannelResponse: ActionConstructor<CreateChannelResponse> = p => ({

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -323,4 +323,26 @@ export const addressResponse: ActionConstructor<AddressResponse> = p => ({
   type: "WALLET.ADDRESS_RESPONSE"
 });
 
-export type JsonRpcResponseAction = AddressResponse | CreateChannelResponse;
+export interface UnknownSigningAddress extends JsonRpcAction {
+  type: "WALLET.UNKNOWN_SIGNING_ADDRESS_ERROR";
+  signingAddress: string;
+}
+
+export const unknownSigningAddress: ActionConstructor<UnknownSigningAddress> = p => ({
+  ...p,
+  type: "WALLET.UNKNOWN_SIGNING_ADDRESS_ERROR"
+});
+
+export interface NoContractError extends JsonRpcAction {
+  address: string;
+  type: "WALLET.NO_CONTRACT_ERROR";
+}
+export const noContractError: ActionConstructor<NoContractError> = p => ({
+  ...p,
+  type: "WALLET.NO_CONTRACT_ERROR"
+});
+export type JsonRpcResponseAction =
+  | AddressResponse
+  | CreateChannelResponse
+  | UnknownSigningAddress
+  | NoContractError;

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -21,6 +21,7 @@ import {LedgerFundingAction} from "./protocols/ledger-funding";
 import {LOAD as LOAD_FROM_STORAGE} from "redux-storage";
 import {SignedState, State} from "@statechannels/nitro-protocol";
 import {BigNumber} from "ethers/utils";
+import {JsonRpcParticipant, JsonRpcAllocations} from "../utils/json-rpc-utils";
 export * from "./protocols/transaction-submission/actions";
 
 export type TransactionAction = TA;
@@ -306,7 +307,21 @@ export interface JsonRpcAction {
   id: number | string; // Either a string or number is technically valid
   type: string;
 }
-
+export interface CreateChannelResponse extends JsonRpcAction {
+  type: "WALLET.CREATE_CHANNEL_RESPONSE";
+  participants: JsonRpcParticipant[];
+  allocations: JsonRpcAllocations;
+  appDefinition: string;
+  appData: string;
+  status: "Opening";
+  funding: [];
+  turnNum: 0;
+  channelId: string;
+}
+export const createChannelResponse: ActionConstructor<CreateChannelResponse> = p => ({
+  ...p,
+  type: "WALLET.CREATE_CHANNEL_RESPONSE"
+});
 export interface AddressResponse extends JsonRpcAction {
   type: "WALLET.ADDRESS_RESPONSE";
   address: string;
@@ -316,4 +331,4 @@ export const addressResponse: ActionConstructor<AddressResponse> = p => ({
   type: "WALLET.ADDRESS_RESPONSE"
 });
 
-export type JsonRpcResponseAction = AddressResponse;
+export type JsonRpcResponseAction = AddressResponse | CreateChannelResponse;

--- a/packages/wallet/src/redux/channel-store/channel-state/__tests__/index.ts
+++ b/packages/wallet/src/redux/channel-store/channel-state/__tests__/index.ts
@@ -9,12 +9,14 @@ export function channelFromStates(
   const lastState = states[numStates - 1];
   const {turnNum, channel, appDefinition: libraryAddress} = lastState.state;
 
-  const participants: [string, string] = channel.participants as [string, string];
+  const participants = channel.participants.map(p => {
+    return {signingAddress: p, destination: p, participantId: p};
+  });
   let funded = true;
   if (turnNum <= 1) {
     funded = false;
   }
-  const ourIndex = participants.indexOf(ourAddress);
+  const ourIndex = participants.map(p => p.signingAddress).indexOf(ourAddress);
   if (ourIndex === -1) {
     throw new Error("Address provided is not a participant according to the lastState.");
   }

--- a/packages/wallet/src/redux/channel-store/channel-state/states.ts
+++ b/packages/wallet/src/redux/channel-store/channel-state/states.ts
@@ -1,13 +1,19 @@
 import {Wallet} from "ethers";
 import {SignedState, State, getChannelId} from "@statechannels/nitro-protocol";
 
+export interface ChannelParticipant {
+  participantId?: string;
+  signingAddress: string;
+  destination?: string;
+}
+
 export interface ChannelState {
   address: string;
   privateKey: string;
   channelId: string;
   libraryAddress: string;
   ourIndex: number;
-  participants: string[];
+  participants: ChannelParticipant[];
   channelNonce: string;
   turnNum: number;
   signedStates: SignedState[];
@@ -32,10 +38,14 @@ export function getStates(state: ChannelState): SignedState[] {
 // Helpers
 // -------
 
-export function initializeChannel(signedState: SignedState, privateKey: string): ChannelState {
+export function initializeChannel(
+  signedState: SignedState,
+  privateKey: string,
+  participants: ChannelParticipant[]
+): ChannelState {
   const {state} = signedState;
   const {turnNum, channel, appDefinition} = state;
-  const {participants, channelNonce} = channel;
+  const {channelNonce} = channel;
   const address = new Wallet(privateKey).address;
   const ourIndex = state.channel.participants.indexOf(address);
 
@@ -82,7 +92,7 @@ export function isFullyOpen(state: ChannelState): state is OpenChannelState {
 export function theirAddress(state: ChannelState): string {
   const {participants, ourIndex} = state;
   const theirIndex = 1 - ourIndex; // todo: only two player channels
-  return participants[theirIndex];
+  return participants[theirIndex].signingAddress;
 }
 
 export function nextParticipant(participants, ourIndex: number): string {

--- a/packages/wallet/src/redux/channel-store/channel-state/valid-transition.ts
+++ b/packages/wallet/src/redux/channel-store/channel-state/valid-transition.ts
@@ -9,8 +9,8 @@ export function validTransition(channelState: ChannelState, state: State): boole
   return (
     state.turnNum === channelState.turnNum + 1 &&
     channelNonce === channelState.channelNonce &&
-    state.channel.participants[0] === channelState.participants[0] &&
-    state.channel.participants[1] === channelState.participants[1] &&
+    state.channel.participants[0] === channelState.participants[0].signingAddress &&
+    state.channel.participants[1] === channelState.participants[1].signingAddress &&
     channelId === channelState.channelId
   );
 }

--- a/packages/wallet/src/redux/protocols/actions.ts
+++ b/packages/wallet/src/redux/protocols/actions.ts
@@ -2,6 +2,7 @@ import {TwoPartyPlayerIndex} from "../types";
 import {ActionConstructor} from "../utils";
 import {ConcludeInstigated, ProcessProtocol} from "../../communication";
 import {WalletAction} from "../actions";
+import {ChannelParticipant} from "../channel-store";
 export {BaseProcessAction} from "../../communication";
 
 // -------
@@ -11,6 +12,7 @@ export interface InitializeChannel {
   type: "WALLET.NEW_PROCESS.INITIALIZE_CHANNEL";
   protocol: ProcessProtocol.Application;
   channelId: string;
+  participants: ChannelParticipant[];
 }
 export interface FundingRequested {
   type: "WALLET.NEW_PROCESS.FUNDING_REQUESTED";

--- a/packages/wallet/src/redux/protocols/advance-channel/reducer.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/reducer.ts
@@ -144,7 +144,14 @@ function initializeWithNewChannel(
       challengeDuration: CHALLENGE_DURATION
     };
 
-    const signResult = signAndInitialize(sharedData, ourState, privateKey);
+    const signResult = signAndInitialize(
+      sharedData,
+      ourState,
+      privateKey,
+      participants.map(p => {
+        return {signingAddress: p};
+      })
+    );
     if (!signResult.isSuccess) {
       throw new Error("Could not store new ledger channel state.");
     }
@@ -245,9 +252,17 @@ const channelUnknownReducer = (
   sharedData,
   action: SignedStatesReceived
 ) => {
-  const {privateKey} = protocolState;
+  const {privateKey, participants} = protocolState;
   const channelId = getChannelId(action.signedStates[0].state.channel);
-  const checkResult = checkAndInitialize(sharedData, action.signedStates[0], privateKey);
+
+  const checkResult = checkAndInitialize(
+    sharedData,
+    action.signedStates[0],
+    privateKey,
+    participants.map(p => {
+      return {signingAddress: p};
+    })
+  );
   if (!checkResult.isSuccess) {
     throw new Error("Could not initialize channel");
   }

--- a/packages/wallet/src/redux/protocols/application/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/application/__tests__/reducer.test.ts
@@ -20,7 +20,8 @@ describe("when initializing", () => {
     scenario.initialize.sharedData,
     scenario.channelId,
     scenario.address,
-    scenario.privateKey
+    scenario.privateKey,
+    scenario.participants
   );
   itTransitionsTo(result, "Application.WaitForFirstState");
 });

--- a/packages/wallet/src/redux/protocols/application/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/application/__tests__/scenarios.ts
@@ -6,7 +6,7 @@ import * as actions from "../actions";
 // -----------------
 // Channel Scenarios
 // -----------------
-const {channelId, asAddress: address, asPrivateKey: privateKey} = testScenarios;
+const {channelId, asAddress: address, asPrivateKey: privateKey, participants} = testScenarios;
 import {ChannelState} from "../../../channel-store";
 import {setChannel, EMPTY_SHARED_DATA} from "../../../state";
 import {channelFromStates} from "../../../channel-store/channel-state/__tests__";
@@ -32,12 +32,12 @@ const ourTurn = channelFromStates([signedState20, signedState21], address, priva
 const processId = "processId";
 const storage = (channelState: ChannelState) => setChannel(EMPTY_SHARED_DATA, channelState);
 
-const defaults = {processId, channelId, address, privateKey};
+const defaults = {processId, channelId, address, privateKey, participants};
 
 // ------
 // States
 // ------
-const addressKnown = states.waitForFirstState({channelId, address, privateKey});
+const addressKnown = states.waitForFirstState({channelId, address, privateKey, participants});
 const ongoing = states.ongoing({channelId, address, privateKey});
 const waitForDispute1 = states.waitForDispute({
   channelId,

--- a/packages/wallet/src/redux/protocols/application/states.ts
+++ b/packages/wallet/src/redux/protocols/application/states.ts
@@ -1,6 +1,7 @@
 import {StateConstructor} from "../../utils";
 import {DisputeState} from "../dispute/state";
 import {ProtocolState} from "..";
+import {ChannelParticipant} from "../../channel-store";
 
 // -------
 // States
@@ -10,6 +11,7 @@ export interface WaitForFirstState {
   channelId: string;
   address: string;
   privateKey: string;
+  participants: ChannelParticipant[];
 }
 
 export interface Ongoing {

--- a/packages/wallet/src/redux/protocols/reducer-helpers.ts
+++ b/packages/wallet/src/redux/protocols/reducer-helpers.ts
@@ -199,7 +199,7 @@ export const getTwoPlayerIndex = (
   sharedData: SharedData
 ): TwoPartyPlayerIndex => {
   const channelState = selectors.getChannelState(sharedData, channelId);
-  return channelState.participants.indexOf(channelState.address);
+  return channelState.participants.map(p => p.signingAddress).indexOf(channelState.address);
 };
 export const isFirstPlayer = (channelId: string, sharedData: SharedData) => {
   const channelState = selectors.getChannelState(sharedData, channelId);
@@ -246,12 +246,12 @@ export function getOpponentAddress(channelId: string, sharedData: SharedData) {
 
   const {participants} = channel;
   const opponentAddress = participants[(channel.ourIndex + 1) % participants.length];
-  return opponentAddress;
+  return opponentAddress.signingAddress;
 }
 
 export function getOurAddress(channelId: string, sharedData: SharedData) {
   const channel = getExistingChannel(sharedData, channelId);
-  return channel.participants[channel.ourIndex];
+  return channel.participants[channel.ourIndex].signingAddress;
 }
 
 export function getLatestState(channelId: string, sharedData: SharedData) {

--- a/packages/wallet/src/redux/reducer.ts
+++ b/packages/wallet/src/redux/reducer.ts
@@ -198,7 +198,8 @@ function initializeNewProtocol(
         incomingSharedData,
         action.channelId,
         state.address,
-        state.privateKey
+        state.privateKey,
+        action.participants
       );
     case "WALLET.NEW_PROCESS.CLOSE_LEDGER_CHANNEL":
       return closeLedgerChannelProtocol.initializeCloseLedgerChannel(

--- a/packages/wallet/src/redux/sagas/__tests__/message-handler.test.ts
+++ b/packages/wallet/src/redux/sagas/__tests__/message-handler.test.ts
@@ -1,12 +1,11 @@
 import {messageHandler} from "../message-handler";
 import * as walletStates from "../../state";
-
 import {addressResponse} from "../../actions";
 import {expectSaga} from "redux-saga-test-plan";
 import {Wallet} from "ethers";
-
 import {messageSender} from "../message-sender";
-import {fork} from "redux-saga/effects";
+import * as matchers from "redux-saga-test-plan/matchers";
+
 describe("message listener", () => {
   const wallet = Wallet.createRandom();
   const initialState = walletStates.initialized({
@@ -30,9 +29,79 @@ describe("message listener", () => {
       expectSaga(messageHandler, requestMessage, "localhost")
         .withState(initialState)
         // Mock out the fork call so we don't actually try to post the message
-        .provide([[fork(messageSender, addressResponse({id: 1, address: wallet.address})), 0]])
+        .provide([[matchers.fork.fn(messageSender), 0]])
         .fork(messageSender, addressResponse({id: 1, address: wallet.address}))
         .run()
     );
+  });
+  it("handles a create channel request", async () => {
+    const destinationA = Wallet.createRandom().address;
+    const signingAddressA = Wallet.createRandom().address;
+    const signingAddressB = Wallet.createRandom().address;
+    const destinationB = Wallet.createRandom().address;
+    const appDefinition = Wallet.createRandom().address;
+    const appData = "0x0";
+    const participants = [
+      {
+        participantId: "user-a",
+        signingAddress: signingAddressA,
+        destination: destinationA
+      },
+      {
+        participantId: "user-b",
+        signingAddress: signingAddressB,
+        destination: destinationB
+      }
+    ];
+    const allocations = [
+      {
+        token: "0x0",
+        allocationItems: [
+          {destination: destinationA, amount: "12"},
+          {destination: destinationB, amount: "12"}
+        ]
+      }
+    ];
+    const requestMessage = JSON.stringify({
+      jsonrpc: "2.0",
+      method: "CreateChannel",
+      id: 1,
+      params: {
+        participants,
+        allocations,
+        appDefinition,
+        appData
+      }
+    });
+    const {effects} = await expectSaga(messageHandler, requestMessage, "localhost")
+      .withState(initialState)
+      // Mock out the fork call so we don't actually try to post the message
+      .provide([[matchers.fork.fn(messageSender), 0]])
+      .run();
+
+    expect(effects.put[1].payload.action).toMatchObject({
+      type: "WALLET.APPLICATION.OWN_STATE_RECEIVED",
+      state: {
+        channel: {participants: [signingAddressA, signingAddressB]},
+        outcome: [
+          {
+            assetHolderAddress: "0x0",
+            allocation: [
+              {destination: destinationA, amount: "12"},
+              {destination: destinationB, amount: "12"}
+            ]
+          }
+        ]
+      }
+    });
+
+    expect(effects.fork[0].payload.args[0]).toMatchObject({
+      type: "WALLET.CREATE_CHANNEL_RESPONSE",
+      participants,
+      allocations,
+      status: "Opening",
+      funding: [],
+      channelId: expect.any(String)
+    });
   });
 });

--- a/packages/wallet/src/redux/sagas/__tests__/message-handler.test.ts
+++ b/packages/wallet/src/redux/sagas/__tests__/message-handler.test.ts
@@ -97,10 +97,7 @@ describe("message listener", () => {
 
     expect(effects.fork[0].payload.args[0]).toMatchObject({
       type: "WALLET.CREATE_CHANNEL_RESPONSE",
-      participants,
-      allocations,
-      status: "Opening",
-      funding: [],
+      id: 1,
       channelId: expect.any(String)
     });
   });

--- a/packages/wallet/src/redux/sagas/__tests__/message-handler.test.ts
+++ b/packages/wallet/src/redux/sagas/__tests__/message-handler.test.ts
@@ -5,7 +5,9 @@ import {expectSaga} from "redux-saga-test-plan";
 import {Wallet} from "ethers";
 import {messageSender} from "../message-sender";
 import * as matchers from "redux-saga-test-plan/matchers";
-
+import {getAddress} from "../../selectors";
+import {asAddress, bsAddress} from "../../__tests__/state-helpers";
+import {getProvider} from "../../../utils/contract-utils";
 describe("message listener", () => {
   const wallet = Wallet.createRandom();
   const initialState = walletStates.initialized({
@@ -34,71 +36,207 @@ describe("message listener", () => {
         .run()
     );
   });
-  it("handles a create channel request", async () => {
-    const destinationA = Wallet.createRandom().address;
-    const signingAddressA = Wallet.createRandom().address;
-    const signingAddressB = Wallet.createRandom().address;
-    const destinationB = Wallet.createRandom().address;
-    const appDefinition = Wallet.createRandom().address;
-    const appData = "0x0";
-    const participants = [
-      {
-        participantId: "user-a",
-        signingAddress: signingAddressA,
-        destination: destinationA
-      },
-      {
-        participantId: "user-b",
-        signingAddress: signingAddressB,
-        destination: destinationB
-      }
-    ];
-    const allocations = [
-      {
-        token: "0x0",
-        allocationItems: [
-          {destination: destinationA, amount: "12"},
-          {destination: destinationB, amount: "12"}
-        ]
-      }
-    ];
-    const requestMessage = JSON.stringify({
-      jsonrpc: "2.0",
-      method: "CreateChannel",
-      id: 1,
-      params: {
-        participants,
-        allocations,
-        appDefinition,
-        appData
-      }
-    });
-    const {effects} = await expectSaga(messageHandler, requestMessage, "localhost")
-      .withState(initialState)
-      // Mock out the fork call so we don't actually try to post the message
-      .provide([[matchers.fork.fn(messageSender), 0]])
-      .run();
+  describe("CreateChannel", () => {
+    it("handles a create channel request", async () => {
+      const destinationA = Wallet.createRandom().address;
+      const signingAddressA = asAddress;
+      const signingAddressB = bsAddress;
+      const destinationB = Wallet.createRandom().address;
+      const appDefinition = Wallet.createRandom().address;
+      const appData = "0x0";
+      const participants = [
+        {
+          participantId: "user-a",
+          signingAddress: signingAddressA,
+          destination: destinationA
+        },
+        {
+          participantId: "user-b",
+          signingAddress: signingAddressB,
+          destination: destinationB
+        }
+      ];
+      const allocations = [
+        {
+          token: "0x0",
+          allocationItems: [
+            {destination: destinationA, amount: "12"},
+            {destination: destinationB, amount: "12"}
+          ]
+        }
+      ];
+      const requestMessage = JSON.stringify({
+        jsonrpc: "2.0",
+        method: "CreateChannel",
+        id: 1,
+        params: {
+          participants,
+          allocations,
+          appDefinition,
+          appData
+        }
+      });
+      const {effects} = await expectSaga(messageHandler, requestMessage, "localhost")
+        .withState(initialState)
+        // Mock out the fork call so we don't actually try to post the message
+        .provide([
+          [matchers.fork.fn(messageSender), 0],
+          [matchers.select.selector(getAddress), asAddress],
+          [
+            matchers.call.fn(getProvider),
+            {
+              getCode: address => {
+                return "0x12345";
+              }
+            }
+          ]
+        ])
+        .run();
 
-    expect(effects.put[1].payload.action).toMatchObject({
-      type: "WALLET.APPLICATION.OWN_STATE_RECEIVED",
-      state: {
-        channel: {participants: [signingAddressA, signingAddressB]},
-        outcome: [
-          {
-            assetHolderAddress: "0x0",
-            allocation: [
-              {destination: destinationA, amount: "12"},
-              {destination: destinationB, amount: "12"}
-            ]
-          }
-        ]
-      }
+      expect(effects.put[1].payload.action).toMatchObject({
+        type: "WALLET.APPLICATION.OWN_STATE_RECEIVED",
+        state: {
+          channel: {participants: [signingAddressA, signingAddressB]},
+          outcome: [
+            {
+              assetHolderAddress: "0x0",
+              allocation: [
+                {destination: destinationA, amount: "12"},
+                {destination: destinationB, amount: "12"}
+              ]
+            }
+          ]
+        }
+      });
+
+      expect(effects.fork[0].payload.args[0]).toMatchObject({
+        type: "WALLET.CREATE_CHANNEL_RESPONSE",
+        id: 1,
+        channelId: expect.any(String)
+      });
     });
 
-    expect(effects.fork[0].payload.args[0]).toMatchObject({
-      type: "WALLET.CREATE_CHANNEL_RESPONSE",
-      id: 1,
-      channelId: expect.any(String)
+    it("returns an error when the contract is not deployed", async () => {
+      const destinationA = Wallet.createRandom().address;
+      const signingAddressA = Wallet.createRandom().address;
+      const signingAddressB = Wallet.createRandom().address;
+      const destinationB = Wallet.createRandom().address;
+      const appDefinition = Wallet.createRandom().address;
+      const appData = "0x0";
+      const participants = [
+        {
+          participantId: "user-a",
+          signingAddress: signingAddressA,
+          destination: destinationA
+        },
+        {
+          participantId: "user-b",
+          signingAddress: signingAddressB,
+          destination: destinationB
+        }
+      ];
+      const allocations = [
+        {
+          token: "0x0",
+          allocationItems: [
+            {destination: destinationA, amount: "12"},
+            {destination: destinationB, amount: "12"}
+          ]
+        }
+      ];
+      const requestMessage = JSON.stringify({
+        jsonrpc: "2.0",
+        method: "CreateChannel",
+        id: 1,
+        params: {
+          participants,
+          allocations,
+          appDefinition,
+          appData
+        }
+      });
+      const {effects} = await expectSaga(messageHandler, requestMessage, "localhost")
+        .withState(initialState)
+        // Mock out the fork call so we don't actually try to post the message
+        .provide([
+          [matchers.fork.fn(messageSender), 0],
+          [matchers.select.selector(getAddress), asAddress],
+          [
+            matchers.call.fn(getProvider),
+            {
+              getCode: address => {
+                return "0x";
+              }
+            }
+          ]
+        ])
+        .run();
+
+      expect(effects.fork[0].payload.args[0]).toMatchObject({
+        type: "WALLET.NO_CONTRACT_ERROR",
+        id: 1
+      });
+    });
+    it("returns an error the first participant does not have our address", async () => {
+      const destinationA = Wallet.createRandom().address;
+      const signingAddressA = Wallet.createRandom().address;
+      const signingAddressB = bsAddress;
+      const destinationB = Wallet.createRandom().address;
+      const appDefinition = Wallet.createRandom().address;
+      const appData = "0x0";
+      const participants = [
+        {
+          participantId: "user-a",
+          signingAddress: signingAddressA,
+          destination: destinationA
+        },
+        {
+          participantId: "user-b",
+          signingAddress: signingAddressB,
+          destination: destinationB
+        }
+      ];
+      const allocations = [
+        {
+          token: "0x0",
+          allocationItems: [
+            {destination: destinationA, amount: "12"},
+            {destination: destinationB, amount: "12"}
+          ]
+        }
+      ];
+      const requestMessage = JSON.stringify({
+        jsonrpc: "2.0",
+        method: "CreateChannel",
+        id: 1,
+        params: {
+          participants,
+          allocations,
+          appDefinition,
+          appData
+        }
+      });
+      const {effects} = await expectSaga(messageHandler, requestMessage, "localhost")
+        .withState(initialState)
+        // Mock out the fork call so we don't actually try to post the message
+        .provide([
+          [matchers.fork.fn(messageSender), 0],
+          [matchers.select.selector(getAddress), asAddress],
+          [
+            matchers.call.fn(getProvider),
+            {
+              getCode: address => {
+                return "0x";
+              }
+            }
+          ]
+        ])
+        .run();
+
+      expect(effects.fork[0].payload.args[0]).toMatchObject({
+        type: "WALLET.NO_CONTRACT_ERROR",
+        id: 1
+      });
     });
   });
 });

--- a/packages/wallet/src/redux/sagas/__tests__/message-sender.test.ts
+++ b/packages/wallet/src/redux/sagas/__tests__/message-sender.test.ts
@@ -1,5 +1,5 @@
 import {createResponseMessage} from "../message-sender";
-import {addressResponse} from "../../actions";
+import {addressResponse, createChannelResponse} from "../../actions";
 import {Wallet} from "ethers";
 
 describe("create message", () => {
@@ -13,5 +13,63 @@ describe("create message", () => {
         result: address
       })
     );
+  });
+  it("creates a correct response message for WALLET.CREATE_CHANNEL_RESPONSE", () => {
+    const destinationA = Wallet.createRandom().address;
+    const signingAddressA = Wallet.createRandom().address;
+    const signingAddressB = Wallet.createRandom().address;
+    const destinationB = Wallet.createRandom().address;
+    const appDefinition = Wallet.createRandom().address;
+    const appData = "0x0";
+    const participants = [
+      {
+        participantId: "user-a",
+        signingAddress: signingAddressA,
+        destination: destinationA
+      },
+      {
+        participantId: "user-b",
+        signingAddress: signingAddressB,
+        destination: destinationB
+      }
+    ];
+    const allocations = [
+      {
+        token: "0x0",
+        allocationItems: [
+          {destination: destinationA, amount: "12"},
+          {destination: destinationB, amount: "12"}
+        ]
+      }
+    ];
+    const channelId = Wallet.createRandom().address;
+    const message = createChannelResponse({
+      id: 1,
+      participants,
+      allocations,
+      appData,
+      appDefinition,
+      funding: [],
+      turnNum: 0,
+      status: "Opening",
+      channelId
+    });
+    const response = {
+      jsonrpc: "2.0",
+
+      id: 1,
+      result: {
+        participants,
+        allocations,
+        appData,
+        appDefinition,
+        funding: [],
+        turnNum: 0,
+        status: "Opening",
+        channelId
+      }
+    };
+    const result = createResponseMessage(message);
+    expect(JSON.parse(result)).toEqual(response);
   });
 });

--- a/packages/wallet/src/redux/sagas/__tests__/message-sender.test.ts
+++ b/packages/wallet/src/redux/sagas/__tests__/message-sender.test.ts
@@ -34,12 +34,16 @@ describe("create message", () => {
     const channelId = stateHelpers.channelId;
     const message = createChannelResponse({
       id: 1,
-
       channelId
     });
-    const response = {
-      jsonrpc: "2.0",
 
+    const {effects} = await expectSaga(messageSender, message)
+      .withState(initialState)
+      .provide([[matchers.call.fn(window.parent.postMessage), 0]])
+      .run();
+
+    expect(JSON.parse(effects.call[0].payload.args[0])).toMatchObject({
+      jsonrpc: "2.0",
       id: 1,
       result: {
         funding: [],
@@ -47,12 +51,6 @@ describe("create message", () => {
         status: "Opening",
         channelId
       }
-    };
-    const {effects} = await expectSaga(messageSender, message)
-      .withState(initialState)
-      .provide([[matchers.call.fn(window.parent.postMessage), 0]])
-      .run();
-
-    expect(JSON.parse(effects.call[0].payload.args[0])).toMatchObject(response);
+    });
   });
 });

--- a/packages/wallet/src/redux/sagas/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/message-handler.ts
@@ -1,7 +1,7 @@
 import {select, fork, put, call} from "redux-saga/effects";
 
 import * as actions from "../actions";
-import jrs, {RequestPayloadObject} from "jsonrpc-serializer";
+import jrs, {RequestObject} from "jsonrpc-lite";
 import {getAddress} from "../selectors";
 import {messageSender} from "./message-sender";
 import {getChannelId} from "@statechannels/nitro-protocol";
@@ -10,7 +10,7 @@ import {createStateFromCreateChannelParams} from "../../utils/json-rpc-utils";
 import {getProvider} from "../../utils/contract-utils";
 
 export function* messageHandler(jsonRpcMessage: string, fromDomain: string) {
-  const parsedMessage = jrs.deserialize(jsonRpcMessage);
+  const parsedMessage = jrs.parseObject(JSON.parse(jsonRpcMessage));
   switch (parsedMessage.type) {
     case "notification":
     case "success":
@@ -19,13 +19,14 @@ export function* messageHandler(jsonRpcMessage: string, fromDomain: string) {
     case "error":
       throw new Error("TODO: Respond with error message");
     case "request":
-      yield handleMessage(parsedMessage.payload as RequestPayloadObject);
+      yield handleMessage(parsedMessage.payload as RequestObject);
       break;
   }
 }
 
-function* handleMessage(payload: jrs.RequestPayloadObject) {
+function* handleMessage(payload: RequestObject) {
   const {id} = payload;
+
   switch (payload.method) {
     case "GetAddress":
       const address = yield select(getAddress);
@@ -37,8 +38,9 @@ function* handleMessage(payload: jrs.RequestPayloadObject) {
   }
 }
 
-function* handleCreateChannelMessage(payload: jrs.RequestPayloadObject) {
-  const {participants, appDefinition} = payload.params;
+function* handleCreateChannelMessage(payload: RequestObject) {
+  // TODO: We should verify the params we expect are there
+  const {participants, appDefinition} = payload.params as any;
   const {id} = payload;
 
   const address = select(getAddress);
@@ -56,7 +58,7 @@ function* handleCreateChannelMessage(payload: jrs.RequestPayloadObject) {
   } else if (!contractAtAddress) {
     yield fork(messageSender, actions.noContractError({id, address: appDefinition}));
   } else {
-    const state = createStateFromCreateChannelParams(payload.params);
+    const state = createStateFromCreateChannelParams(payload.params as any);
     yield put(
       actions.protocol.initializeChannel({channelId: getChannelId(state.channel), participants})
     );

--- a/packages/wallet/src/redux/sagas/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/message-handler.ts
@@ -32,7 +32,7 @@ function* handleMessage(payload: jrs.RequestPayloadObject) {
 
       break;
     case "CreateChannel":
-      const {allocations, participants} = payload.params;
+      const {participants} = payload.params;
       const state = createStateFromCreateChannelParams(payload.params);
 
       yield put(
@@ -46,18 +46,10 @@ function* handleMessage(payload: jrs.RequestPayloadObject) {
       );
       // TODO: Need to handle the case where something goes wrong
 
-      // TODO: Do we want this saga to be responsible for issuing the response?
       yield fork(
         messageSender,
         actions.createChannelResponse({
           id,
-          participants,
-          allocations,
-          turnNum: 0,
-          funding: [],
-          status: "Opening",
-          appDefinition: state.appDefinition,
-          appData: state.appData,
           channelId: getChannelId(state.channel)
         })
       );

--- a/packages/wallet/src/redux/sagas/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/message-handler.ts
@@ -35,7 +35,9 @@ function* handleMessage(payload: jrs.RequestPayloadObject) {
       const {allocations, participants} = payload.params;
       const state = createStateFromCreateChannelParams(payload.params);
 
-      yield put(actions.protocol.initializeChannel({channelId: getChannelId(state.channel)}));
+      yield put(
+        actions.protocol.initializeChannel({channelId: getChannelId(state.channel), participants})
+      );
       yield put(
         actions.application.ownStateReceived({
           processId: APPLICATION_PROCESS_ID,

--- a/packages/wallet/src/redux/sagas/message-sender.ts
+++ b/packages/wallet/src/redux/sagas/message-sender.ts
@@ -5,6 +5,7 @@ import {getChannelStatus} from "../state";
 import {ChannelState, getLastState} from "../channel-store";
 import {createJsonRpcAllocationsFromOutcome} from "../../utils/json-rpc-utils";
 import jrs from "jsonrpc-lite";
+import {unreachable} from "../../utils/reducer-utils";
 
 export function* messageSender(action: JsonRpcResponseAction) {
   const message = yield createResponseMessage(action);
@@ -35,7 +36,14 @@ function* createResponseMessage(action: JsonRpcResponseAction) {
       });
     case "WALLET.ADDRESS_RESPONSE":
       return jrs.success(action.id, action.address);
+    case "WALLET.NO_CONTRACT_ERROR":
+      return jrs.error(action.id, new jrs.JsonRpcError("Invalid app definition", 1001));
+    case "WALLET.UNKNOWN_SIGNING_ADDRESS_ERROR":
+      return jrs.error(
+        action.id,
+        new jrs.JsonRpcError("Signing address not found in the participants array", 1000)
+      );
     default:
-      return jrs.error(action.id, new jrs.JsonRpcError("some error", 99));
+      return unreachable(action);
   }
 }

--- a/packages/wallet/src/redux/sagas/message-sender.ts
+++ b/packages/wallet/src/redux/sagas/message-sender.ts
@@ -1,6 +1,7 @@
 import {JsonRpcResponseAction} from "../actions";
 import jrs from "jsonrpc-serializer";
 import {call} from "redux-saga/effects";
+import {unreachable} from "../../utils/reducer-utils";
 
 export function* messageSender(action: JsonRpcResponseAction) {
   const message = createResponseMessage(action);
@@ -10,9 +11,32 @@ export function* messageSender(action: JsonRpcResponseAction) {
 // This is exported so we can easily test it
 export function createResponseMessage(action: JsonRpcResponseAction) {
   switch (action.type) {
+    // TODO: If we switch this to a saga the action could just have a channelId
+    // We could look up the rest using a selector
+    case "WALLET.CREATE_CHANNEL_RESPONSE":
+      const {
+        participants,
+        allocations,
+        appDefinition,
+        appData,
+        status,
+        funding,
+        turnNum,
+        channelId
+      } = action;
+      return jrs.success(action.id, {
+        participants,
+        allocations,
+        appDefinition,
+        appData,
+        status,
+        funding,
+        turnNum,
+        channelId
+      });
     case "WALLET.ADDRESS_RESPONSE":
       return jrs.success(action.id, action.address);
     default:
-      return jrs.error(action.id, new jrs.err.MethodNotFoundError());
+      return unreachable(action);
   }
 }

--- a/packages/wallet/src/redux/sagas/message-sender.ts
+++ b/packages/wallet/src/redux/sagas/message-sender.ts
@@ -1,14 +1,14 @@
 import {JsonRpcResponseAction} from "../actions";
-import jrs from "jsonrpc-serializer";
+
 import {call, select} from "redux-saga/effects";
-import {unreachable} from "../../utils/reducer-utils";
 import {getChannelStatus} from "../state";
 import {ChannelState, getLastState} from "../channel-store";
 import {createJsonRpcAllocationsFromOutcome} from "../../utils/json-rpc-utils";
+import jrs from "jsonrpc-lite";
 
 export function* messageSender(action: JsonRpcResponseAction) {
   const message = yield createResponseMessage(action);
-  yield call(window.parent.postMessage, message, "*");
+  yield call(window.parent.postMessage, JSON.stringify(message), "*");
 }
 
 function* createResponseMessage(action: JsonRpcResponseAction) {
@@ -36,6 +36,6 @@ function* createResponseMessage(action: JsonRpcResponseAction) {
     case "WALLET.ADDRESS_RESPONSE":
       return jrs.success(action.id, action.address);
     default:
-      return unreachable(action);
+      return jrs.error(action.id, new jrs.JsonRpcError("some error", 99));
   }
 }

--- a/packages/wallet/src/redux/sagas/message-sender.ts
+++ b/packages/wallet/src/redux/sagas/message-sender.ts
@@ -4,12 +4,11 @@ import {call} from "redux-saga/effects";
 import {unreachable} from "../../utils/reducer-utils";
 
 export function* messageSender(action: JsonRpcResponseAction) {
-  const message = createResponseMessage(action);
+  const message = yield createResponseMessage(action);
   yield call(window.parent.postMessage, message, "*");
 }
 
-// This is exported so we can easily test it
-export function createResponseMessage(action: JsonRpcResponseAction) {
+function* createResponseMessage(action: JsonRpcResponseAction) {
   switch (action.type) {
     // TODO: If we switch this to a saga the action could just have a channelId
     // We could look up the rest using a selector

--- a/packages/wallet/src/redux/selectors.ts
+++ b/packages/wallet/src/redux/selectors.ts
@@ -1,4 +1,10 @@
-import {OpenChannelState, ChannelState, isFullyOpen, getLastState} from "./channel-store";
+import {
+  OpenChannelState,
+  ChannelState,
+  isFullyOpen,
+  getLastState,
+  ChannelParticipant
+} from "./channel-store";
 import * as walletStates from "./state";
 import {SharedData, FundingState} from "./state";
 import {ProcessProtocol} from "../communication";
@@ -46,8 +52,12 @@ export const getFundedLedgerChannelForParticipants = (
     return (
       channel.libraryAddress === CONSENSUS_LIBRARY_ADDRESS &&
       // We call concat() on participants in order to not sort it in place
-      JSON.stringify(channel.participants.concat().sort()) ===
-        JSON.stringify([playerA, playerB].sort()) &&
+      JSON.stringify(
+        channel.participants
+          .map(p => p.signingAddress)
+          .concat()
+          .sort()
+      ) === JSON.stringify([playerA, playerB].sort()) &&
       directlyFunded
     );
   });
@@ -147,4 +157,9 @@ export const getNextNonce = (
 
 export const getChannelIds = (state: SharedData): string[] => {
   return Object.keys(state.channelStore);
+};
+
+export const getParticipants = (state: SharedData, channelId: string): ChannelParticipant[] => {
+  const status = walletStates.getChannelStatus(state, channelId);
+  return status.participants;
 };

--- a/packages/wallet/src/redux/state.ts
+++ b/packages/wallet/src/redux/state.ts
@@ -15,7 +15,8 @@ import {
   signAndStore as signAndStoreChannelStore,
   signAndInitialize as signAndInitializeChannelStore,
   emptyChannelStore,
-  SignFailureReason
+  SignFailureReason,
+  ChannelParticipant
 } from "./channel-store";
 import {Properties} from "./utils";
 import * as NewLedgerChannel from "./protocols/new-ledger-channel/states";
@@ -182,7 +183,7 @@ export function initialized(params: Properties<Initialized>): Initialized {
 // Getters and setters
 // -------------------
 
-export function getChannelStatus(state: WalletState, channelId: string): ChannelState {
+export function getChannelStatus(state: SharedData, channelId: string): ChannelState {
   return state.channelStore[channelId];
 }
 
@@ -237,9 +238,15 @@ export function getPrivatekey(state: SharedData, channelId: string): string {
 export function signAndInitialize(
   sharedDataState: SharedData,
   state: State,
-  privateKey: string
+  privateKey: string,
+  participants: ChannelParticipant[]
 ): SignResult {
-  const result = signAndInitializeChannelStore(sharedDataState.channelStore, state, privateKey);
+  const result = signAndInitializeChannelStore(
+    sharedDataState.channelStore,
+    state,
+    privateKey,
+    participants
+  );
   if (result.isSuccess) {
     return {
       isSuccess: result.isSuccess,
@@ -254,9 +261,15 @@ export function signAndInitialize(
 export function checkAndInitialize(
   state: SharedData,
   signedState: SignedState,
-  privateKey: string
+  privateKey: string,
+  participants: ChannelParticipant[]
 ): CheckResult {
-  const result = checkAndInitializeChannelStore(state.channelStore, signedState, privateKey);
+  const result = checkAndInitializeChannelStore(
+    state.channelStore,
+    signedState,
+    privateKey,
+    participants
+  );
   if (result.isSuccess) {
     return {...result, store: setChannelStore(state, result.store)};
   } else {

--- a/packages/wallet/src/utils/json-rpc-utils.ts
+++ b/packages/wallet/src/utils/json-rpc-utils.ts
@@ -1,4 +1,4 @@
-import {Outcome, State, Channel} from "@statechannels/nitro-protocol";
+import {Outcome, State, Channel, isAllocationOutcome} from "@statechannels/nitro-protocol";
 import {bigNumberify, randomBytes} from "ethers/utils";
 import {NETWORK_ID, CHALLENGE_DURATION} from "../constants";
 
@@ -29,6 +29,18 @@ export interface JsonRpcCreateChannelParams {
 function createAllocationOutcomeFromParams(params: JsonRpcAllocations): Outcome {
   return params.map(p => {
     return {assetHolderAddress: p.token, allocation: p.allocationItems};
+  });
+}
+
+export function createJsonRpcAllocationsFromOutcome(outcome: Outcome): JsonRpcAllocations {
+  return outcome.map(o => {
+    if (!isAllocationOutcome(o)) {
+      throw new Error("Attempted to convert non allocation outcome to an allocation");
+    }
+    return {
+      token: o.assetHolderAddress,
+      allocationItems: o.allocation
+    };
   });
 }
 

--- a/packages/wallet/src/utils/json-rpc-utils.ts
+++ b/packages/wallet/src/utils/json-rpc-utils.ts
@@ -1,0 +1,55 @@
+import {Outcome, State, Channel} from "@statechannels/nitro-protocol";
+import {bigNumberify, randomBytes} from "ethers/utils";
+import {NETWORK_ID, CHALLENGE_DURATION} from "../constants";
+
+export interface JsonRpcParticipant {
+  participantId: string;
+  signingAddress: string;
+  destination: string;
+}
+
+export interface JsonRpcAllocationItem {
+  destination: string;
+  amount: string;
+}
+export type JsonRpcAllocations = JsonRpcAllocation[];
+
+export interface JsonRpcAllocation {
+  token: string;
+  allocationItems: JsonRpcAllocationItem[];
+}
+
+export interface JsonRpcCreateChannelParams {
+  participants: JsonRpcParticipant[];
+  allocations: JsonRpcAllocations;
+  appDefinition: string;
+  appData: string;
+}
+
+function createAllocationOutcomeFromParams(params: JsonRpcAllocations): Outcome {
+  return params.map(p => {
+    return {assetHolderAddress: p.token, allocation: p.allocationItems};
+  });
+}
+
+// TODO: Error handling
+export function createStateFromCreateChannelParams(params: JsonRpcCreateChannelParams): State {
+  const {appData, appDefinition} = params;
+
+  // TODO: We should implement a nonce negotiation protocol once it's fully specced out
+  const channelNonce = bigNumberify(randomBytes(32)).toHexString();
+  const channel: Channel = {
+    channelNonce,
+    participants: params.participants.map(p => p.signingAddress),
+    chainId: bigNumberify(NETWORK_ID).toHexString()
+  };
+  return {
+    channel,
+    challengeDuration: CHALLENGE_DURATION,
+    appData,
+    appDefinition,
+    outcome: createAllocationOutcomeFromParams(params.allocations),
+    turnNum: 0,
+    isFinal: false
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15845,12 +15845,10 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-jsonrpc-serializer@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.npmjs.org/jsonrpc-serializer/-/jsonrpc-serializer-0.2.1.tgz#0edf529cd8714eed87cbeb55a9bcfab7635b4c39"
-  integrity sha1-Dt9SnNhxTu2Hy+tVqbz6t2NbTDk=
-  dependencies:
-    inherits "^2.0.3"
+jsonrpc-lite@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/jsonrpc-lite/-/jsonrpc-lite-2.1.0.tgz#65171c521ce037c761a6e3dc3b22ec99cceb2d18"
+  integrity sha512-gjGlngwEERed9VKmBALN7vLYQf6S0ggEqGnzYAMdoH+cSLGqVUCpU62sioa2/ts+xKYOOLye0CDu7/w/HAJ53w==
 
 jsonschema@^1.2.0:
   version "1.2.4"


### PR DESCRIPTION
Fixes #435. Fixes #462.

Implements the `Create Channel` Api Call (https://deploy-preview-427--app-wallet-interface.netlify.com/#create-channel)

Currently `CreateChannel` does not send a message to the opponent so they know a channel has been created. That will be handled under #470.