### PR TITLE
[monorepo] Disable custom netlify configuration in production

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,3 @@
-[build]
+[context.deploy-preview]
  ignore = "bash ./netlify-ignore.sh"
+ 


### PR DESCRIPTION
This should mean that our sites *always* build from the latest code on master after a PR is merged.

Deploy-preview builds for PRs themselves will still be skipped if packages have not changed.