### PR TITLE
Update comments about the adjudicatorStateUpdater

### DIFF
--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -143,7 +143,6 @@ export interface ChannelUpdate {
   type: "WALLET.ADJUDICATOR.CHANNEL_UPDATE";
   channelId: string;
   isFinalized: boolean;
-  balance: string;
 }
 // -------
 // Constructors

--- a/packages/wallet/src/redux/adjudicator-state/reducer.ts
+++ b/packages/wallet/src/redux/adjudicator-state/reducer.ts
@@ -68,7 +68,7 @@ const fundingReceivedEventReducer = (
 };
 const channelUpdateReducer = (state: AdjudicatorState, action: actions.ChannelUpdate) => {
   const {channelId} = action;
-  let updatedState = setBalance(state, channelId, action.balance);
+  let updatedState = setBalance(state, channelId, "0x0");
   if (action.isFinalized) {
     updatedState = markAsFinalized(updatedState, channelId);
   }

--- a/packages/wallet/src/redux/sagas/adjudicator-state-updater.ts
+++ b/packages/wallet/src/redux/sagas/adjudicator-state-updater.ts
@@ -1,19 +1,28 @@
-// TODO: Update to work with nitro protocol
-
 // import * as selectors from "../selectors";
 // import {select, call, put} from "redux-saga/effects";
-// import {getAdjudicatorHoldings, getProvider, getAdjudicatorOutcome} from "../../utils/contract-utils";
+// import {getProvider, getAdjudicatorChannelStorageHash} from "../../utils/contract-utils";
 // import {channelUpdate} from "../actions";
-// import {BigNumber, bigNumberify} from "ethers/utils";
+// import {bigNumberify} from "ethers/utils";
 
-// A simple saga that runs and dispatches update actions to load the latest adjudicator state
+// // A simple saga that runs and dispatches update actions to load the latest adjudicator state
 export function* adjudicatorStateUpdater() {
-  // const channelIds = yield select(selectors.getChannelIds);
-  // const provider = yield call(getProvider);
-  // for (const channelId of channelIds) {
-  //   const totalForChannel: BigNumber = yield call(getAdjudicatorHoldings, provider, channelId);
-  //   const outcome = yield call(getAdjudicatorOutcome, provider, channelId);
-  //   const isFinalized = bigNumberify(outcome.finalizedAt).gt("0x0");
-  //   yield put(channelUpdate({balance: totalForChannel.toHexString(), channelId, isFinalized}));
-  // }
+  //   const channelIds = yield select(selectors.getChannelIds);
+  //   const provider = yield call(getProvider);
+  //   for (const channelId of channelIds) {
+  //     // const channelStorageHash = yield call(getAdjudicatorChannelStorageHash, provider, channelId);
+  //     //
+  //     // const isFinalzied = ...
+  //     //
+  //     // TODO: To determine if this channel is in a "finalized" state we must learn about the most recent
+  //     // ChannelStorage object that has been put on chain by filtering all events since the most recently
+  //     // observed block of the wallet of any of these types:
+  //     // - ChallengeRegistered
+  //     // - ChallengeCleared
+  //     // - Concluded
+  //     // Then, based on the most recent one, understand the state that the channel is now in. If it is
+  //     // not explicitly finalized, then we should check the current block number to determine if it is.
+  //     // We can confirm our hypothesis by checking `channelStorageHash` against the hash of our guess.
+  //     //
+  //     // yield put(channelUpdate({channelId, isFinalized}));
+  //   }
 }

--- a/packages/wallet/src/utils/contract-utils.ts
+++ b/packages/wallet/src/utils/contract-utils.ts
@@ -2,6 +2,7 @@ import NetworkContext from "@statechannels/ganache-deployer/ganache-network-cont
 import {ethers} from "ethers";
 import {AddressZero} from "ethers/constants";
 import log from "loglevel";
+import { Provider } from "ethers/providers";
 
 log.setDefaultLevel(log.levels.DEBUG);
 
@@ -114,15 +115,8 @@ export function isDevelopmentNetwork(): boolean {
     networkId !== 61717561 // aquachain
   );
 }
-// TODO: Update to work with nitro protocol
-// export async function getAdjudicatorHoldings(provider, channelId) {
-//   const contract = await getAdjudicatorContract(provider);
-//   const holdingForChannel = await contract.holdings(channelId);
-//   return holdingForChannel;
-// }
 
-// export async function getAdjudicatorOutcome(provider, channelId) {
-//   const contract = await getAdjudicatorContract(provider);
-//   const outcomeForChannel = await contract.outcomes(channelId);
-//   return outcomeForChannel;
-// }
+export async function getAdjudicatorChannelStorageHash(provider: Provider, channelId: string) {
+  const contract = await getAdjudicatorContract(provider);
+  return await contract.channelStorageHashes(channelId);
+}


### PR DESCRIPTION
We do not have the luxury of on-chain data availability for our channel states (i.e., outcome, isFinalized, etc) anymore. The only piece of on-chain data we have is the current block number, which we will need to implement a different kind of saga / state updater for.