### PR TITLE
Ignore local environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,9 @@ e2e.log
 
 # local env vars
 .env.local
+.env.*.local
 packages/**/.env.local
+packages/**/.env.*.local
 
 # licenses
 packages/**/LICENSE


### PR DESCRIPTION
Seems like `env.ts` doesn't actually use `.env.local` files, it uses `.env.{NODE_ENV}.local` files...

https://github.com/statechannels/monorepo/blob/bfc0b0240a6dfca146f0107bf616f8e2963af83b/packages/devtools/src/config/env.ts#L13:L13

I use `USE_NATIVE_SOLC` to make compilation times 10 faster (see #86) so I need this.