### PR TITLE
Switch wallet tsconfig to use esnext module

### DIFF
--- a/packages/wallet/config/webpack.config.js
+++ b/packages/wallet/config/webpack.config.js
@@ -273,8 +273,18 @@ module.exports = function(webpackEnv) {
         PnpWebpackPlugin.moduleLoader(module)
       ]
     },
+    
+    // Webpack has some issue with ts-loader, transpileOnly, and esnext
+    // https://github.com/TypeStrong/ts-loader/issues/751#issuecomment-376318718
+    stats: {
+      warningsFilter: /export .* was not found in/,
+    },
+
     module: {
-      strictExportPresence: true,
+      // Because of the issue above w.r.t. ts-loader warnings, this must be set to false
+      // otherwise those meaningless warnings would break the compilation
+      strictExportPresence: false,
+
       rules: [
         // Disable require.ensure as it's not a standard language feature.
         {

--- a/packages/wallet/config/webpack.config.js
+++ b/packages/wallet/config/webpack.config.js
@@ -416,7 +416,7 @@ module.exports = function(webpackEnv) {
               // its runtime that would otherwise be processed through "file" loader.
               // Also exclude `html` and `json` extensions so they get processed
               // by webpacks internal loaders.
-              exclude: [/\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/],
+              exclude: [/\.(js|mjs|jsx|ts|tsx)$/, /\.wasm$/, /\.html$/, /\.json$/],
               options: {
                 name: "static/media/[name].[hash:8].[ext]"
               }

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -31,7 +31,7 @@
     "test:ci": "yarn test:ci:contracts && yarn test:ci:app",
     "test:contracts": "npx jest --runInBand -c ./config/jest/jest.contracts.config.js --detectOpenHandles --bail",
     "test": "run-s 'test:app --all' 'test:contracts --all'",
-    "test:integration": "npx ts-node ./puppeteer/funding.ts"
+    "test:integration": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' npx ts-node ./puppeteer/funding.ts"
   },
   "dependencies": {
     "@firebase/app-types": "^0.3.2",

--- a/packages/wallet/src/json-rpc-validation/validator.ts
+++ b/packages/wallet/src/json-rpc-validation/validator.ts
@@ -1,13 +1,13 @@
 import Ajv, {ErrorObject} from "ajv";
-import * as requestSchema from "./schema/request.json";
-import * as responseSchema from "./schema/response.json";
-import * as createChannelSchema from "./schema/create-channel.json";
-import * as getAddressSchema from "./schema/get-address.json";
-import * as joinChannelSchema from "./schema/join-channel.json";
-import * as updateChannelSchema from "./schema/update-channel.json";
-import * as definitionsSchema from "./schema/definitions.json";
-import * as pushMessageSchema from "./schema/push-message.json";
-import * as notifSchema from "./schema/notification.json";
+import requestSchema from "./schema/request.json";
+import responseSchema from "./schema/response.json";
+import createChannelSchema from "./schema/create-channel.json";
+import getAddressSchema from "./schema/get-address.json";
+import joinChannelSchema from "./schema/join-channel.json";
+import updateChannelSchema from "./schema/update-channel.json";
+import definitionsSchema from "./schema/definitions.json";
+import pushMessageSchema from "./schema/push-message.json";
+import notifSchema from "./schema/notification.json";
 
 export interface ValidationResult {
   isValid: boolean;

--- a/packages/wallet/tsconfig.json
+++ b/packages/wallet/tsconfig.json
@@ -3,7 +3,11 @@
     "baseUrl": ".",
     "composite": true,
     "outDir": "lib",
+  
+    // esnext is required for TypeScript to recognize dynamic imports (which pure-evm must be)
+    // https://github.com/Microsoft/TypeScript/issues/16820
     "module": "esnext",
+  
     "target": "es2015",
     "lib": ["es6", "dom"],
     "sourceMap": true,

--- a/packages/wallet/tsconfig.json
+++ b/packages/wallet/tsconfig.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "composite": true,
     "outDir": "lib",
-    "module": "commonjs",
+    "module": "esnext",
     "target": "es2015",
     "lib": ["es6", "dom"],
     "sourceMap": true,


### PR DESCRIPTION
In order to use dynamic imports, we need to use the `import(...)` syntax. TypeScript doesn't know how to handle this with `commonjs`, so we need to use `esnext`.

In order to use WebAssembly in the browser we need to use dynamic imports.

In order to use `pure-evm`, we need to use WebAssembly, which means we need dynamic imports.

The integration tests use `ts-node`, which uses Node.js, which can't handle ES modules. See https://github.com/TypeStrong/ts-node/issues/436.

So, I need to use `commonjs` for the `puppeteer/funding.ts` test script. Note that this is _just_ for the test script, which launches a browser, which runs the webpack output, which was built from the TypeScript source compiled using `esnext`. 