### PR TITLE
[wallet] Send Message to opponent's wallet when joining a channel

### DIFF
--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -396,6 +396,18 @@ export const sendChannelProposedMessage: ActionConstructor<SendChannelProposedMe
   type: "WALLET.SEND_CHANNEL_PROPOSED_MESSAGE"
 });
 
+export interface SendChannelJoinedMessage {
+  type: "WALLET.SEND_CHANNEL_JOINED_MESSAGE";
+  channelId: string;
+  toParticipantId: string;
+  fromParticipantId: string;
+}
+
+export const sendChannelJoinedMessage: ActionConstructor<SendChannelJoinedMessage> = p => ({
+  ...p,
+  type: "WALLET.SEND_CHANNEL_JOINED_MESSAGE"
+});
+
 export interface ChannelProposedEvent {
   type: "WALLET.CHANNEL_PROPOSED_EVENT";
   channelId: string;
@@ -439,6 +451,7 @@ export type OutgoingApiAction =
   | UnknownSigningAddress
   | NoContractError
   | SendChannelProposedMessage
+  | SendChannelJoinedMessage
   | ChannelProposedEvent
   | PostMessageResponse
   | UnknownChannelId

--- a/packages/wallet/src/redux/sagas/__tests__/message-handler.test.ts
+++ b/packages/wallet/src/redux/sagas/__tests__/message-handler.test.ts
@@ -42,7 +42,7 @@ describe("message listener", () => {
   });
 
   describe("PushMessage", () => {
-    it("handles a pushMessage", async () => {
+    it("handles a pushMessage with a channel open message", async () => {
       const signedState = appState({turnNum: 0});
       const destinationA = Wallet.createRandom().address;
       const signingAddressA = asAddress;
@@ -106,6 +106,43 @@ describe("message listener", () => {
       expect(effects.fork[1].payload.args[0]).toMatchObject({
         type: "WALLET.CHANNEL_PROPOSED_EVENT",
         channelId: expect.any(String)
+      });
+    });
+
+    it("handles a pushMessage with a channel joined message", async () => {
+      const signedState = appState({turnNum: 0});
+
+      const pushMessage = {
+        jsonrpc: "2.0",
+        method: "PushMessage",
+        id: 1,
+        params: {
+          recipient: "user-a",
+          sender: "user-b",
+          data: {type: "Channel.Joined", signedState}
+        }
+      };
+
+      const {effects} = await expectSaga(messageHandler, pushMessage, "localhost")
+        .withState(initialState)
+        // Mock out the fork call so we don't actually try to post the message
+        .provide([
+          [matchers.fork.fn(messageSender), 0],
+          [matchers.select.selector(getAddress), asAddress],
+          [
+            matchers.call.fn(getProvider),
+            {
+              getCode: address => {
+                return "0x12345";
+              }
+            }
+          ]
+        ])
+        .run();
+
+      expect(effects.put[0].payload.action).toMatchObject({
+        type: "WALLET.APPLICATION.OPPONENT_STATE_RECEIVED",
+        signedState
       });
     });
   });
@@ -438,6 +475,10 @@ describe("message listener", () => {
       expect(effects.fork[0].payload.args[0]).toMatchObject({
         type: "WALLET.JOIN_CHANNEL_RESPONSE",
         id: 1,
+        channelId: testChannel.channelId
+      });
+      expect(effects.fork[1].payload.args[0]).toMatchObject({
+        type: "WALLET.SEND_CHANNEL_JOINED_MESSAGE",
         channelId: testChannel.channelId
       });
     });

--- a/packages/wallet/src/redux/sagas/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/message-handler.ts
@@ -3,7 +3,12 @@ import {getChannelId, State} from "@statechannels/nitro-protocol";
 import jrs, {RequestObject} from "jsonrpc-lite";
 
 import * as actions from "../actions";
-import {getAddress, getLastStateForChannel, doesAStateExistForChannel} from "../selectors";
+import {
+  getAddress,
+  getLastStateForChannel,
+  doesAStateExistForChannel,
+  getParticipants
+} from "../selectors";
 import {messageSender} from "./message-sender";
 import {APPLICATION_PROCESS_ID} from "../protocols/application/reducer";
 import {
@@ -80,6 +85,17 @@ function* handleJoinChannelMessage(payload: RequestObject) {
     );
 
     yield fork(messageSender, actions.joinChannelResponse({channelId, id}));
+    const address = yield select(getAddress);
+    const participants = yield select(getParticipants, channelId);
+    // We assume a two player channel
+    const {participantId: fromParticipantId} =
+      participants[0].signingAddress === address ? participants[0] : participants[1];
+    const {participantId: toParticipantId} =
+      participants[0].signingAddress !== address ? participants[0] : participants[1];
+    yield fork(
+      messageSender,
+      actions.sendChannelJoinedMessage({channelId, toParticipantId, fromParticipantId})
+    );
   }
 }
 
@@ -88,6 +104,14 @@ function* handlePushMessage(payload: RequestObject) {
   const {id} = payload;
   const message = payload.params as JsonRpcMessage;
   switch (message.data.type) {
+    case "Channel.Joined":
+      yield put(
+        actions.application.opponentStateReceived({
+          processId: APPLICATION_PROCESS_ID,
+          signedState: message.data.signedState
+        })
+      );
+      break;
     case "Channel.Open":
       const {signedState, participants} = message.data;
       // The channel gets initialized and the state will be pushed into the app protocol

--- a/packages/wallet/src/redux/sagas/message-sender.ts
+++ b/packages/wallet/src/redux/sagas/message-sender.ts
@@ -34,17 +34,29 @@ function* createResponseMessage(action: OutgoingApiAction) {
         new jrs.JsonRpcError("Signing address not found in the participants array", 1000)
       );
     case "WALLET.SEND_CHANNEL_PROPOSED_MESSAGE":
-      const channelStatus: ChannelState = yield select(getChannelStatus, action.channelId);
+      const proposedChannelStatus: ChannelState = yield select(getChannelStatus, action.channelId);
 
-      const request = {
+      const openRequest = {
         type: "Channel.Open",
-        signedState: channelStatus.signedStates.slice(-1)[0],
-        participants: channelStatus.participants
+        signedState: proposedChannelStatus.signedStates.slice(-1)[0],
+        participants: proposedChannelStatus.participants
       };
       return jrs.notification("MessageQueued", {
         recipient: action.fromParticipantId,
         sender: action.toParticipantId,
-        data: request
+        data: openRequest
+      });
+    case "WALLET.SEND_CHANNEL_JOINED_MESSAGE":
+      const joinChannelState: ChannelState = yield select(getChannelStatus, action.channelId);
+      const joinedMessage = {
+        type: "Channel.Joined",
+        signedState: joinChannelState.signedStates.slice(-1)[0],
+        participants: joinChannelState.participants
+      };
+      return jrs.notification("MessageQueued", {
+        recipient: action.fromParticipantId,
+        sender: action.toParticipantId,
+        data: joinedMessage
       });
     case "WALLET.CHANNEL_PROPOSED_EVENT":
       return jrs.notification("ChannelProposed", yield getChannelInfo(action.channelId));

--- a/packages/wallet/src/utils/json-rpc-utils.ts
+++ b/packages/wallet/src/utils/json-rpc-utils.ts
@@ -44,7 +44,11 @@ interface OpenChannel {
   participants: ChannelParticipant[];
   signedState: SignedState;
 }
-type WalletMessage = OpenChannel;
+interface ChannelJoined {
+  type: "Channel.Joined";
+  signedState: SignedState;
+}
+type WalletMessage = OpenChannel | ChannelJoined;
 
 export interface JsonRpcUpdateChannelParams {
   allocations: JsonRpcAllocations;


### PR DESCRIPTION
Send a message to the opponent's wallet when joining a channel. This allows your opponent to continue funding.