### PR TITLE
Don't use jest-gas-reporter when testing app

### DIFF
--- a/packages/rps/config/jest/jest.config.js
+++ b/packages/rps/config/jest/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   rootDir: root,
   collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
-  reporters: ['default', '@statechannels/jest-gas-reporter'],
+  reporters: ['default'],
   setupFiles: ['<rootDir>/config/polyfills.js'],
   setupFilesAfterEnv: ['<rootDir>/config/jest/jest.setup.js', '<rootDir>/src/setupTests.ts'],
   testMatch: ['<rootDir>/src/**/__tests__/?(*.)test.ts?(x)'],


### PR DESCRIPTION
If you try to load jest-gas-reporter when ganache isn't running, you get weird errors like:
```
Error: invalid response - 0
    at exports.XMLHttpRequest.request.onreadystatechange (~/magmo/monorepo/node_modules/ethers/utils/web.js:84:29)
```
We shouldn't need ganache (or jest-gas-reporter) when running app-only tests.