### PR TITLE
Changes to channel client

### DIFF
--- a/packages/rps/src/utils/channel-client.ts
+++ b/packages/rps/src/utils/channel-client.ts
@@ -71,11 +71,32 @@ export interface Message {
   data: string;
 }
 
-export type PushMessageParameters = Message;
-
 export interface Funds {
   token: string;
   amount: string;
+}
+
+export interface CreateChannelParameters {
+  participants: Participant[];
+  allocations: Allocation[];
+  appData: string;
+  appDefinition: string;
+}
+export interface ChannelResult {
+  participants: Participant[];
+  allocations: Allocation[];
+  appData: string;
+  appDefinition: string;
+  channelId: string;
+  status: ChannelStatus;
+  funding: Funds[];
+  turnNum: BigNumberish;
+}
+
+export interface UpdateChannelParameters {
+  participants: Participant[];
+  allocations: Allocation[];
+  appData: string;
 }
 
 export interface JsonRPCNotification<Name, ParametersType> {
@@ -109,17 +130,6 @@ export interface JsonRPCErrorResponse<ErrorType extends JsonRPCError = JsonRPCEr
   error: ErrorType;
 }
 
-export interface CreateChannelParameters extends UpdateChannelParameters {
-  appDefinition: string;
-}
-
-export interface ChannelResult extends CreateChannelParameters {
-  channelId: string;
-  status: ChannelStatus;
-  funding: Funds[];
-  turnNum: BigNumberish;
-}
-
 // Requests and Responses
 // ======================
 
@@ -136,12 +146,6 @@ export interface JoinChannelParameters {
 export type JoinChannelRequest = JsonRPCRequest<'JoinChannel', JoinChannelParameters>;
 
 export interface JoinChannelResponse extends JsonRPCResponse<ChannelResult> {}
-
-export interface UpdateChannelParameters {
-  participants: Participant[];
-  allocations: Allocation[];
-  appData: string;
-}
 
 export type UpdateChannelRequest = JsonRPCRequest<'UpdateChannel', UpdateChannelParameters>;
 

--- a/packages/rps/src/utils/channel-client.ts
+++ b/packages/rps/src/utils/channel-client.ts
@@ -14,61 +14,25 @@ export enum ErrorCodes {
 }
 
 export interface Participant {
-  /**
-   * App allocated id, used for relaying messages to the participant
-   */
-  participantId: string;
-
-  /**
-   * Address used to sign channel updates
-   */
-  signingAddress: string;
-
-  /**
-   * Address of EOA to receive channel proceeds (the account that'll get the funds).
-   */
-  destination: string;
+  participantId: string; // App allocated id, used for relaying messages to the participant
+  signingAddress: string; // Address used to sign channel updates
+  destination: string; // Address of EOA to receive channel proceeds (the account that'll get the funds).
 }
 
 export interface AllocationItem {
-  /**
-   * Address of EOA to receive channel proceeds.
-   */
-  destination: string;
-
-  /**
-   * How much funds will be transferred to the destination address.
-   */
-  amount: BigNumberish;
+  destination: string; // Address of EOA to receive channel proceeds.
+  amount: BigNumberish; // How much funds will be transferred to the destination address.
 }
 
 export interface Allocation {
-  /**
-   * The token's contract address.
-   */
-  token: string;
-
-  /**
-   * A list of allocations (how much funds will each destination address get).
-   */
-  allocationItems: AllocationItem[];
+  token: string; // The token's contract address.
+  allocationItems: AllocationItem[]; // A list of allocations (how much funds will each destination address get).
 }
 
 export interface Message {
-  /**
-   * Identifier of user that the message should be relayed to
-   */
-  recipient: string;
-
-  /**
-   * Identifier of user that the message is from
-   */
-  sender: string;
-
-  /**
-   * Message payload. Format defined by wallet and opaque to app.
-   */
-  data: string;
+  recipient: string; // Identifier of user that the message should be relayed to
+  sender: string; // Identifier of user that the message is from
+  data: string; // Message payload. Format defined by wallet and opaque to app.
 }
 
 export interface Funds {


### PR DESCRIPTION
There are a lot of types defined in the channel client, which end up being a lot of information to process. This PR attempts to simplify the types and their relationships, e.g. by using less inheritance.