### PR TITLE
Hub: rename variables from snake_case to camelCase

### DIFF
--- a/packages/hub/src/hub/handlers/__test__/handle-ongoing-process-action.test.ts
+++ b/packages/hub/src/hub/handlers/__test__/handle-ongoing-process-action.test.ts
@@ -7,7 +7,7 @@ import {handleOngoingProcessAction} from '../handle-ongoing-process-action';
 
 describe('handle-ongoing-process-action', () => {
   it('postfund signed states received', async () => {
-    const state: State = stateConstructors.post_fund_setup(2);
+    const state: State = stateConstructors.postfundSetup(2);
     const signedStatesReceivedAction: SignedStatesReceived = {
       type: 'WALLET.COMMON.SIGNED_STATES_RECEIVED',
       processId: '1234',
@@ -21,6 +21,6 @@ describe('handle-ongoing-process-action', () => {
     const states: State[] = messageReleayRequested[0].messagePayload.signedStates.map(
       signedState => signedState.state
     );
-    expect(states).toEqual([state, stateConstructors.post_fund_setup(3)]);
+    expect(states).toEqual([state, stateConstructors.postfundSetup(3)]);
   });
 });

--- a/packages/hub/src/test/test_data.ts
+++ b/packages/hub/src/test/test_data.ts
@@ -83,12 +83,12 @@ export const FUNDED_GUARANTOR_CHANNEL_ID = getChannelId(fundedGuarantorChannel);
 export const BEGINNING_APP_CHANNEL_ID = getChannelId(beginningAppPhaseChannel);
 export const ONGOING_APP_CHANNEL_ID = getChannelId(ongoingAppPhaseChannel);
 
-export const consensus_app_data2 = (n: number): ConsensusData => ({
+export const consensusAppData2 = (n: number): ConsensusData => ({
   furtherVotesRequired: n,
   proposedOutcome: allocationOutcome2
 });
 
-export const consensus_app_data3 = (n: number): ConsensusData => ({
+export const consensusAppData3 = (n: number): ConsensusData => ({
   furtherVotesRequired: n,
   proposedOutcome: allocationOutcome3
 });
@@ -99,37 +99,37 @@ const baseState = (turnNum: number) => ({
   challengeDuration: 1000,
   outcome: allocationOutcome2,
   appDefinition: DUMMY_RULES_ADDRESS,
-  appData: encodeConsensusData(consensus_app_data2(0))
+  appData: encodeConsensusData(consensusAppData2(0))
 });
 
 const baseState3 = (turnNum: number) => ({
   ...baseState(turnNum),
   outcome: allocationOutcome3,
-  appData: encodeConsensusData(consensus_app_data3(0))
+  appData: encodeConsensusData(consensusAppData3(0))
 });
 
-function pre_fund_setup(turnNum: number): State {
+function prefundSetup(turnNum: number): State {
   return {
     ...baseState(turnNum),
     channel: {...defaultChannel}
   };
 }
 
-export function pre_fund_setup_3(turnNum: number): State {
+export function prefundSetup3(turnNum: number): State {
   return {
     ...baseState3(turnNum),
     channel: {...defaultChannel3}
   };
 }
 
-function post_fund_setup(turnNum: number): State {
+function postfundSetup(turnNum: number): State {
   return {
     ...baseState(turnNum),
     channel: {...fundedChannel}
   };
 }
 
-export function post_fund_setup_3(turnNum: number): State {
+export function postfundSetup3(turnNum: number): State {
   return {
     ...baseState3(turnNum),
     channel: {...fundedChannel3}
@@ -140,19 +140,19 @@ function app(turnNum: number, channel: Channel): State {
   return {
     ...baseState(turnNum),
     channel,
-    appData: encodeConsensusData(consensus_app_data2((turnNum + 1) % channel.participants.length))
+    appData: encodeConsensusData(consensusAppData2((turnNum + 1) % channel.participants.length))
   };
 }
 
 export const stateConstructors = {
-  pre_fund_setup,
-  post_fund_setup,
+  prefundSetup,
+  postfundSetup,
   app,
-  pre_fund_setup_3,
-  post_fund_setup_3
+  prefundSetup3,
+  postfundSetup3
 };
 
-const base_response = {
+const baseResponse = {
   channel: {
     channelNonce: expect.any(String),
     participants: PARTICIPANTS,
@@ -164,7 +164,7 @@ const base_response = {
   isFinal: false
 };
 
-const base_response_3 = {
+const baseResponse3 = {
   channel: {
     channelNonce: expect.any(String),
     participants: PARTICIPANTS_3,
@@ -177,61 +177,61 @@ const base_response_3 = {
 };
 
 // Ledger Channel Manager Responses
-export const pre_fund_setup_1_response: State = {
-  ...base_response,
+export const prefundSetup1Response: State = {
+  ...baseResponse,
   turnNum: 1,
-  appData: encodeConsensusData(consensus_app_data2(0))
+  appData: encodeConsensusData(consensusAppData2(0))
 };
 
-export const pre_fund_setup_3_2_response: State = {
-  ...base_response_3,
+export const prefundSetup2Response3: State = {
+  ...baseResponse3,
   turnNum: 2,
-  appData: encodeConsensusData(consensus_app_data3(0))
+  appData: encodeConsensusData(consensusAppData3(0))
 };
 
-export const post_fund_setup_1_response: State = {
-  ...base_response,
+export const postfundSetup1Response: State = {
+  ...baseResponse,
   turnNum: 3,
-  appData: encodeConsensusData(consensus_app_data2(0)),
+  appData: encodeConsensusData(consensusAppData2(0)),
   channel: fundedChannel
 };
 
-export const post_fund_setup_3_2_response: State = {
-  ...base_response_3,
+export const postfundSetup2Response3: State = {
+  ...baseResponse3,
   turnNum: 5,
-  appData: encodeConsensusData(consensus_app_data3(0)),
+  appData: encodeConsensusData(consensusAppData3(0)),
   channel: fundedChannel3
 };
 
-export const app_1_response: State = {
-  ...base_response,
+export const app1Response: State = {
+  ...baseResponse,
   turnNum: 5,
   appData: encodeConsensusData({proposedOutcome: [], furtherVotesRequired: 0}),
   channel: beginningAppPhaseChannel
 };
 
 // Ledger Channel Manager input states
-export const created_pre_fund_setup_1: State = {
+export const createdPrefundSetup1: State = {
   channel: defaultChannel,
   turnNum: 1,
   outcome: allocationOutcome2,
-  appData: encodeConsensusData(consensus_app_data2(1)),
+  appData: encodeConsensusData(consensusAppData2(1)),
   isFinal: false,
   challengeDuration: 1000,
   appDefinition: DUMMY_RULES_ADDRESS
 };
 
-export const created_pre_fund_setup_3_2: State = {
+export const createdPrefundSetup2Participants3: State = {
   channel: defaultChannel3,
   turnNum: 2,
   outcome: allocationOutcome3,
-  appData: encodeConsensusData(consensus_app_data3(1)),
+  appData: encodeConsensusData(consensusAppData3(1)),
   isFinal: false,
   challengeDuration: 1000,
   appDefinition: DUMMY_RULES_ADDRESS
 };
 
-export const created_channel = {
+export const createdChannel = {
   id: expect.any(Number),
   participants: [{address: PARTICIPANT_1_ADDRESS}, {address: HUB_ADDRESS}],
   chainId: DUMMY_CHAIN_ID

--- a/packages/hub/src/wallet/__test__/wallet.test.ts
+++ b/packages/hub/src/wallet/__test__/wallet.test.ts
@@ -2,15 +2,15 @@ import {State} from '@statechannels/nitro-protocol';
 import Wallet from '..';
 import {stateConstructors as testDataConstructors} from '../../test/test_data';
 
-let pre_fund_setup_0: State;
+let preFundSetup0: State;
 
 beforeEach(() => {
-  pre_fund_setup_0 = testDataConstructors.pre_fund_setup(0);
+  preFundSetup0 = testDataConstructors.prefundSetup(0);
 });
 
 describe('sanitize', () => {
   it('sanitizes application attributes with the sanitize method it was passed', async () => {
     const wallet = new Wallet(() => '0xf00');
-    expect(wallet.sanitize(pre_fund_setup_0.appData)).toEqual('0xf00');
+    expect(wallet.sanitize(preFundSetup0.appData)).toEqual('0xf00');
   });
 });

--- a/packages/hub/src/wallet/db/queries/__test__/channels.test.ts
+++ b/packages/hub/src/wallet/db/queries/__test__/channels.test.ts
@@ -1,6 +1,6 @@
 import {errors} from '../../..';
 import {
-  created_channel,
+  createdChannel,
   fundedChannel,
   stateConstructors as testDataConstructors
 } from '../../../../test/test_data';
@@ -19,13 +19,13 @@ import {queries} from '../channels';
 describe('updateChannel', () => {
   describe('when theirState is a PreFundSetup', () => {
     it("works when the channel doesn't exist", async () => {
-      const allocator_channel = await queries.updateChannel(
-        [testDataConstructors.pre_fund_setup(0)],
-        testDataConstructors.pre_fund_setup(1)
+      const allocatorChannel = await queries.updateChannel(
+        [testDataConstructors.prefundSetup(0)],
+        testDataConstructors.prefundSetup(1)
       );
       expect.assertions(5);
 
-      expect(allocator_channel).toMatchObject(created_channel);
+      expect(allocatorChannel).toMatchObject(createdChannel);
       expect((await knex('channels').select('*')).length).toEqual(SEEDED_CHANNELS + 1);
       expect((await knex('channel_states').select('*')).length).toEqual(SEEDED_STATES + 2);
 
@@ -37,9 +37,9 @@ describe('updateChannel', () => {
     });
 
     it('throws when the channel exists', async () => {
-      const theirState = testDataConstructors.pre_fund_setup(0);
+      const theirState = testDataConstructors.prefundSetup(0);
       theirState.channel = fundedChannel;
-      const hubState = testDataConstructors.pre_fund_setup(1);
+      const hubState = testDataConstructors.prefundSetup(1);
       expect.assertions(1);
       await queries.updateChannel([theirState], hubState).catch(err => {
         expect(err).toMatchObject(errors.CHANNEL_EXISTS);
@@ -49,30 +49,30 @@ describe('updateChannel', () => {
 
   describe('when theirState is not a PreFundSetup', () => {
     it('works when the channel exists', async () => {
-      const {channelNonce} = testDataConstructors.post_fund_setup(2).channel;
-      const existing_allocator_channel = await Channel.query()
+      const {channelNonce} = testDataConstructors.postfundSetup(2).channel;
+      const existingAllocatorChannel = await Channel.query()
         .findOne({channel_nonce: channelNonce})
         .eager('[states.[outcome.[allocation]], participants, holdings]');
 
-      expect(existing_allocator_channel).toMatchObject(seeds.fundedChannelWithStates);
+      expect(existingAllocatorChannel).toMatchObject(seeds.fundedChannelWithStates);
 
-      const updated_allocator_channel = await queries.updateChannel(
-        [testDataConstructors.post_fund_setup(2)],
-        testDataConstructors.post_fund_setup(3)
+      const updatedAllocatorChannel = await queries.updateChannel(
+        [testDataConstructors.postfundSetup(2)],
+        testDataConstructors.postfundSetup(3)
       );
 
-      expect(updated_allocator_channel).toMatchObject({
+      expect(updatedAllocatorChannel).toMatchObject({
         ...seeds.fundedChannelWithStates,
         states: [
-          seedDataConstructors.postFundSetupState(2),
-          seedDataConstructors.postFundSetupState(3)
+          seedDataConstructors.postfundSetupState(2),
+          seedDataConstructors.postfundSetupState(3)
         ]
       });
 
       expect((await knex('channels').select('*')).length).toEqual(SEEDED_CHANNELS);
       expect(
         (await knex('channel_states')
-          .where({channel_id: updated_allocator_channel.id})
+          .where({channel_id: updatedAllocatorChannel.id})
           .select('*')).length
       ).toEqual(2);
 
@@ -83,9 +83,9 @@ describe('updateChannel', () => {
 
     it("throws when the channel doesn't exist and the commitment is not PreFundSetup", async () => {
       expect.assertions(1);
-      const theirState = testDataConstructors.post_fund_setup(2);
+      const theirState = testDataConstructors.postfundSetup(2);
       theirState.channel = {...fundedChannel, channelNonce: '1234'};
-      const hubState = testDataConstructors.post_fund_setup(1);
+      const hubState = testDataConstructors.postfundSetup(1);
       expect.assertions(1);
       await queries.updateChannel([theirState], hubState).catch(err => {
         expect(err).toMatchObject(errors.CHANNEL_MISSING);

--- a/packages/hub/src/wallet/db/queries/channels.ts
+++ b/packages/hub/src/wallet/db/queries/channels.ts
@@ -26,12 +26,12 @@ async function updateChannel(stateRound: State[], hubState: State) {
 
   const outcome = (s: State) => outcomeObjectToModel(s.outcome);
   const stateModel = (s: State) => ({
-    turn_num: s.turnNum,
-    is_final: s.isFinal,
-    challenge_duration: s.challengeDuration,
+    turnNum: s.turnNum,
+    isFinal: s.isFinal,
+    challengeDuration: s.challengeDuration,
     outcome: outcome(s),
     appDefinition: s.appDefinition,
-    app_data: s.appData
+    appData: s.appData
   });
 
   const states = [...stateRound.map(s => stateModel(s)), stateModel(hubState)];

--- a/packages/hub/src/wallet/db/queries/getCurrentState.ts
+++ b/packages/hub/src/wallet/db/queries/getCurrentState.ts
@@ -4,9 +4,9 @@ import ChannelState from '../../models/channelState';
 
 export async function getCurrentState(theirState: State) {
   const {channel: stateChannel} = theirState;
-  const channel_id = getChannelId(stateChannel);
+  const channelId = getChannelId(stateChannel);
   const channel = await Channel.query()
-    .findOne({channel_id})
+    .findOne({channel_id: channelId})
     .select('id');
   if (!channel) {
     return;

--- a/packages/hub/src/wallet/db/seeds/2_allocator_channels_seed.ts
+++ b/packages/hub/src/wallet/db/seeds/2_allocator_channels_seed.ts
@@ -13,8 +13,8 @@ import {
   BEGINNING_APP_CHANNEL_ID,
   beginningAppPhaseChannel,
   channelObjectToModel,
-  consensus_app_data2,
-  consensus_app_data3,
+  consensusAppData2,
+  consensusAppData3,
   FUNDED_CHANNEL_ID,
   FUNDED_CHANNEL_ID_3,
   FUNDED_GUARANTOR_CHANNEL_ID,
@@ -47,7 +47,7 @@ function prefundSetupState(turnNum: number) {
     ...baseStateProperties,
     turnNum,
     outcome: outcomeObjectToModel(allocationOutcome2),
-    appData: encodeConsensusData(consensus_app_data2(2))
+    appData: encodeConsensusData(consensusAppData2(2))
   };
 }
 
@@ -57,7 +57,7 @@ function prefundSetupGuarantorState(turnNum: number) {
     turnNum,
     outcome: outcomeObjectToModel(guaranteeOutcome2),
     // todo: appData does not reflect the outcome above
-    appData: encodeConsensusData(consensus_app_data2(2))
+    appData: encodeConsensusData(consensusAppData2(2))
   };
 }
 
@@ -66,16 +66,16 @@ function prefundSetupState3(turnNum: number) {
     ...baseStateProperties,
     turnNum,
     outcome: outcomeObjectToModel(allocationOutcome3),
-    appData: encodeConsensusData(consensus_app_data3(3))
+    appData: encodeConsensusData(consensusAppData3(3))
   };
 }
 
-function postFundSetupState(turnNum: number) {
+function postfundSetupState(turnNum: number) {
   return {
     ...baseStateProperties,
     turnNum,
     outcome: outcomeObjectToModel(allocationOutcome2),
-    appData: encodeConsensusData(consensus_app_data2(0))
+    appData: encodeConsensusData(consensusAppData2(0))
   };
 }
 
@@ -84,7 +84,7 @@ function appState(turnNum: number) {
     ...baseStateProperties,
     turnNum,
     outcome: outcomeObjectToModel(allocationOutcome2),
-    appData: encodeConsensusData(consensus_app_data2(turnNum % 2))
+    appData: encodeConsensusData(consensusAppData2(turnNum % 2))
   };
 }
 
@@ -118,7 +118,7 @@ const fundedChannel3WithStates = {
 const beginningAppPhaseChannelWithStates = {
   ...channelObjectToModel(beginningAppPhaseChannel),
   channel_id: BEGINNING_APP_CHANNEL_ID,
-  states: [postFundSetupState(2), postFundSetupState(3)],
+  states: [postfundSetupState(2), postfundSetupState(3)],
   holdings: [{assetHolderAddress: DUMMY_ASSET_HOLDER_ADDRESS, amount: holdings2}]
 };
 
@@ -129,7 +129,7 @@ const ongoingAppPhaseChannelWithStates = {
   holdings: [{assetHolderAddress: DUMMY_ASSET_HOLDER_ADDRESS, amount: holdings2}]
 };
 
-const two_participant_channel_seeds = {
+const twoParticipantChannelSeeds = {
   unfundedChannelWithStates,
   fundedChannelWithStates,
   fundedGuarantorChannelWithStates,
@@ -137,10 +137,10 @@ const two_participant_channel_seeds = {
   ongoingAppPhaseChannelWithStates
 };
 
-const three_participant_channel_seeds = {fundedChannel3WithStates};
+const threeParticipantChannelSeeds = {fundedChannel3WithStates};
 
-const SEEDED_CHANNELS_2 = Object.keys(two_participant_channel_seeds).length;
-const SEEDED_CHANNELS_3 = Object.keys(three_participant_channel_seeds).length;
+const SEEDED_CHANNELS_2 = Object.keys(twoParticipantChannelSeeds).length;
+const SEEDED_CHANNELS_3 = Object.keys(threeParticipantChannelSeeds).length;
 
 const SEEDED_STATES_2 = SEEDED_CHANNELS_2 * 2;
 const SEEDED_STATES_3 = SEEDED_CHANNELS_3 * 3;
@@ -160,8 +160,8 @@ export const SEEDED_ALLOCATIONS = SEEDED_ALLOCATIONS_2 + SEEDED_ALLOCATIONS_3;
 export const SEEDED_PARTICIPANTS = SEEDED_PARTICIPANTS_2 + SEEDED_PARTICIPANTS_3;
 
 export const seeds = {
-  ...two_participant_channel_seeds,
-  ...three_participant_channel_seeds
+  ...twoParticipantChannelSeeds,
+  ...threeParticipantChannelSeeds
 };
 
 export function seed() {
@@ -173,5 +173,5 @@ export function seed() {
 }
 
 export const stateConstructors = {
-  postFundSetupState
+  postfundSetupState
 };

--- a/packages/hub/src/wallet/models/__test__/channelState.test.ts
+++ b/packages/hub/src/wallet/models/__test__/channelState.test.ts
@@ -5,7 +5,7 @@ import {
   guaranteeOutcome2
 } from '../../../test/test-constants';
 import {
-  consensus_app_data2,
+  consensusAppData2,
   FUNDED_CHANNEL_ID,
   FUNDED_GUARANTOR_CHANNEL_ID,
   fundedChannel,
@@ -40,7 +40,7 @@ describe('asStateObject', () => {
       challengeDuration: 1000,
       outcome: allocationOutcome2,
       appDefinition: DUMMY_RULES_ADDRESS,
-      appData: encodeConsensusData(consensus_app_data2(2))
+      appData: encodeConsensusData(consensusAppData2(2))
     };
 
     expect(state).toMatchObject(expectedState);
@@ -56,7 +56,7 @@ describe('asStateObject', () => {
       challengeDuration: 1000,
       outcome: guaranteeOutcome2,
       appDefinition: DUMMY_RULES_ADDRESS,
-      appData: encodeConsensusData(consensus_app_data2(2))
+      appData: encodeConsensusData(consensusAppData2(2))
     };
 
     expect(state).toMatchObject(expectedState);

--- a/packages/hub/src/wallet/services/__test__/channelManager.test.ts
+++ b/packages/hub/src/wallet/services/__test__/channelManager.test.ts
@@ -5,49 +5,49 @@ import {HUB_PRIVATE_KEY} from '../../../constants';
 import {fundedChannel, stateConstructors as testDataConstructors} from '../../../test/test_data';
 import * as ChannelManager from '../channelManager';
 
-let pre_fund_setup_0: State;
-let pre_fund_setup_1: State;
-let post_fund_setup_0: State;
-let post_fund_setup_1: State;
-let app_0: State;
+let prefundSetup0: State;
+let prefundSetup1: State;
+let postfundSetup0: State;
+let postfundSetup1: State;
+let app0: State;
 let hubSignature: Signature;
 
 beforeEach(() => {
-  pre_fund_setup_0 = testDataConstructors.pre_fund_setup(0);
-  pre_fund_setup_1 = testDataConstructors.pre_fund_setup(1);
+  prefundSetup0 = testDataConstructors.prefundSetup(0);
+  prefundSetup1 = testDataConstructors.prefundSetup(1);
 
-  post_fund_setup_0 = testDataConstructors.post_fund_setup(2);
-  post_fund_setup_1 = testDataConstructors.post_fund_setup(3);
-  app_0 = testDataConstructors.app(4, fundedChannel);
+  postfundSetup0 = testDataConstructors.postfundSetup(2);
+  postfundSetup1 = testDataConstructors.postfundSetup(3);
+  app0 = testDataConstructors.app(4, fundedChannel);
 
-  hubSignature = signState(pre_fund_setup_1, HUB_PRIVATE_KEY).signature;
+  hubSignature = signState(prefundSetup1, HUB_PRIVATE_KEY).signature;
 });
 
 describe('validSignature', () => {
   it('returns true when the state was signed by the mover', async () => {
-    expect(ChannelManager.validSignature(pre_fund_setup_1, hubSignature)).toBe(true);
+    expect(ChannelManager.validSignature(prefundSetup1, hubSignature)).toBe(true);
   });
 
   it.skip('returns false when the state was not signed by the mover', async () => {
     // TODO: Unskip when validation is enabled
-    expect(ChannelManager.validSignature(pre_fund_setup_0, hubSignature)).toBe(false);
+    expect(ChannelManager.validSignature(prefundSetup0, hubSignature)).toBe(false);
   });
 
   it.skip('returns false when the state was not signed by the mover', async () => {
     // TODO: Unskip when validation is enabled
-    const signature = signState(pre_fund_setup_0, '0xf00').signature;
-    expect(ChannelManager.validSignature(pre_fund_setup_0, signature)).toBe(false);
+    const signature = signState(prefundSetup0, '0xf00').signature;
+    expect(ChannelManager.validSignature(prefundSetup0, signature)).toBe(false);
   });
 });
 
 describe('formResponse', () => {
   it('returns a signed core state', async () => {
-    pre_fund_setup_1.channel = fundedChannel;
+    prefundSetup1.channel = fundedChannel;
 
-    hubSignature = signState(pre_fund_setup_1, HUB_PRIVATE_KEY).signature;
+    hubSignature = signState(prefundSetup1, HUB_PRIVATE_KEY).signature;
 
-    expect(await ChannelManager.formResponse(pre_fund_setup_1)).toMatchObject({
-      state: pre_fund_setup_1,
+    expect(await ChannelManager.formResponse(prefundSetup1)).toMatchObject({
+      state: prefundSetup1,
       signature: hubSignature
     });
   });
@@ -55,14 +55,14 @@ describe('formResponse', () => {
 
 describe('nextState', () => {
   it('works on preFundSetup states', () => {
-    expect(ChannelManager.nextState(pre_fund_setup_0)).toMatchObject(pre_fund_setup_1);
+    expect(ChannelManager.nextState(prefundSetup0)).toMatchObject(prefundSetup1);
   });
 
   it('works on postFundSetup states', () => {
-    expect(ChannelManager.nextState(post_fund_setup_0)).toMatchObject(post_fund_setup_1);
+    expect(ChannelManager.nextState(postfundSetup0)).toMatchObject(postfundSetup1);
   });
 
   it('throws on app commitments', () => {
-    expect(() => ChannelManager.nextState(app_0)).toThrowError();
+    expect(() => ChannelManager.nextState(app0)).toThrowError();
   });
 });

--- a/packages/hub/src/wallet/services/__test__/ledgerChannelManager.test.ts
+++ b/packages/hub/src/wallet/services/__test__/ledgerChannelManager.test.ts
@@ -9,14 +9,14 @@ import {
   PARTICIPANTS
 } from '../../../test/test-constants';
 import {
-  app_1_response,
+  app1Response,
   beginningAppPhaseChannel,
-  created_pre_fund_setup_1,
-  created_pre_fund_setup_3_2,
-  post_fund_setup_1_response,
-  post_fund_setup_3_2_response,
-  pre_fund_setup_1_response,
-  pre_fund_setup_3_2_response,
+  createdPrefundSetup1,
+  createdPrefundSetup2Participants3,
+  postfundSetup1Response,
+  postfundSetup2Response3,
+  prefundSetup1Response,
+  prefundSetup2Response3,
   stateConstructors as testDataConstructors
 } from '../../../test/test_data';
 import errors from '../../errors';
@@ -24,65 +24,65 @@ import * as ChannelManager from '../channelManager';
 import * as LedgerChannelManager from '../ledgerChannelManager';
 
 // 2 participant channel
-let pre_fund_setup_0: State;
-let post_fund_setup_0: State;
-let app_0: State;
+let prefundSetup0: State;
+let postfundSetup0: State;
+let app0: State;
 let theirSignature: Signature;
 
 // 3 participant channel
-let pre_fund_setup_3_0: State;
-let pre_fund_setup_3_1: State;
-let post_fund_setup_3_0: State;
-let post_fund_setup_3_1: State;
+let prefundSetup30: State;
+let prefundSetup31: State;
+let postfundSetup30: State;
+let postfundSetup31: State;
 
 beforeEach(() => {
-  pre_fund_setup_0 = testDataConstructors.pre_fund_setup(0);
-  post_fund_setup_0 = testDataConstructors.post_fund_setup(2);
-  app_0 = testDataConstructors.app(4, beginningAppPhaseChannel);
+  prefundSetup0 = testDataConstructors.prefundSetup(0);
+  postfundSetup0 = testDataConstructors.postfundSetup(2);
+  app0 = testDataConstructors.app(4, beginningAppPhaseChannel);
 
-  pre_fund_setup_3_0 = testDataConstructors.pre_fund_setup_3(0);
-  pre_fund_setup_3_1 = testDataConstructors.pre_fund_setup_3(1);
-  post_fund_setup_3_0 = testDataConstructors.post_fund_setup_3(3);
-  post_fund_setup_3_1 = testDataConstructors.post_fund_setup_3(4);
+  prefundSetup30 = testDataConstructors.prefundSetup3(0);
+  prefundSetup31 = testDataConstructors.prefundSetup3(1);
+  postfundSetup30 = testDataConstructors.postfundSetup3(3);
+  postfundSetup31 = testDataConstructors.postfundSetup3(4);
 });
 
 describe('updateLedgerChannel', () => {
   describe('opening a channel', () => {
     beforeEach(() => {
-      theirSignature = signState(pre_fund_setup_0, PARTICIPANT_1_PRIVATE_KEY).signature;
+      theirSignature = signState(prefundSetup0, PARTICIPANT_1_PRIVATE_KEY).signature;
     });
 
     it('should return an allocator channel and a signed state', async () => {
       const {state, signature} = await LedgerChannelManager.updateLedgerChannel([
-        {state: pre_fund_setup_0, signature: theirSignature}
+        {state: prefundSetup0, signature: theirSignature}
       ]);
-      expect(state).toMatchObject(pre_fund_setup_1_response);
+      expect(state).toMatchObject(prefundSetup1Response);
       expect(ChannelManager.validSignature(state, signature)).toBe(true);
     });
 
     it('on valid round received -- should return an allocator channel and a signed state', async () => {
       const {state, signature} = await LedgerChannelManager.updateLedgerChannel([
         {
-          state: pre_fund_setup_3_0,
-          signature: signState(pre_fund_setup_3_0, PARTICIPANT_1_PRIVATE_KEY).signature
+          state: prefundSetup30,
+          signature: signState(prefundSetup30, PARTICIPANT_1_PRIVATE_KEY).signature
         },
         {
-          state: pre_fund_setup_3_1,
-          signature: signState(pre_fund_setup_3_1, PARTICIPANT_2_PRIVATE_KEY).signature
+          state: prefundSetup31,
+          signature: signState(prefundSetup31, PARTICIPANT_2_PRIVATE_KEY).signature
         }
       ]);
-      expect(state).toMatchObject(pre_fund_setup_3_2_response);
+      expect(state).toMatchObject(prefundSetup2Response3);
       expect(ChannelManager.validSignature(state, signature)).toBe(true);
     });
 
     it.skip('throws when the state is incorrectly signed', async () => {
       // TODO: Unskip when signatures are validated
       expect.assertions(1);
-      theirSignature = signState(pre_fund_setup_0, '0xf00').signature;
+      theirSignature = signState(prefundSetup0, '0xf00').signature;
 
       await LedgerChannelManager.updateLedgerChannel([
         {
-          state: pre_fund_setup_0,
+          state: prefundSetup0,
           signature: theirSignature
         }
       ]).catch((err: Error) => {
@@ -93,16 +93,16 @@ describe('updateLedgerChannel', () => {
     it('throws when the channel exists', async () => {
       expect.assertions(1);
 
-      pre_fund_setup_0.channel = {
+      prefundSetup0.channel = {
         channelNonce: FUNDED_NONCE,
         participants: PARTICIPANTS,
         chainId: DUMMY_CHAIN_ID
       };
-      theirSignature = signState(pre_fund_setup_0, PARTICIPANT_1_PRIVATE_KEY).signature;
+      theirSignature = signState(prefundSetup0, PARTICIPANT_1_PRIVATE_KEY).signature;
 
       await LedgerChannelManager.updateLedgerChannel([
         {
-          state: pre_fund_setup_0,
+          state: prefundSetup0,
           signature: theirSignature
         }
       ]).catch((err: Error) => {
@@ -113,20 +113,20 @@ describe('updateLedgerChannel', () => {
 
   describe('transitioning to a postFundSetup state', () => {
     beforeEach(() => {
-      theirSignature = signState(post_fund_setup_0, PARTICIPANT_1_PRIVATE_KEY).signature;
+      theirSignature = signState(postfundSetup0, PARTICIPANT_1_PRIVATE_KEY).signature;
     });
 
     it('should return an allocator channel and a signed state', async () => {
       const {state, signature} = await LedgerChannelManager.updateLedgerChannel(
         [
           {
-            state: post_fund_setup_0,
+            state: postfundSetup0,
             signature: theirSignature
           }
         ],
-        created_pre_fund_setup_1
+        createdPrefundSetup1
       );
-      expect(state).toMatchObject(post_fund_setup_1_response);
+      expect(state).toMatchObject(postfundSetup1Response);
       expect(ChannelManager.validSignature(state, signature)).toBe(true);
     });
 
@@ -135,17 +135,17 @@ describe('updateLedgerChannel', () => {
         const {state, signature} = await LedgerChannelManager.updateLedgerChannel(
           [
             {
-              state: post_fund_setup_3_0,
-              signature: signState(post_fund_setup_3_0, PARTICIPANT_1_PRIVATE_KEY).signature
+              state: postfundSetup30,
+              signature: signState(postfundSetup30, PARTICIPANT_1_PRIVATE_KEY).signature
             },
             {
-              state: post_fund_setup_3_1,
-              signature: signState(post_fund_setup_3_1, PARTICIPANT_2_PRIVATE_KEY).signature
+              state: postfundSetup31,
+              signature: signState(postfundSetup31, PARTICIPANT_2_PRIVATE_KEY).signature
             }
           ],
-          created_pre_fund_setup_3_2
+          createdPrefundSetup2Participants3
         );
-        expect(state).toMatchObject(post_fund_setup_3_2_response);
+        expect(state).toMatchObject(postfundSetup2Response3);
         expect(ChannelManager.validSignature(state, signature)).toBe(true);
       });
 
@@ -153,11 +153,11 @@ describe('updateLedgerChannel', () => {
         await LedgerChannelManager.updateLedgerChannel(
           [
             {
-              state: post_fund_setup_3_0,
-              signature: signState(post_fund_setup_3_0, PARTICIPANT_1_PRIVATE_KEY).signature
+              state: postfundSetup30,
+              signature: signState(postfundSetup30, PARTICIPANT_1_PRIVATE_KEY).signature
             }
           ],
-          created_pre_fund_setup_3_2
+          createdPrefundSetup2Participants3
         ).catch((err: Error) => {
           expect(err).toMatchObject(errors.NOT_OUR_TURN);
         });
@@ -167,10 +167,10 @@ describe('updateLedgerChannel', () => {
     it.skip('throws when the state is incorrectly signed', async () => {
       // TODO: Unskip when signatures are validated
       expect.assertions(1);
-      theirSignature = signState(post_fund_setup_0, '0xf00').signature;
+      theirSignature = signState(postfundSetup0, '0xf00').signature;
       await LedgerChannelManager.updateLedgerChannel([
         {
-          state: post_fund_setup_0,
+          state: postfundSetup0,
           signature: theirSignature
         }
       ]).catch((err: Error) => {
@@ -180,17 +180,17 @@ describe('updateLedgerChannel', () => {
 
     it('throws when the transition is invalid', async () => {
       expect.assertions(1);
-      theirSignature = signState(created_pre_fund_setup_1, PARTICIPANT_1_PRIVATE_KEY).signature;
+      theirSignature = signState(createdPrefundSetup1, PARTICIPANT_1_PRIVATE_KEY).signature;
 
       await LedgerChannelManager.updateLedgerChannel(
         [
           {
-            state: post_fund_setup_0,
+            state: postfundSetup0,
             signature: theirSignature
           }
         ],
         {
-          ...created_pre_fund_setup_1,
+          ...createdPrefundSetup1,
           turnNum: 0
         }
       ).catch(err => {
@@ -201,20 +201,20 @@ describe('updateLedgerChannel', () => {
     it("throws when the channel doesn't exist", async () => {
       expect.assertions(1);
 
-      post_fund_setup_0.channel = {
-        ...post_fund_setup_0.channel,
+      postfundSetup0.channel = {
+        ...postfundSetup0.channel,
         channelNonce: '999'
       };
-      theirSignature = signState(post_fund_setup_0, PARTICIPANT_1_PRIVATE_KEY).signature;
+      theirSignature = signState(postfundSetup0, PARTICIPANT_1_PRIVATE_KEY).signature;
 
       await LedgerChannelManager.updateLedgerChannel(
         [
           {
-            state: post_fund_setup_0,
+            state: postfundSetup0,
             signature: theirSignature
           }
         ],
-        created_pre_fund_setup_1
+        createdPrefundSetup1
       ).catch(err => {
         expect(err).toMatchObject(errors.CHANNEL_MISSING);
       });
@@ -225,7 +225,7 @@ describe('updateLedgerChannel', () => {
 
       await LedgerChannelManager.updateLedgerChannel([
         {
-          state: post_fund_setup_0,
+          state: postfundSetup0,
           signature: theirSignature
         }
       ]).catch(err => {
@@ -236,20 +236,20 @@ describe('updateLedgerChannel', () => {
 
   describe('transitioning to an app state', () => {
     beforeEach(() => {
-      theirSignature = signState(app_0, PARTICIPANT_1_PRIVATE_KEY).signature;
+      theirSignature = signState(app0, PARTICIPANT_1_PRIVATE_KEY).signature;
     });
 
     it('should return an allocator channel and a signed state', async () => {
       const {state, signature} = await LedgerChannelManager.updateLedgerChannel(
         [
           {
-            state: app_0,
+            state: app0,
             signature: theirSignature
           }
         ],
-        post_fund_setup_1_response
+        postfundSetup1Response
       );
-      expect(state).toMatchObject(app_1_response);
+      expect(state).toMatchObject(app1Response);
 
       expect(ChannelManager.validSignature(state, signature)).toBe(true);
     });


### PR DESCRIPTION
Fixes https://github.com/statechannels/monorepo/issues/547.

Upper case constants remain in snake case.