### PR TITLE
[wallet/nitro-protocol] Comment out pure-evm use

### DIFF
--- a/packages/nitro-protocol/src/contract/consensus-app.ts
+++ b/packages/nitro-protocol/src/contract/consensus-app.ts
@@ -1,13 +1,8 @@
-import {Buffer} from 'buffer';
-import {Interface, defaultAbiCoder} from 'ethers/utils';
-import PureEVM from 'pure-evm';
-
-import ConsensusAppArtifact from '../../build/contracts/ConsensusApp.json';
 import {ConsensusData, encodeConsensusData} from './consensus-data';
 import {encodeOutcome, Outcome} from './outcome';
 import {VariablePart} from './state';
 
-const ConsensusAppContractInterface = new Interface(ConsensusAppArtifact.abi);
+// const ConsensusAppContractInterface = new Interface(ConsensusAppArtifact.abi);
 
 export function getVariablePart(consensusData: ConsensusData, outcome: Outcome): VariablePart {
   const appData = encodeConsensusData(consensusData);
@@ -23,23 +18,26 @@ export function validTransition(
   toOutcome: Outcome,
   numberOfParticipants: number
 ): boolean {
-  const fromVariablePart = getVariablePart(fromConsensusData, fromOutcome);
-  const toVariablePart = getVariablePart(toConsensusData, toOutcome);
-  const turnNumB = 0; // This isn't actually used by the contract so any value works
+  return true;
+  // TODO: Enable this once pure-evm can be loaded from the browser
+  // see https://github.com/statechannels/monorepo/issues/537
+  // const fromVariablePart = getVariablePart(fromConsensusData, fromOutcome);
+  // const toVariablePart = getVariablePart(toConsensusData, toOutcome);
+  // const turnNumB = 0; // This isn't actually used by the contract so any value works
 
-  const iface = new Interface(ConsensusAppContractInterface.abi);
+  // const iface = new Interface(ConsensusAppContractInterface.abi);
 
-  const txData = iface.functions.validTransition.encode([
-    fromVariablePart,
-    toVariablePart,
-    turnNumB,
-    numberOfParticipants,
-  ]);
+  // const txData = iface.functions.validTransition.encode([
+  //   fromVariablePart,
+  //   toVariablePart,
+  //   turnNumB,
+  //   numberOfParticipants,
+  // ]);
 
-  const result = PureEVM.exec(
-    Uint8Array.from(Buffer.from(ConsensusAppArtifact.bytecode.substr(2), 'hex')),
-    Uint8Array.from(Buffer.from(txData.substr(2), 'hex'))
-  );
+  // const result = PureEVM.exec(
+  //   Uint8Array.from(Buffer.from(ConsensusAppArtifact.bytecode.substr(2), 'hex')),
+  //   Uint8Array.from(Buffer.from(txData.substr(2), 'hex'))
+  // );
 
-  return defaultAbiCoder.decode(['bool'], result)[0] as boolean;
+  // return defaultAbiCoder.decode(['bool'], result)[0] as boolean;
 }

--- a/packages/nitro-protocol/src/contract/consensus-app.ts
+++ b/packages/nitro-protocol/src/contract/consensus-app.ts
@@ -2,7 +2,7 @@ import {ConsensusData, encodeConsensusData} from './consensus-data';
 import {encodeOutcome, Outcome} from './outcome';
 import {VariablePart} from './state';
 
-// const ConsensusAppContractInterface = new Interface(ConsensusAppArtifact.abi);
+// Const ConsensusAppContractInterface = new Interface(ConsensusAppArtifact.abi);
 
 export function getVariablePart(consensusData: ConsensusData, outcome: Outcome): VariablePart {
   const appData = encodeConsensusData(consensusData);
@@ -20,24 +20,24 @@ export function validTransition(
 ): boolean {
   return true;
   // TODO: Enable this once pure-evm can be loaded from the browser
-  // see https://github.com/statechannels/monorepo/issues/537
-  // const fromVariablePart = getVariablePart(fromConsensusData, fromOutcome);
-  // const toVariablePart = getVariablePart(toConsensusData, toOutcome);
-  // const turnNumB = 0; // This isn't actually used by the contract so any value works
+  // See https://github.com/statechannels/monorepo/issues/537
+  // Const fromVariablePart = getVariablePart(fromConsensusData, fromOutcome);
+  // Const toVariablePart = getVariablePart(toConsensusData, toOutcome);
+  // Const turnNumB = 0; // This isn't actually used by the contract so any value works
 
-  // const iface = new Interface(ConsensusAppContractInterface.abi);
+  // Const iface = new Interface(ConsensusAppContractInterface.abi);
 
-  // const txData = iface.functions.validTransition.encode([
-  //   fromVariablePart,
-  //   toVariablePart,
-  //   turnNumB,
-  //   numberOfParticipants,
+  // Const txData = iface.functions.validTransition.encode([
+  //   FromVariablePart,
+  //   ToVariablePart,
+  //   TurnNumB,
+  //   NumberOfParticipants,
   // ]);
 
-  // const result = PureEVM.exec(
+  // Const result = PureEVM.exec(
   //   Uint8Array.from(Buffer.from(ConsensusAppArtifact.bytecode.substr(2), 'hex')),
   //   Uint8Array.from(Buffer.from(txData.substr(2), 'hex'))
   // );
 
-  // return defaultAbiCoder.decode(['bool'], result)[0] as boolean;
+  // Return defaultAbiCoder.decode(['bool'], result)[0] as boolean;
 }

--- a/packages/nitro-protocol/src/contract/force-move-app.ts
+++ b/packages/nitro-protocol/src/contract/force-move-app.ts
@@ -8,25 +8,25 @@ export const ForceMoveAppContractInterface = new Interface(ForceMoveAppArtifact.
 export function validTransition(fromState: State, toState: State, appBytecode: string): boolean {
   return true;
   // TODO: Enable this once pure-evm can be loaded from the browser
-  // see https://github.com/statechannels/monorepo/issues/537
-  // const numberOfParticipants = toState.channel.participants.length;
-  // const fromVariablePart = getVariablePart(fromState);
-  // const toVariablePart = getVariablePart(toState);
-  // const turnNumB = toState.turnNum;
+  // See https://github.com/statechannels/monorepo/issues/537
+  // Const numberOfParticipants = toState.channel.participants.length;
+  // Const fromVariablePart = getVariablePart(fromState);
+  // Const toVariablePart = getVariablePart(toState);
+  // Const turnNumB = toState.turnNum;
 
-  // const iface = new Interface(ForceMoveAppContractInterface.abi);
+  // Const iface = new Interface(ForceMoveAppContractInterface.abi);
 
-  // const txData = iface.functions.validTransition.encode([
-  //   fromVariablePart,
-  //   toVariablePart,
-  //   turnNumB,
-  //   numberOfParticipants,
+  // Const txData = iface.functions.validTransition.encode([
+  //   FromVariablePart,
+  //   ToVariablePart,
+  //   TurnNumB,
+  //   NumberOfParticipants,
   // ]);
 
-  // const result = PureEVM.exec(
+  // Const result = PureEVM.exec(
   //   Uint8Array.from(Buffer.from(appBytecode.substr(2), 'hex')),
   //   Uint8Array.from(Buffer.from(txData.substr(2), 'hex'))
   // );
 
-  // return defaultAbiCoder.decode(['bool'], result)[0] as boolean;
+  // Return defaultAbiCoder.decode(['bool'], result)[0] as boolean;
 }

--- a/packages/nitro-protocol/src/contract/force-move-app.ts
+++ b/packages/nitro-protocol/src/contract/force-move-app.ts
@@ -1,31 +1,32 @@
-import {Buffer} from 'buffer';
-import {Interface, defaultAbiCoder} from 'ethers/utils';
-import PureEVM from 'pure-evm';
+import {Interface} from 'ethers/utils';
 
 import ForceMoveAppArtifact from '../../build/contracts/ForceMoveApp.json';
-import {getVariablePart, State} from '../contract/state';
+import {State} from '../contract/state';
 
 export const ForceMoveAppContractInterface = new Interface(ForceMoveAppArtifact.abi);
 
 export function validTransition(fromState: State, toState: State, appBytecode: string): boolean {
-  const numberOfParticipants = toState.channel.participants.length;
-  const fromVariablePart = getVariablePart(fromState);
-  const toVariablePart = getVariablePart(toState);
-  const turnNumB = toState.turnNum;
+  return true;
+  // TODO: Enable this once pure-evm can be loaded from the browser
+  // see https://github.com/statechannels/monorepo/issues/537
+  // const numberOfParticipants = toState.channel.participants.length;
+  // const fromVariablePart = getVariablePart(fromState);
+  // const toVariablePart = getVariablePart(toState);
+  // const turnNumB = toState.turnNum;
 
-  const iface = new Interface(ForceMoveAppContractInterface.abi);
+  // const iface = new Interface(ForceMoveAppContractInterface.abi);
 
-  const txData = iface.functions.validTransition.encode([
-    fromVariablePart,
-    toVariablePart,
-    turnNumB,
-    numberOfParticipants,
-  ]);
+  // const txData = iface.functions.validTransition.encode([
+  //   fromVariablePart,
+  //   toVariablePart,
+  //   turnNumB,
+  //   numberOfParticipants,
+  // ]);
 
-  const result = PureEVM.exec(
-    Uint8Array.from(Buffer.from(appBytecode.substr(2), 'hex')),
-    Uint8Array.from(Buffer.from(txData.substr(2), 'hex'))
-  );
+  // const result = PureEVM.exec(
+  //   Uint8Array.from(Buffer.from(appBytecode.substr(2), 'hex')),
+  //   Uint8Array.from(Buffer.from(txData.substr(2), 'hex'))
+  // );
 
-  return defaultAbiCoder.decode(['bool'], result)[0] as boolean;
+  // return defaultAbiCoder.decode(['bool'], result)[0] as boolean;
 }

--- a/packages/wallet/src/redux/channel-store/channel-state/valid-transition.ts
+++ b/packages/wallet/src/redux/channel-store/channel-state/valid-transition.ts
@@ -1,14 +1,6 @@
 import {ChannelState} from "./states";
-import {
-  getChannelId,
-  State,
-  SignedState,
-  getVariablePart,
-  ForceMoveAppContractInterface
-} from "@statechannels/nitro-protocol";
+import {getChannelId, State, SignedState} from "@statechannels/nitro-protocol";
 import {hasValidSignature} from "../../../utils/signing-utils";
-import {Interface, defaultAbiCoder} from "ethers/utils";
-import PureEVM from "pure-evm";
 
 export function validTransition(channelState: ChannelState, state: State): boolean {
   const channelNonce = state.channel.channelNonce;
@@ -35,26 +27,25 @@ export function validAppTransition(
   toState: State,
   bytecode: string
 ): boolean {
-  const fromState = channelState.signedStates[channelState.signedStates.length - 1].state;
-
-  const numberOfParticipants = toState.channel.participants.length;
-  const fromVariablePart = getVariablePart(fromState);
-  const toVariablePart = getVariablePart(toState);
-  const turnNumB = toState.turnNum;
-
-  const txData = new Interface(ForceMoveAppContractInterface.abi).functions.validTransition.encode([
-    fromVariablePart,
-    toVariablePart,
-    turnNumB,
-    numberOfParticipants
-  ]);
-
-  const result = PureEVM.exec(
-    Uint8Array.from(Buffer.from(bytecode.substr(2), "hex")),
-    Uint8Array.from(Buffer.from(txData.substr(2), "hex"))
-  );
-
-  return defaultAbiCoder.decode(["bool"], result)[0] as boolean;
+  return true;
+  // TODO: Enable this once pure-evm can be loaded from the browser
+  // see https://github.com/statechannels/monorepo/issues/537
+  // const fromState = channelState.signedStates[channelState.signedStates.length - 1].state;
+  // const numberOfParticipants = toState.channel.participants.length;
+  // const fromVariablePart = getVariablePart(fromState);
+  // const toVariablePart = getVariablePart(toState);
+  // const turnNumB = toState.turnNum;
+  // const txData = new Interface(ForceMoveAppContractInterface.abi).functions.validTransition.encode([
+  //   fromVariablePart,
+  //   toVariablePart,
+  //   turnNumB,
+  //   numberOfParticipants
+  // ]);
+  // const result = PureEVM.exec(
+  //   Uint8Array.from(Buffer.from(bytecode.substr(2), "hex")),
+  //   Uint8Array.from(Buffer.from(txData.substr(2), "hex"))
+  // );
+  // return defaultAbiCoder.decode(["bool"], result)[0] as boolean;
 }
 
 export function validTransitions(states: SignedState[]): boolean {


### PR DESCRIPTION
Due to #537 the wallet cannot load in the browser. This PR comments out the `pure-evm` usage so the wallet loads properly.

Once #537 is resolved this should be reverted.