### PR TITLE
Remove redundant action dispatching

### DIFF
--- a/packages/wallet/src/redux/sagas/adjudicator-watcher.ts
+++ b/packages/wallet/src/redux/sagas/adjudicator-watcher.ts
@@ -95,16 +95,8 @@ function* dispatchProcessEventAction(
       );
       break;
     case AdjudicatorEventType.ChallengeCleared:
-      const newTurnNumRecord = event.eventArgs[1].toNumber();
-      yield put(
-        actions.challengeClearedEvent({
-          channelId,
-          newTurnNumRecord
-        })
-      );
       break;
     case AdjudicatorEventType.Concluded:
-      yield put(actions.concludedEvent({channelId}));
       break;
     default:
       throw new Error(


### PR DESCRIPTION
Is this needed @lalexgap? It seems like the "process event actions" are getting dispatched many more times than need be. Also, two of them were being dispatched in the "event actions" helper function anyway.