### PR TITLE
Fix ganache-deployer's set adjudicator address for asset holder contracts

### DIFF
--- a/packages/ganache-deployer/src/deployer.ts
+++ b/packages/ganache-deployer/src/deployer.ts
@@ -39,14 +39,14 @@ export async function deployContracts(chain: GanacheServer): Promise<object> {
     {
       artifact: erc20AssetHolderArtifact,
       arguments: (deployedArtifacts: DeployedArtifacts) => {
-        if (testNitroAdjudicatorArtifact.contractName in deployedArtifacts) {
+        if (nitroAdjudicatorArtifact.contractName in deployedArtifacts) {
           return [
-            deployedArtifacts[testNitroAdjudicatorArtifact.contractName].address,
+            deployedArtifacts[nitroAdjudicatorArtifact.contractName].address,
             deployedArtifacts[tokenArtifact.contractName].address,
           ];
         }
         throw Error(`${erc20AssetHolderArtifact.contractName} requires that the following contracts are deployed:
-          - ${testNitroAdjudicatorArtifact.contractName}
+          - ${nitroAdjudicatorArtifact.contractName}
           - ${tokenArtifact.contractName}
         `);
       },
@@ -54,11 +54,11 @@ export async function deployContracts(chain: GanacheServer): Promise<object> {
     {
       artifact: ethAssetHolderArtifact,
       arguments: (deployedArtifacts: DeployedArtifacts) => {
-        if (testNitroAdjudicatorArtifact.contractName in deployedArtifacts) {
-          return [deployedArtifacts[testNitroAdjudicatorArtifact.contractName].address];
+        if (nitroAdjudicatorArtifact.contractName in deployedArtifacts) {
+          return [deployedArtifacts[nitroAdjudicatorArtifact.contractName].address];
         }
         throw Error(`${ethAssetHolderArtifact.contractName} requires that the following contracts are deployed:
-          - ${testNitroAdjudicatorArtifact.contractName}
+          - ${nitroAdjudicatorArtifact.contractName}
         `);
       },
     },

--- a/packages/wallet/src/contract-tests/eth-asset-holder-events.test.ts
+++ b/packages/wallet/src/contract-tests/eth-asset-holder-events.test.ts
@@ -59,7 +59,7 @@ describe("ETHAssetHolder listener", () => {
     expect(action.destinationHoldings).toEqual(depositAmount);
   });
 
-  it.skip("should handle an AssetTransferred event", async () => {
+  it("should handle an AssetTransferred event", async () => {
     const channelNonce = getNextNonce();
     const chainId = (await provider.getNetwork()).chainId.toString();
     const channelId = nitroGetChannelId({

--- a/packages/wallet/src/contract-tests/transactions.test.ts
+++ b/packages/wallet/src/contract-tests/transactions.test.ts
@@ -1,6 +1,6 @@
 import {ethers} from "ethers";
 
-import {createChallenge, concludeGame, fiveFive} from "./test-utils";
+import {createChallenge, fiveFive} from "./test-utils";
 import {
   createForceMoveTransaction,
   createETHDepositTransaction,
@@ -8,8 +8,7 @@ import {
   createRefuteTransaction,
   createConcludeTransaction,
   ConcludePushOutcomeAndTransferAllArgs,
-  createConcludePushOutcomeAndTransferAllTransaction,
-  createTransferAndWithdrawTransaction
+  createConcludePushOutcomeAndTransferAllTransaction
 } from "../utils/transaction-generator";
 
 import {depositIntoETHAssetHolder} from "./test-utils";
@@ -247,31 +246,7 @@ describe("transactions", () => {
     await testTransactionSender(concludeTransaction);
   });
 
-  it.skip("should send a transferAndWithdraw transaction", async () => {
-    const channelNonce = getNextNonce();
-    const channel: Channel = {
-      channelNonce,
-      chainId: bigNumberify(NETWORK_ID).toHexString(),
-      participants: [participantA.address, participantB.address]
-    };
-    const channelId = getChannelId(channel);
-
-    await depositIntoETHAssetHolder(provider, channelId);
-    await depositIntoETHAssetHolder(provider, channelId);
-    await concludeGame(provider, channel.channelNonce, participantA, participantB);
-
-    const verificationSignature = "0x0";
-    const transferAndWithdraw = createTransferAndWithdrawTransaction(
-      channelId,
-      participantA.address,
-      participantA.address,
-      "0x01",
-      verificationSignature
-    );
-    await testTransactionSender(transferAndWithdraw);
-  });
-
-  it.skip("should send a conclude, push outcome, and transfer all transaction", async () => {
+  it("should send a conclude, push outcome, and transfer all transaction", async () => {
     const channelNonce = getNextNonce();
     const channel: Channel = {
       channelNonce,

--- a/packages/wallet/src/utils/transaction-generator.ts
+++ b/packages/wallet/src/utils/transaction-generator.ts
@@ -81,32 +81,6 @@ export function createWithdrawTransaction(
   };
 }
 
-export function createTransferAndWithdrawTransaction(
-  channelId: string,
-  participant: string,
-  destination: string,
-  amount: string,
-  verificationSignature: string
-) {
-  // TODO: Implement using Nitro
-  // const adjudicatorInterface = getAdjudicatorInterface();
-  // const {v, r, s} = splitSignature(verificationSignature);
-  // const data = adjudicatorInterface.functions.transferAndWithdraw.encode([
-  //   channelId,
-  //   participant,
-  //   destination,
-  //   amount,
-  //   v,
-  //   r,
-  //   s
-  // ]);
-
-  return {
-    data: "0x0",
-    gasLimit: 3000000
-  };
-}
-
 export function createETHDepositTransaction(
   destination: string,
   depositAmount: string,


### PR DESCRIPTION
This was causing some tests to be skipped unnecessarily.