### PR TITLE
Remove deploy step in nitro-protocol local tests

### DIFF
--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -47,9 +47,8 @@
     "prettier:check": "npx prettier --check '{contracts,src,test}/**/*.{ts,tsx,sol}'",
     "prettier:write": "npx prettier --write '{contracts,src,test}/**/*.{ts,tsx,sol}'",
     "test:ci": "yarn contract:compile && npx jest --ci --bail --runInBand",
-    "test:prepare": "yarn deploy:test",
     "test:typescript": "npx jest --testPathIgnorePatterns='test/contracts' --reporters='default'",
-    "test": "yarn test:prepare && npx jest",
+    "test": "yarn contract:compile && npx jest",
     "website:deploy": "yarn contract:compile && yarn docgen && cd website && yarn install && yarn build"
   },
   "dependencies": {


### PR DESCRIPTION
We shouldn't need this anymore with the new shared contracts infrastructure.