### PR TITLE
Ignore tsconfig.tsbuildinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ functions/
 .npm
 .rpt2_cache
 .eslintcache
+tsconfig.tsbuildinfo
 
 # coverage
 coverage


### PR DESCRIPTION
This file is produced by packages with `composite` set to `true` in their `tsconfig`. It helps make builds go faster. See [here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#composite-projects) for more.