### PR TITLE
[hub] Further support for guarantees

### DIFF
--- a/packages/hub/src/hub/handlers/__test__/handle-ongoing-process-action.test.ts
+++ b/packages/hub/src/hub/handlers/__test__/handle-ongoing-process-action.test.ts
@@ -1,0 +1,26 @@
+import {State} from '@statechannels/nitro-protocol';
+import {signState} from '@statechannels/nitro-protocol/lib/src/signatures';
+import {EmbeddedProtocol, SignedStatesReceived} from '@statechannels/wallet/lib/src/communication';
+import {PARTICIPANT_1_ADDRESS, PARTICIPANT_1_PRIVATE_KEY} from '../../../test/test-constants';
+import {stateConstructors} from '../../../test/test_data';
+import {handleOngoingProcessAction} from '../handle-ongoing-process-action';
+
+describe('handle-ongoing-process-action', () => {
+  it('postfund signed states received', async () => {
+    const state: State = stateConstructors.post_fund_setup(2);
+    const signedStatesReceivedAction: SignedStatesReceived = {
+      type: 'WALLET.COMMON.SIGNED_STATES_RECEIVED',
+      processId: '1234',
+      protocolLocator: [EmbeddedProtocol.AdvanceChannel],
+      signedStates: [signState(state, PARTICIPANT_1_PRIVATE_KEY)]
+    };
+    const messageReleayRequested = await handleOngoingProcessAction(signedStatesReceivedAction);
+
+    expect(messageReleayRequested).toHaveLength(1);
+    expect(messageReleayRequested[0].to).toEqual(PARTICIPANT_1_ADDRESS);
+    const states: State[] = messageReleayRequested[0].messagePayload.signedStates.map(
+      signedState => signedState.state
+    );
+    expect(states).toEqual([state, stateConstructors.post_fund_setup(3)]);
+  });
+});

--- a/packages/hub/src/hub/handlers/handle-new-process-action.ts
+++ b/packages/hub/src/hub/handlers/handle-new-process-action.ts
@@ -3,9 +3,9 @@ import {
   ConcludeInstigated,
   SignedStatesReceived
 } from '@statechannels/wallet/lib/src/communication';
-import {HUB_ADDRESS} from 'src/constants';
-import {startFundingProcess} from 'src/wallet/db/queries/walletProcess';
+import {HUB_ADDRESS} from '../../constants';
 import {MessageRelayRequested} from '../../wallet-client';
