### PR TITLE
Fix netlify error

### DIFF
--- a/netlify-ignore.sh
+++ b/netlify-ignore.sh
@@ -1,28 +1,30 @@
 # Set this environment variable as appropriate in netlify UI config
 status=0
+git remote add origin https://github.com/statechannels/monorepo.git
+git fetch origin --quiet
 case $TARGET_PACKAGE in
 
     web3torrent)
         echo "Checking for changes across web3torrent, embedded-wallet and channel-provider packages..."
-        git diff --quiet origin/master HEAD ./packages/web3torrent ./packages/embedded-wallet ./packages/channel-provider
+        git diff --quiet origin/master HEAD -- ./packages/web3torrent ./packages/embedded-wallet ./packages/channel-provider
         status=$?
         ;;
 
     embedded-wallet)
         echo "Checking for changes across web3torrent, embedded-wallet and channel-provider packages..."
-        git diff --quiet origin/master HEAD ./packages/web3torrent ./packages/embedded-wallet ./packages/channel-provider
+        git diff --quiet origin/master HEAD -- ./packages/web3torrent ./packages/embedded-wallet ./packages/channel-provider
         status=$?
         ;;
 
     nitro-protocol)
         echo "Checking for changes in nitro-protocol package..."
-        git diff --quiet origin/master HEAD ./packages/nitro-protocol
+        git diff --quiet origin/master HEAD -- ./packages/nitro-protocol
         status=$?
         ;;
     
     app-wallet-interface)
         echo "Checking for changes in app-wallet-interface package..."
-        git diff --quiet origin/master HEAD ./packages/app-wallet-interface
+        git diff --quiet origin/master HEAD -- ./packages/app-wallet-interface
         status=$?
         ;;
 


### PR DESCRIPTION
Netlify does not seem to have upstream branches, meaning we cannot do a `git diff` to, e.g. `origin/master` .

Solution: add the remote and fetch as a part of our custom script.