### PR TITLE
Fix listeners

### DIFF
--- a/packages/rps/src/redux/message-service/channel-updated-listener.ts
+++ b/packages/rps/src/redux/message-service/channel-updated-listener.ts
@@ -7,7 +7,8 @@ import { ChannelState } from '../../core';
 export function* channelUpdatedListener() {
   const rpsChannelClient = new RPSChannelClient();
 
-  const channel = eventChannel(rpsChannelClient.onChannelUpdated, buffers.fixed(10));
+  const subscribe = emit => rpsChannelClient.onChannelUpdated(emit);
+  const channel = eventChannel(subscribe, buffers.fixed(10));
 
   while (true) {
     const channelState: ChannelState = yield take(channel);

--- a/packages/rps/src/redux/message-service/message-queued-listener.ts
+++ b/packages/rps/src/redux/message-service/message-queued-listener.ts
@@ -7,7 +7,8 @@ import { RPSChannelClient } from '../../utils/rps-channel-client';
 export function* messageQueuedListener() {
   const rpsChannelClient = new RPSChannelClient();
 
-  const channel = eventChannel(rpsChannelClient.onMessageQueued, buffers.fixed(10));
+  const subscribe = emit => rpsChannelClient.onMessageQueued(emit);
+  const channel = eventChannel(subscribe, buffers.fixed(10));
 
   while (true) {
     const notification: MessageQueuedNotification = yield take(channel);


### PR DESCRIPTION
Turns out that if you do this:
```ts
const channel = eventChannel(rpsChannelClient.onMessageQueued, buffers.fixed(10))
```
you just get the `onMessagedQueued` function, and *not* the `onMessageQueued` function in the context of the `rpsChannelClient`. We need to do this instead:

```ts
const subscribe = emit => rpsChannelClient.onMessageQueued(emit);
const channel = eventChannel(subscribe, buffers.fixed(10));
```