+import {startFundingProcess} from '../../wallet/db/queries/walletProcess';
 import * as ongoing from './handle-ongoing-process-action';
 
 export async function handleNewProcessAction(

--- a/packages/hub/src/hub/handlers/handle-ongoing-process-action.ts
+++ b/packages/hub/src/hub/handlers/handle-ongoing-process-action.ts
@@ -1,14 +1,12 @@
 import {unreachable} from '@statechannels/wallet';
-
 import {SignedStatesReceived, StrategyProposed} from '@statechannels/wallet/lib/src/communication';
 import * as communication from '@statechannels/wallet/lib/src/communication';
+import {HUB_ADDRESS} from '../../constants';
 import {errors} from '../../wallet';
-
-import {HUB_ADDRESS} from 'src/constants';
-import {getCurrentState} from 'src/wallet/db/queries/getCurrentState';
-import {updateLedgerChannel} from 'src/wallet/services';
 import {MessageRelayRequested} from '../../wallet-client';
+import {getCurrentState} from '../../wallet/db/queries/getCurrentState';
 import {getProcess} from '../../wallet/db/queries/walletProcess';
+import {updateLedgerChannel} from '../../wallet/services';
 
 export async function handleOngoingProcessAction(
   action: StrategyProposed | SignedStatesReceived

--- a/packages/hub/src/test/test-constants.ts
+++ b/packages/hub/src/test/test-constants.ts
@@ -1,4 +1,5 @@
 import {AllocationItem, Outcome} from '@statechannels/nitro-protocol';
+import {GuaranteeAssetOutcome} from '@statechannels/nitro-protocol/lib/src/contract/outcome';
 import {convertAddressToBytes32} from '@statechannels/wallet';
 import {ethers} from 'ethers';
 import {bigNumberify} from 'ethers/utils';
@@ -19,6 +20,8 @@ export const UNKNOWN_RULES_ADDRESS = '0x92b5b042047731FF882423cB555554F11F632Bd6
 export const FUNDED_CHANNEL_NONCE = '3';
 export const FUNDED_CHANNEL_NONCE_3 = '33';
 export const FUNDED_CHANNEL_HOLDINGS = '0x00';
+
+export const FUNDED_GUARANTOR_CHANNEL_NONCE = '31';
 
 export const BEGINNING_APP_CHANNEL_NONCE = '44';
 export const BEGINNING_APP_CHANNEL_HOLDINGS = '0x05';
@@ -48,15 +51,23 @@ export const allocation: AllocationItem[] = [
   {destination: convertAddressToBytes32(PARTICIPANT_2_ADDRESS), amount: hex5},
   {destination: convertAddressToBytes32(HUB_ADDRESS), amount: hex5}
 ];
-export const outcome2: Outcome = [
+export const allocationOutcome2: Outcome = [
   {
     assetHolderAddress: dummyEthAssetHolderAddress,
     allocation: allocation.slice(0, 2)
   }
 ];
-export const outcome3: Outcome = [
+
+export const allocationOutcome3: Outcome = [
   {
     assetHolderAddress: dummyEthAssetHolderAddress,
     allocation: allocation.slice(0, 3)
+  }
+];
+
+export const guaranteeOutcome2: GuaranteeAssetOutcome[] = [
+  {
+    assetHolderAddress: dummyEthAssetHolderAddress,
+    guarantee: {targetChannelId: '1234', destinations: PARTICIPANTS}
   }
 ];

--- a/packages/hub/src/test/test_data.ts
+++ b/packages/hub/src/test/test_data.ts
@@ -2,15 +2,16 @@ import {Channel, encodeConsensusData, getChannelId, State} from '@statechannels/
 import {ConsensusData} from '@statechannels/nitro-protocol/lib/src/contract/consensus-data';
 import {HUB_ADDRESS} from '../constants';
 import {
+  allocationOutcome2,
+  allocationOutcome3,
   BEGINNING_APP_CHANNEL_NONCE,
   DUMMY_CHAIN_ID,
   DUMMY_RULES_ADDRESS,
   FUNDED_CHANNEL_NONCE,
   FUNDED_CHANNEL_NONCE_3,
+  FUNDED_GUARANTOR_CHANNEL_NONCE,
   NONCE,
   ONGOING_APP_CHANNEL_NONCE,
-  outcome2,
-  outcome3,
   PARTICIPANT_1_ADDRESS,
   PARTICIPANTS,
   PARTICIPANTS_3
@@ -26,97 +27,104 @@ export function channelObjectToModel(channel: Channel) {
   };
 }
 
-export const default_channel: Channel = {
+export const defaultChannel: Channel = {
   participants: PARTICIPANTS,
   channelNonce: NONCE,
   chainId: DUMMY_CHAIN_ID
 };
 
-const default_channel_3: Channel = {
+const defaultChannel3: Channel = {
   participants: PARTICIPANTS_3,
   channelNonce: NONCE,
   chainId: DUMMY_CHAIN_ID
 };
 
-export const funded_channel: Channel = {
+export const fundedChannel: Channel = {
   participants: PARTICIPANTS,
   channelNonce: FUNDED_CHANNEL_NONCE,
   chainId: DUMMY_CHAIN_ID
 };
 
-export const funded_channel_3: Channel = {
+export const fundedChannel3: Channel = {
   participants: PARTICIPANTS_3,
   channelNonce: FUNDED_CHANNEL_NONCE_3,
   chainId: DUMMY_CHAIN_ID
 };
 
-export const beginning_app_phase_channel: Channel = {
+export const fundedGuarantorChannel: Channel = {
+  participants: PARTICIPANTS,
+  channelNonce: FUNDED_GUARANTOR_CHANNEL_NONCE,
+  chainId: DUMMY_CHAIN_ID
+};
+
+export const beginningAppPhaseChannel: Channel = {
   participants: PARTICIPANTS,
   channelNonce: BEGINNING_APP_CHANNEL_NONCE,
   chainId: DUMMY_CHAIN_ID
 };
 
-export const ongoing_app_phase_channel: Channel = {
+export const ongoingAppPhaseChannel: Channel = {
   participants: PARTICIPANTS,
   channelNonce: ONGOING_APP_CHANNEL_NONCE,
   chainId: DUMMY_CHAIN_ID
 };
 
-export const FUNDED_NONCE_CHANNEL_ID = getChannelId(funded_channel);
-export const FUNDED_NONCE_CHANNEL_ID_3 = getChannelId(funded_channel_3);
-export const BEGINNING_APP_CHANNEL_NONCE_CHANNEL_ID = getChannelId(beginning_app_phase_channel);
-export const ONGOING_APP_CHANNEL_NONCE_CHANNEL_ID = getChannelId(ongoing_app_phase_channel);
+export const FUNDED_NONCE_CHANNEL_ID = getChannelId(fundedChannel);
+export const FUNDED_NONCE_CHANNEL_ID_3 = getChannelId(fundedChannel3);
+export const FUNDED_NONCE_GUARANTOR_CHANNEL_ID = getChannelId(fundedGuarantorChannel);
+export const BEGINNING_APP_CHANNEL_NONCE_CHANNEL_ID = getChannelId(beginningAppPhaseChannel);
+export const ONGOING_APP_CHANNEL_NONCE_CHANNEL_ID = getChannelId(ongoingAppPhaseChannel);
 
 export const consensus_app_data2 = (n: number): ConsensusData => ({
   furtherVotesRequired: n,
-  proposedOutcome: outcome2
+  proposedOutcome: allocationOutcome2
 });
 
 export const consensus_app_data3 = (n: number): ConsensusData => ({
   furtherVotesRequired: n,
-  proposedOutcome: outcome3
+  proposedOutcome: allocationOutcome3
 });
 
 const baseState = (turnNum: number) => ({
   turnNum,
   isFinal: false,
   challengeDuration: 1000,
-  outcome: outcome2,
+  outcome: allocationOutcome2,
   appDefinition: DUMMY_RULES_ADDRESS,
   appData: encodeConsensusData(consensus_app_data2(0))
 });
 
 const baseState3 = (turnNum: number) => ({
   ...baseState(turnNum),
-  outcome: outcome3,
+  outcome: allocationOutcome3,
   appData: encodeConsensusData(consensus_app_data3(0))
 });
 
 function pre_fund_setup(turnNum: number): State {
   return {
     ...baseState(turnNum),
-    channel: {...default_channel}
+    channel: {...defaultChannel}
   };
 }
 
 export function pre_fund_setup_3(turnNum: number): State {
   return {
     ...baseState3(turnNum),
-    channel: {...default_channel_3}
+    channel: {...defaultChannel3}
   };
 }
 
 function post_fund_setup(turnNum: number): State {
   return {
     ...baseState(turnNum),
-    channel: {...funded_channel}
+    channel: {...fundedChannel}
   };
 }
 
 export function post_fund_setup_3(turnNum: number): State {
   return {
     ...baseState3(turnNum),
-    channel: {...funded_channel_3}
+    channel: {...fundedChannel3}
   };
 }
 
@@ -142,7 +150,7 @@ const base_response = {
     participants: PARTICIPANTS,
     chainId: DUMMY_CHAIN_ID
   },
-  outcome: outcome2,
+  outcome: allocationOutcome2,
   challengeDuration: 1000,
   appDefinition: DUMMY_RULES_ADDRESS,
   isFinal: false
@@ -154,7 +162,7 @@ const base_response_3 = {
     participants: PARTICIPANTS_3,
     chainId: DUMMY_CHAIN_ID
   },
-  outcome: outcome3,
+  outcome: allocationOutcome3,
   challengeDuration: 1000,
   appDefinition: DUMMY_RULES_ADDRESS,
   isFinal: false
@@ -177,28 +185,28 @@ export const post_fund_setup_1_response: State = {
   ...base_response,
   turnNum: 3,
   appData: encodeConsensusData(consensus_app_data2(0)),
-  channel: funded_channel
+  channel: fundedChannel
 };
 
 export const post_fund_setup_3_2_response: State = {
   ...base_response_3,
   turnNum: 5,
   appData: encodeConsensusData(consensus_app_data3(0)),
-  channel: funded_channel_3
+  channel: fundedChannel3
 };
 
 export const app_1_response: State = {
   ...base_response,
   turnNum: 5,
   appData: encodeConsensusData({proposedOutcome: [], furtherVotesRequired: 0}),
-  channel: beginning_app_phase_channel
+  channel: beginningAppPhaseChannel
 };
 
 // Ledger Channel Manager input states
 export const created_pre_fund_setup_1: State = {
-  channel: default_channel,
+  channel: defaultChannel,
   turnNum: 1,
-  outcome: outcome2,
+  outcome: allocationOutcome2,
   appData: encodeConsensusData(consensus_app_data2(1)),
   isFinal: false,
   challengeDuration: 1000,
@@ -206,9 +214,9 @@ export const created_pre_fund_setup_1: State = {
 };
 
 export const created_pre_fund_setup_3_2: State = {
-  channel: default_channel_3,
+  channel: defaultChannel3,
   turnNum: 2,
-  outcome: outcome3,
+  outcome: allocationOutcome3,
   appData: encodeConsensusData(consensus_app_data3(1)),
   isFinal: false,
   challengeDuration: 1000,

--- a/packages/hub/src/wallet/adjudicator-watcher/__chain-test__/adjudicator-watcher.test.ts
+++ b/packages/hub/src/wallet/adjudicator-watcher/__chain-test__/adjudicator-watcher.test.ts
@@ -2,11 +2,11 @@ import {getChannelId} from '@statechannels/nitro-protocol';
 import {fork} from 'child_process';
 import {bigNumberify} from 'ethers/utils';
 import {AdjudicatorWatcherEvent} from '..';
-import {funded_channel} from '../../../test/test_data';
+import {fundedChannel} from '../../../test/test_data';
 import {Blockchain} from '../../services/blockchain';
 
 jest.setTimeout(20000);
-const channelId = getChannelId(funded_channel);
+const channelId = getChannelId(fundedChannel);
 let killSubprocess = null;
 const five = bigNumberify(5).toHexString();
 

--- a/packages/hub/src/wallet/db/migrations/20191111110900_allocations.ts
+++ b/packages/hub/src/wallet/db/migrations/20191111110900_allocations.ts
@@ -20,7 +20,7 @@ exports.up = (knex: Knex) => {
         .unsigned()
         .notNullable();
       table.string('destination').notNullable();
-      table.string('amount').notNullable();
+      table.string('amount');
 
       table.unique(['outcome_id', 'priority']);
     })

--- a/packages/hub/src/wallet/db/queries/__test__/channels.test.ts
+++ b/packages/hub/src/wallet/db/queries/__test__/channels.test.ts
@@ -1,18 +1,18 @@
 import {errors} from '../../..';
 import {
   created_channel,
-  funded_channel,
+  fundedChannel,
   stateConstructors as testDataConstructors
 } from '../../../../test/test_data';
 import Channel from '../../../models/channel';
 import knex from '../../connection';
 import {
-  constructors as seedDataConstructors,
   SEEDED_ALLOCATIONS,
   SEEDED_CHANNELS,
   SEEDED_PARTICIPANTS,
   SEEDED_STATES,
-  seeds
+  seeds,
+  stateConstructors as seedDataConstructors
 } from '../../seeds/2_allocator_channels_seed';
 import {queries} from '../channels';
 
@@ -38,7 +38,7 @@ describe('updateChannel', () => {
 
     it('throws when the channel exists', async () => {
       const theirState = testDataConstructors.pre_fund_setup(0);
-      theirState.channel = funded_channel;
+      theirState.channel = fundedChannel;
       const hubState = testDataConstructors.pre_fund_setup(1);
       expect.assertions(1);
       await queries.updateChannel([theirState], hubState).catch(err => {
@@ -64,7 +64,10 @@ describe('updateChannel', () => {
 
       expect(updated_allocator_channel).toMatchObject({
         ...seeds.fundedChannelWithStates,
-        states: [seedDataConstructors.post_fund_setup(2), seedDataConstructors.post_fund_setup(3)]
+        states: [
+          seedDataConstructors.postFundSetupState(2),
+          seedDataConstructors.postFundSetupState(3)
+        ]
       });
 
       expect((await knex('channels').select('*')).length).toEqual(SEEDED_CHANNELS);
@@ -82,7 +85,7 @@ describe('updateChannel', () => {
     it("throws when the channel doesn't exist and the commitment is not PreFundSetup", async () => {
       expect.assertions(1);
       const theirState = testDataConstructors.post_fund_setup(2);
-      theirState.channel = {...funded_channel, channelNonce: '1234'};
+      theirState.channel = {...fundedChannel, channelNonce: '1234'};
       const hubState = testDataConstructors.post_fund_setup(1);
       expect.assertions(1);
       await queries.updateChannel([theirState], hubState).catch(err => {

--- a/packages/hub/src/wallet/db/seeds/3_wallet_processes.ts
+++ b/packages/hub/src/wallet/db/seeds/3_wallet_processes.ts
@@ -1,0 +1,21 @@
+import {EmbeddedProtocol} from '@statechannels/wallet/lib/src/communication';
+import {Model} from 'objection';
+import {PARTICIPANT_1_ADDRESS} from '../../../test/test-constants';
+import WalletProcess from '../../models/WalletProcess';
+import knex from '../connection';
+Model.knex(knex);
+
+export function seed() {
+  // Deletes ALL existing entries
+  return knex('wallet_processes')
+    .del()
+    .then(() => {
+      return WalletProcess.query().insert([
+        {
+          processId: '1234',
+          theirAddress: PARTICIPANT_1_ADDRESS,
+          protocol: EmbeddedProtocol.AdvanceChannel
+        }
+      ]);
+    });
+}

--- a/packages/hub/src/wallet/models/__test__/channelState.test.ts
+++ b/packages/hub/src/wallet/models/__test__/channelState.test.ts
@@ -1,46 +1,66 @@
 import {encodeConsensusData, State} from '@statechannels/nitro-protocol';
-import {HUB_ADDRESS} from '../../../constants';
 import {
-  DUMMY_CHAIN_ID,
+  allocationOutcome2,
   DUMMY_RULES_ADDRESS,
-  FUNDED_CHANNEL_NONCE,
-  outcome2,
-  PARTICIPANT_1_ADDRESS
+  guaranteeOutcome2
 } from '../../../test/test-constants';
-import {consensus_app_data2, FUNDED_NONCE_CHANNEL_ID} from '../../../test/test_data';
+import {
+  consensus_app_data2,
+  FUNDED_NONCE_CHANNEL_ID,
+  FUNDED_NONCE_GUARANTOR_CHANNEL_ID,
+  fundedChannel,
+  fundedGuarantorChannel
+} from '../../../test/test_data';
 import Channel from '../channel';
 import ChannelState from '../channelState';
 
+async function getChannelStates(channelId): Promise<State> {
+  const channel = await Channel.query()
+    .where({channel_id: channelId})
+    .select('id')
+    .first();
+  expect(channel).toBeTruthy();
+  const channelState: ChannelState = await ChannelState.query()
+    .where({
+      channel_id: channel.id,
+      turn_num: 0
+    })
+    .eager('[channel.[participants], outcome.[allocation]]')
+    .select()
+    .first();
+  return channelState.asStateObject();
+}
+
 describe('asStateObject', () => {
-  it('channelState relation to object conversion', async () => {
-    const channel = await Channel.query()
-      .where({channel_id: FUNDED_NONCE_CHANNEL_ID})
-      .select('id')
-      .first();
-    expect(channel).toBeTruthy();
-    const channelState: ChannelState = await ChannelState.query()
-      .where({
-        channel_id: channel.id,
-        turn_num: 0
-      })
-      .eager('[channel.[participants], outcome.[allocation]]')
-      .select()
-      .first();
+  it('allocation channelState relation to object conversion', async () => {
+    const state = await getChannelStates(FUNDED_NONCE_CHANNEL_ID);
 
     const expectedState: State = {
       turnNum: 0,
       isFinal: false,
-      channel: {
-        channelNonce: FUNDED_CHANNEL_NONCE,
-        participants: [PARTICIPANT_1_ADDRESS, HUB_ADDRESS],
-        chainId: DUMMY_CHAIN_ID
-      },
+      channel: fundedChannel,
       challengeDuration: 1000,
-      outcome: outcome2,
+      outcome: allocationOutcome2,
       appDefinition: DUMMY_RULES_ADDRESS,
       appData: encodeConsensusData(consensus_app_data2(2))
     };
-    const state: State = channelState.asStateObject();
+
+    expect(state).toMatchObject(expectedState);
+  });
+
+  it('guarantor channelState relation to object conversion', async () => {
+    const state = await getChannelStates(FUNDED_NONCE_GUARANTOR_CHANNEL_ID);
+
+    const expectedState: State = {
+      turnNum: 0,
+      isFinal: false,
+      channel: fundedGuarantorChannel,
+      challengeDuration: 1000,
+      outcome: guaranteeOutcome2,
+      appDefinition: DUMMY_RULES_ADDRESS,
+      appData: encodeConsensusData(consensus_app_data2(2))
+    };
+
     expect(state).toMatchObject(expectedState);
   });
 });

--- a/packages/hub/src/wallet/models/channelState.ts
+++ b/packages/hub/src/wallet/models/channelState.ts
@@ -21,7 +21,7 @@ export default class ChannelState extends Model {
     },
     outcome: {
       relation: Model.HasManyRelation,
-      modelClass: `${__dirname}/outcome`,
+      modelClass: Outcome,
       join: {
         from: 'channel_states.id',
         to: 'outcomes.channel_state_id'

--- a/packages/hub/src/wallet/models/outcome.ts
+++ b/packages/hub/src/wallet/models/outcome.ts
@@ -26,7 +26,7 @@ export default class Outcome extends Model {
     },
     allocation: {
       relation: Model.HasManyRelation,
-      modelClass: `${__dirname}/allocation`,
+      modelClass: Allocation,
       join: {
         from: 'outcomes.id',
         to: 'allocations.outcome_id'
@@ -38,14 +38,14 @@ export default class Outcome extends Model {
   state!: ChannelState;
   assetHolderAddress!: Address;
   allocation!: Allocation[];
-  tagetChannelId: string;
+  targetChannelId: string;
 
   get asOutcomeObject(): AssetOutcome {
-    if (this.tagetChannelId) {
+    if (this.targetChannelId) {
       const guaranteeAssetOutcome: GuaranteeAssetOutcome = {
         assetHolderAddress: this.assetHolderAddress,
         guarantee: {
-          targetChannelId: this.tagetChannelId,
+          targetChannelId: this.targetChannelId,
           destinations: this.allocation.map(allocation => allocation.destination)
         }
       };

--- a/packages/hub/src/wallet/services/__test__/channelManager.test.ts
+++ b/packages/hub/src/wallet/services/__test__/channelManager.test.ts
@@ -2,7 +2,7 @@ import {State} from '@statechannels/nitro-protocol';
 import {signState} from '@statechannels/nitro-protocol/lib/src/signatures';
 import {Signature} from 'ethers/utils';
 import {HUB_PRIVATE_KEY} from '../../../constants';
-import {funded_channel, stateConstructors as testDataConstructors} from '../../../test/test_data';
+import {fundedChannel, stateConstructors as testDataConstructors} from '../../../test/test_data';
 import * as ChannelManager from '../channelManager';
 
 let pre_fund_setup_0: State;
@@ -18,7 +18,7 @@ beforeEach(() => {
 
   post_fund_setup_0 = testDataConstructors.post_fund_setup(2);
   post_fund_setup_1 = testDataConstructors.post_fund_setup(3);
-  app_0 = testDataConstructors.app(4, funded_channel);
+  app_0 = testDataConstructors.app(4, fundedChannel);
 
   hubSignature = signState(pre_fund_setup_1, HUB_PRIVATE_KEY).signature;
 });
@@ -42,7 +42,7 @@ describe('validSignature', () => {
 
 describe('formResponse', () => {
   it('returns a signed core state', async () => {
-    pre_fund_setup_1.channel = funded_channel;
+    pre_fund_setup_1.channel = fundedChannel;
 
     hubSignature = signState(pre_fund_setup_1, HUB_PRIVATE_KEY).signature;
 

--- a/packages/hub/src/wallet/services/__test__/ledgerChannelManager.test.ts
+++ b/packages/hub/src/wallet/services/__test__/ledgerChannelManager.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../test/test-constants';
 import {
   app_1_response,
-  beginning_app_phase_channel,
+  beginningAppPhaseChannel,
   created_pre_fund_setup_1,
   created_pre_fund_setup_3_2,
   post_fund_setup_1_response,
@@ -38,7 +38,7 @@ let post_fund_setup_3_1: State;
 beforeEach(() => {
   pre_fund_setup_0 = testDataConstructors.pre_fund_setup(0);
   post_fund_setup_0 = testDataConstructors.post_fund_setup(2);
-  app_0 = testDataConstructors.app(4, beginning_app_phase_channel);
+  app_0 = testDataConstructors.app(4, beginningAppPhaseChannel);
 
   pre_fund_setup_3_0 = testDataConstructors.pre_fund_setup_3(0);
   pre_fund_setup_3_1 = testDataConstructors.pre_fund_setup_3(1);

--- a/packages/hub/src/wallet/utilities/outcome.ts
+++ b/packages/hub/src/wallet/utilities/outcome.ts
@@ -1,15 +1,30 @@
 import {isAllocationOutcome, Outcome} from '@statechannels/nitro-protocol';
-import {AssetOutcome} from '@statechannels/nitro-protocol/lib/src/contract/outcome';
+import {
+  AssetOutcome,
+  isGuaranteeOutcome
+} from '@statechannels/nitro-protocol/lib/src/contract/outcome';
+import {unreachable} from '@statechannels/wallet';
 
-function assetOutcomeAddPriorities(assetOutcome: AssetOutcome) {
+function assetOutcomeObjectToModel(assetOutcome: AssetOutcome) {
   if (isAllocationOutcome(assetOutcome)) {
     const allocationsWithPriorities = assetOutcome.allocation.map((allocationItem, index) => ({
       ...allocationItem,
       priority: index
     }));
     return {...assetOutcome, allocation: allocationsWithPriorities};
+  } else if (isGuaranteeOutcome(assetOutcome)) {
+    const guaranteeWithPriorities = assetOutcome.guarantee.destinations.map(
+      (destination, index) => ({destination, priority: index})
+    );
+    return {
+      assetHolderAddress: assetOutcome.assetHolderAddress,
+      targetChannelId: assetOutcome.guarantee.targetChannelId,
+      allocation: guaranteeWithPriorities
+    };
+  } else {
+    unreachable(assetOutcome);
   }
 }
-export function outcomeAddPriorities(outcome: Outcome) {
-  return outcome.map(assetOutcomeAddPriorities);
+export function outcomeObjectToModel(outcome: Outcome) {
+  return outcome.map(assetOutcomeObjectToModel);
 }


### PR DESCRIPTION
Most important changes are in `packages/hub/src/wallet/utilities/outcome.ts`.

This PR: 
- tests converting a guarantor channel state stored in postgres to an object.
- opportunistically renames snake_case functions and constants to camelCase.