### PR TITLE
Update tsconfig.json of devtools

### DIFF
--- a/packages/devtools/src/config/env.ts
+++ b/packages/devtools/src/config/env.ts
@@ -17,7 +17,7 @@ export function configureEnvVariables(monorepo = true) {
     NODE_ENV !== 'test' && `.env.local`,
     `.env.${NODE_ENV}`,
     '.env'
-  ].filter(Boolean);
+  ].filter((x): x is string => !!x);
 
   if (monorepo) {
     const monorepoDotenvFiles = dotenvFiles.slice(0);

--- a/packages/devtools/tsconfig.json
+++ b/packages/devtools/tsconfig.json
@@ -1,26 +1,15 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "composite": true,
-    "outDir": "lib",
+    "lib": ["es6"],
     "module": "commonjs",
-    "target": "es2015",
-    "lib": ["es6", "dom"],
-    "sourceMap": true,
-    "jsx": "react",
-    "moduleResolution": "node",
-    "declaration": true,
-    "declarationMap": true,
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitReturns": true,
     "noImplicitThis": true,
+    "outDir": "lib",
     "strictNullChecks": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "noUnusedLocals": true,
-    "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true,
-    "esModuleInterop": true,
-    "types": ["node", "jest"]
+    "target": "es2015",
+    "types": ["node", "jest"],
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
When I updated the monorepo `tsconfig` earlier this year I mentioned I would later go through each child package and try to merge any duplicate or unneeded keys to minimize complexity. Devtools was added later, so just doing this now.