### PR TITLE
[Wallet] Allow tests to run without requiring ganache

### DIFF
--- a/packages/wallet/config/jest/jest.contracts.config.js
+++ b/packages/wallet/config/jest/jest.contracts.config.js
@@ -3,5 +3,5 @@ let config = require("./jest.config");
 module.exports = {
   ...config,
   testMatch: ["<rootDir>/src/**/contract-tests/?(*.)test.ts?(x)"],
-  setupFilesAfterEnv: [] // We don't want to run a test setup that mocks out contract related utils
+  setupFilesAfterEnv: ["<rootDir>/src/setupContractTests.ts"]
 };

--- a/packages/wallet/config/jest/jest.contracts.config.js
+++ b/packages/wallet/config/jest/jest.contracts.config.js
@@ -3,4 +3,5 @@ let config = require("./jest.config");
 module.exports = {
   ...config,
   testMatch: ["<rootDir>/src/**/contract-tests/?(*.)test.ts?(x)"],
+  setupFilesAfterEnv: [] // We don't want to run a test setup that mocks out contract related utils
 };

--- a/packages/wallet/src/setupContractTests.ts
+++ b/packages/wallet/src/setupContractTests.ts
@@ -1,0 +1,1 @@
+import "../config/env";

--- a/packages/wallet/src/setupTests.ts
+++ b/packages/wallet/src/setupTests.ts
@@ -3,5 +3,22 @@ import Adapter from "enzyme-adapter-react-16";
 
 // Load environment variables from .env
 import "../config/env";
+import {AddressZero} from "ethers/constants";
 
 Enzyme.configure({adapter: new Adapter()});
+
+// Mock out util functions that require a networkContext
+jest.mock("./utils/contract-utils.ts", () => ({
+  getContractAddress: jest.fn(() => AddressZero),
+  getNetworkId: jest.fn(() => 3),
+  getETHAssetHolderAddress: jest.fn(() => AddressZero),
+  getAdjudicatorContractAddress: jest.fn(() => AddressZero),
+  // tslint:disable-next-line: no-empty
+  getAdjudicatorContract: jest.fn(() => {}),
+  getConsensusContractAddress: jest.fn(() => AddressZero),
+  getProvider: jest.fn(() => {
+    return {
+      getCode: jest.fn(() => "0x0")
+    };
+  })
+}));


### PR DESCRIPTION
Mocks out some contract-utils to allow tests to pass when the `ganache-deployer` isn't running.