### PR TITLE
Remove tslint checker on WebPack

### DIFF
--- a/packages/wallet/config/webpack.config.js
+++ b/packages/wallet/config/webpack.config.js
@@ -510,7 +510,7 @@ module.exports = function(webpackEnv) {
         async: false,
         checkSyntacticErrors: true,
         useTypescriptIncrementalApi: false, // This seems to speed up type checking
-        tslint: true,
+        tslint: false,
         reportFiles: ["src/**/*.{ts,tsx}"],
         watch: paths.appSrc
       })


### PR DESCRIPTION
This seems highly unnecessary.