### PR TITLE
[wallet] Add Join Channel API

### DIFF
--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -394,6 +394,15 @@ export const postMessageResponse: ActionConstructor<PostMessageResponse> = p => 
   type: "WALLET.POST_MESSAGE_RESPONSE"
 });
 
+export interface JoinChannelResponse extends ApiAction {
+  type: "WALLET.JOIN_CHANNEL_RESPONSE";
+  channelId: string;
+}
+export const joinChannelResponse: ActionConstructor<JoinChannelResponse> = p => ({
+  ...p,
+  type: "WALLET.JOIN_CHANNEL_RESPONSE"
+});
+
 export type OutgoingApiAction =
   | AddressResponse
   | CreateChannelResponse
@@ -404,4 +413,5 @@ export type OutgoingApiAction =
   | ChannelProposedEvent
   | PostMessageResponse
   | UnknownChannelId
-  | NoContractError;
+  | NoContractError
+  | JoinChannelResponse;

--- a/packages/wallet/src/redux/sagas/__tests__/message-handler.test.ts
+++ b/packages/wallet/src/redux/sagas/__tests__/message-handler.test.ts
@@ -250,6 +250,7 @@ describe("message listener", () => {
         id: 1
       });
     });
+
     it("returns an error the first participant does not have our address", async () => {
       const destinationA = Wallet.createRandom().address;
       const signingAddressA = Wallet.createRandom().address;
@@ -380,6 +381,69 @@ describe("message listener", () => {
           channelId: unknownChannelId, // <----- important part of the test
           allocations: [],
           appData: "0x"
+        }
+      });
+
+      const {effects} = await expectSaga(messageHandler, requestMessage, "localhost")
+        .withState(initialState)
+        // Mock out the fork call so we don't actually try to post the message
+        .provide([[matchers.fork.fn(messageSender), 0]])
+        .run();
+
+      expect(effects.fork[0].payload.args[0]).toMatchObject({
+        type: "WALLET.UNKNOWN_CHANNEL_ID_ERROR",
+        id: 1,
+        channelId: unknownChannelId
+      });
+    });
+  });
+
+  describe("JoinChannel", () => {
+    it("handles an join channel request", async () => {
+      const existingState = appState({turnNum: 0});
+      const testChannel = channelFromStates([existingState], asAddress, asPrivateKey);
+
+      const requestMessage = JSON.stringify({
+        jsonrpc: "2.0",
+        method: "JoinChannel",
+        id: 1,
+        params: {
+          channelId: testChannel.channelId
+        }
+      });
+
+      const {effects} = await expectSaga(messageHandler, requestMessage, "localhost")
+        .withState({...initialState, channelStore: setChannel({}, testChannel)})
+        // Mock out the fork call so we don't actually try to post the message
+        .provide([[matchers.fork.fn(messageSender), 0]])
+        .run();
+
+      const nextState = {
+        ...existingState.state,
+        turnNum: 1
+      };
+
+      expect(effects.put[0].payload.action).toMatchObject({
+        type: "WALLET.APPLICATION.OWN_STATE_RECEIVED",
+        state: nextState
+      });
+
+      expect(effects.fork[0].payload.args[0]).toMatchObject({
+        type: "WALLET.JOIN_CHANNEL_RESPONSE",
+        id: 1,
+        channelId: testChannel.channelId
+      });
+    });
+
+    it("returns an error when the channelId is not known", async () => {
+      const unknownChannelId = "0xsomefakeid";
+
+      const requestMessage = JSON.stringify({
+        jsonrpc: "2.0",
+        method: "JoinChannel",
+        id: 1,
+        params: {
+          channelId: unknownChannelId
         }
       });
 

--- a/packages/wallet/src/redux/sagas/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/message-handler.ts
@@ -46,8 +46,37 @@ function* handleMessage(payload: RequestObject) {
     case "UpdateChannel":
       yield handleUpdateChannelMessage(payload);
       break;
+    case "JoinChannel":
+      yield handleJoinChannelMessage(payload);
+      break;
   }
 }
+
+function* handleJoinChannelMessage(payload: RequestObject) {
+  const {id} = payload;
+  const {channelId} = payload.params as any;
+
+  const channelExists = yield select(doesAStateExistForChannel, channelId);
+
+  if (!channelExists) {
+    yield fork(messageSender, actions.unknownChannelId({id, channelId}));
+  } else {
+    const lastState: State = yield select(getLastStateForChannel, channelId);
+
+    const newState = {...lastState, turnNum: lastState.turnNum + 1};
+    // We've already initialized the channel when we received the channel proposed message
+    // So we can just sign our state
+    yield put(
+      actions.application.ownStateReceived({
+        state: newState,
+        processId: APPLICATION_PROCESS_ID
+      })
+    );
+
+    yield fork(messageSender, actions.joinChannelResponse({channelId, id}));
+  }
+}
+
 function* handlePushMessage(payload: RequestObject) {
   // TODO: We need to handle the case where we receive an invalid wallet message
   const {id} = payload;

--- a/packages/wallet/src/redux/sagas/message-sender.ts
+++ b/packages/wallet/src/redux/sagas/message-sender.ts
@@ -14,9 +14,10 @@ export function* messageSender(action: OutgoingApiAction) {
 
 function* createResponseMessage(action: OutgoingApiAction) {
   switch (action.type) {
+    case "WALLET.JOIN_CHANNEL_RESPONSE":
+      return jrs.success(action.id, yield getChannelInfo(action.channelId));
     case "WALLET.CREATE_CHANNEL_RESPONSE":
-      const channelInfo = yield getChannelInfo(action.channelId);
-      return jrs.success(action.id, {...channelInfo});
+      return jrs.success(action.id, yield getChannelInfo(action.channelId));
     case "WALLET.UPDATE_CHANNEL_RESPONSE":
       return jrs.success(action.id, action.state);
     case "WALLET.ADDRESS_RESPONSE":


### PR DESCRIPTION
Fixes #436 

Adds support for the Join Channel api call.

Currently it updates the application protocol with the next state and returns success.