### PR TITLE
Attempt to fix pushOutcome test

### DIFF
--- a/packages/ganache-deployer/src/deployer.ts
+++ b/packages/ganache-deployer/src/deployer.ts
@@ -28,8 +28,6 @@ export async function deployContracts(chain: GanacheServer): Promise<object> {
     forceMoveAppArtifact,
     consensusAppArtifact,
     testForceMoveArtifact,
-    testAssetHolderArtifact1,
-    testAssetHolderArtifact2,
     trivialAppArtifact,
     countingAppArtifact,
     singleAssetPaymentsArtifact,
@@ -59,6 +57,28 @@ export async function deployContracts(chain: GanacheServer): Promise<object> {
         }
         throw Error(`${ethAssetHolderArtifact.contractName} requires that the following contracts are deployed:
           - ${nitroAdjudicatorArtifact.contractName}
+        `);
+      },
+    },
+    {
+      artifact: testAssetHolderArtifact1,
+      arguments: (deployedArtifacts: DeployedArtifacts) => {
+        if (testNitroAdjudicatorArtifact.contractName in deployedArtifacts) {
+          return [deployedArtifacts[testNitroAdjudicatorArtifact.contractName].address];
+        }
+        throw Error(`${testAssetHolderArtifact1.contractName} requires that the following contracts are deployed:
+          - ${testNitroAdjudicatorArtifact.contractName}
+        `);
+      },
+    },
+    {
+      artifact: testAssetHolderArtifact2,
+      arguments: (deployedArtifacts: DeployedArtifacts) => {
+        if (testNitroAdjudicatorArtifact.contractName in deployedArtifacts) {
+          return [deployedArtifacts[testNitroAdjudicatorArtifact.contractName].address];
+        }
+        throw Error(`${testAssetHolderArtifact2.contractName} requires that the following contracts are deployed:
+          - ${testNitroAdjudicatorArtifact.contractName}
         `);
       },
     },

--- a/packages/nitro-protocol/contracts/test/TESTAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/test/TESTAssetHolder.sol
@@ -6,6 +6,22 @@ import '../AssetHolder.sol';
   * @dev This contract extends the AssetHolder contract to enable it to be more easily unit-tested. It exposes public or external functions that set storage variables or wrap otherwise internal functions. It should not be deployed in a production environment.
 */
 contract TESTAssetHolder is AssetHolder {
+    address AdjudicatorAddress;
+
+    /**
+    * @notice Constructor function storing the AdjudicatorAddress.
+    * @dev Constructor function storing the AdjudicatorAddress.
+    * @param _AdjudicatorAddress Address of an Adjudicator  contract, supplied at deploy-time.
+    */
+    constructor(address _AdjudicatorAddress) public {
+        AdjudicatorAddress = _AdjudicatorAddress;
+    }
+
+    modifier AdjudicatorOnly {
+        require(msg.sender == AdjudicatorAddress, 'Only the NitroAdjudicator is authorized');
+        _;
+    }
+
     // Public wrappers for internal methods:
 
     /**

--- a/packages/nitro-protocol/contracts/test/TESTAssetHolder2.sol
+++ b/packages/nitro-protocol/contracts/test/TESTAssetHolder2.sol
@@ -6,21 +6,13 @@ import './TESTAssetHolder.sol';
   * @dev This contract is a clone of the TESTAssetHolder contract. It is used for testing purposes only, to enable testing of transferAll and claimAll in multiple AssetHolders. It has a dummy storage variable in order to change the ABI. TODO remove the need for this contract by allowing TESTAssetHolder to be deployed twice.
 */
 contract TESTAssetHolder2 is TESTAssetHolder {
-    address AdjudicatorAddress;
 
     /**
     * @notice Constructor function storing the AdjudicatorAddress.
     * @dev Constructor function storing the AdjudicatorAddress.
     * @param _AdjudicatorAddress Address of an Adjudicator  contract, supplied at deploy-time.
     */
-    constructor(address _AdjudicatorAddress) public {
-        AdjudicatorAddress = _AdjudicatorAddress;
-    }
-
-    modifier AdjudicatorOnly {
-        require(msg.sender == AdjudicatorAddress, 'Only the NitroAdjudicator is authorized');
-        _;
-    }
+    constructor(address _AdjudicatorAddress) TESTAssetHolder(_AdjudicatorAddress) public {}
 
     bool public dummy;
 }

--- a/packages/nitro-protocol/contracts/test/TESTAssetHolder2.sol
+++ b/packages/nitro-protocol/contracts/test/TESTAssetHolder2.sol
@@ -6,5 +6,21 @@ import './TESTAssetHolder.sol';
   * @dev This contract is a clone of the TESTAssetHolder contract. It is used for testing purposes only, to enable testing of transferAll and claimAll in multiple AssetHolders. It has a dummy storage variable in order to change the ABI. TODO remove the need for this contract by allowing TESTAssetHolder to be deployed twice.
 */
 contract TESTAssetHolder2 is TESTAssetHolder {
+    address AdjudicatorAddress;
+
+    /**
+    * @notice Constructor function storing the AdjudicatorAddress.
+    * @dev Constructor function storing the AdjudicatorAddress.
+    * @param _AdjudicatorAddress Address of an Adjudicator  contract, supplied at deploy-time.
+    */
+    constructor(address _AdjudicatorAddress) public {
+        AdjudicatorAddress = _AdjudicatorAddress;
+    }
+
+    modifier AdjudicatorOnly {
+        require(msg.sender == AdjudicatorAddress, 'Only the NitroAdjudicator is authorized');
+        _;
+    }
+
     bool public dummy;
 }

--- a/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcome.test.ts
+++ b/packages/nitro-protocol/test/contracts/NitroAdjudicator/pushOutcome.test.ts
@@ -114,7 +114,10 @@ describe('pushOutcome', () => {
       );
 
       // Call public wrapper to set state (only works on test contract)
-      const tx = await TestNitroAdjudicator.setChannelStorageHash(channelId, initialChannelStorageHash);
+      const tx = await TestNitroAdjudicator.setChannelStorageHash(
+        channelId,
+        initialChannelStorageHash
+      );
       await tx.wait();
       expect(await TestNitroAdjudicator.channelStorageHashes(channelId)).toEqual(
         initialChannelStorageHash


### PR DESCRIPTION
Hey @geoknee I noticed that the `pushOutcome.test.ts` tests were failing with an `Only the NitroAdjudicator is authorized` error occurring. I realized this must have happened because I recently changed `ganache-deployer` to deploy `ETHAssetHolder` and `ERC20AssetHolder` with the real `NitroAdjudicator` contract as the `AdjudicatorAddress` argument (see https://github.com/statechannels/monorepo/pull/583). However this is problematic because the tests relied on those two asset holders allowing the `TESTNitroAdjudicator` as the `AdjudicatorAddress`.

Anyway three things:

1. I don't know how the CI did not catch this.

2. I tried adding the `constructor` from `ETHAssetHolder` to `TESTAssetHolder` and re-writing the tests (as you can see in this PR) but I am now seeing a `revert` on tests 1 and 4 for some reason that I cannot figure out.

3. In general, we need to de-couple contract deployment in the `nitro-protocol` package test environment from contract deployment for the `wallet`.. I think.. maybe.