### PR TITLE
[wallet] Use correct polyfill technique for wallet jest tests

### DIFF
--- a/packages/wallet/config/jest/jest.config.js
+++ b/packages/wallet/config/jest/jest.config.js
@@ -31,8 +31,5 @@ module.exports = {
     "json",
     "node",
     "mjs"
-  ],
-  globals: {
-    PureEVM: require("pure-evm")
-  }
+  ]
 };

--- a/packages/wallet/config/polyfills.js
+++ b/packages/wallet/config/polyfills.js
@@ -20,3 +20,5 @@ Object.assign = require("object-assign");
 if (process.env.NODE_ENV === "test") {
   require("raf").polyfill(global);
 }
+
+window.PureEVM = require("pure-evm");


### PR DESCRIPTION
Using the `globals` field in the jest config was the wrong approach for providing `window.PureEVM` in the jest tests for the `wallet`. Instead, this should have been a polyfill provided to `setupTests`. This fixed that.