### PR TITLE
Remove index.ts in wallet

### DIFF
--- a/packages/wallet/index.ts
+++ b/packages/wallet/index.ts
@@ -1,5 +1,0 @@
-import {unreachable} from "./src/utils/reducer-utils";
-import {addHex} from "./src/utils/hex-utils";
-import {convertAddressToBytes32} from "./src/utils/data-type-utils";
-
-export {unreachable, addHex, convertAddressToBytes32};


### PR DESCRIPTION
The `hub` is the only user of these functions; we should rip them out. There is no need for `@statechannels/wallet` to be creating dependencies on it with these.