### PR TITLE
Fix issues with lint-staged in various packages

### DIFF
--- a/packages/channel-provider/package.json
+++ b/packages/channel-provider/package.json
@@ -16,8 +16,8 @@
     "test:coverage": "jest --coverage",
     "test:ci": "CI=true jest --runInBand --ci --all --detectOpenHandles",
     "precommit": "lint-staged --quiet",
-    "lint:check": "npx eslint \"*/**/*.ts\" --cache",
-    "lint:write": "npx eslint \"*/**/*.ts\" --fix"
+    "lint:check": "eslint \"*/**/*.ts\" --cache",
+    "lint:write": "eslint \"*/**/*.ts\" --fix"
   },
   "jest": {
     "roots": [
@@ -34,7 +34,7 @@
     ]
   },
   "lint-staged": {
-    "src/**/*.ts": "yarn lint:check"
+    "{src,test}/**/*.ts": "eslint"
   },
   "browserslist": {
     "production": [

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "prepare": "yarn build:typescript",
     "build:typescript": "npx tsc -b",
-    "lint:check": "npx eslint \"*/**/*.ts\" --cache",
-    "lint:write": "npx eslint \"*/**/*.ts\" --fix",
+    "lint:check": "eslint \"*/**/*.ts\" --cache",
+    "lint:write": "eslint \"*/**/*.ts\" --fix",
     "precommit": "lint-staged --quiet"
   },
   "author": "Andrew Stewart",
@@ -55,6 +55,6 @@
     "typescript": "3.7.2"
   },
   "lint-staged": {
-    "{src,test}/**/*.ts": "yarn lint:check"
+    "src/**/*.ts": "eslint"
   }
 }

--- a/packages/embedded-wallet/package.json
+++ b/packages/embedded-wallet/package.json
@@ -18,8 +18,8 @@
     "test:ci": "react-scripts test --runInBand",
     "test:coverage": "react-scripts test --coverage --watchAll=false",
     "eject": "react-scripts eject",
-    "lint:check": "npx eslint \"*/**/*.{js,ts,tsx}\" --cache",
-    "lint:write": "npx eslint \"*/**/*.{js,ts,tsx}\" --fix"
+    "lint:check": "eslint \"*/**/*.{js,ts,tsx}\" --cache",
+    "lint:write": "eslint \"*/**/*.{js,ts,tsx}\" --fix"
   },
   "jest": {
     "collectCoverageFrom": [
@@ -33,7 +33,7 @@
     }
   },
   "lint-staged": {
-    "src/**/*.tsx?": "yarn lint:check"
+    "src/**/*.tsx?": "eslint"
   },
   "browserslist": {
     "production": [

--- a/packages/embedded-wallet/package.json
+++ b/packages/embedded-wallet/package.json
@@ -33,7 +33,7 @@
     }
   },
   "lint-staged": {
-    "src/**/*.tsx?": "eslint"
+    "src/**/*.{ts,tsx}": "eslint"
   },
   "browserslist": {
     "production": [

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -22,10 +22,11 @@
     "build": "npx tsc",
     "prepare": "yarn build",
     "prestart": "yarn build && npm run db:rollback && npm run db:migrate && npm run db:seed",
-    "lint:check": "npx eslint \"*/**/*.{js,ts,tsx}\" --cache",
-    "lint:write": "npx eslint \"*/**/*.{js,ts,tsx}\" --fix",
+    "lint:check": "eslint \"*/**/*.{js,ts,tsx}\" --cache",
+    "lint:write": "eslint \"*/**/*.{js,ts,tsx}\" --fix",
     "prettier:check": "npx prettier --check 'src/**/*.{ts,tsx}'",
-    "prettier:write": "npx prettier --write 'src/**/*.{ts,tsx}'"
+    "prettier:write": "npx prettier --write 'src/**/*.{ts,tsx}'",
+    "precommit": "lint-staged --quiet"
   },
   "dependencies": {
     "@koa/cors": "2.2.3",
@@ -73,6 +74,7 @@
     "ganache-cli": "6.7.0",
     "jest": "24.9.0",
     "koa-bodyparser": "4.2.1",
+    "lint-staged": "9.4.0",
     "node-fetch": "2.6.0",
     "nodemon": "1.19.4",
     "npm-run-all": "4.1.5",
@@ -81,5 +83,8 @@
     "ts-jest": "24.1.0",
     "ts-node": "8.4.1",
     "typescript": "3.7.2"
+  },
+  "lint-staged": {
+    "src/**/*.ts": "eslint"
   }
 }

--- a/packages/jest-gas-reporter/package.json
+++ b/packages/jest-gas-reporter/package.json
@@ -11,11 +11,11 @@
     "precommit": "lint-staged --quiet",
     "prepare": "yarn build",
     "build": "yarn lint:check && tsc -b",
-    "lint:check": "npx eslint \"*/**/*.ts\" --cache",
-    "lint:write": "npx eslint \"*/**/*.ts\" --fix"
+    "lint:check": "eslint \"*/**/*.ts\" --cache",
+    "lint:write": "eslint \"*/**/*.ts\" --fix"
   },
   "lint-staged": {
-    "src/*.ts": "yarn lint:check"
+    "src/*.ts": "eslint"
   },
   "devDependencies": {
     "@types/easy-table": "0.0.32",

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -38,8 +38,8 @@
     "contract:compile": "node ./bin/compile.js",
     "clearContracts": "rm -rf build/contracts",
     "clearLib": "rm -rf lib",
-    "lint:check": "npx eslint \"*/**/*.ts\" --cache",
-    "lint:write": "npx eslint \"*/**/*.ts\" --fix",
+    "lint:check": "eslint \"*/**/*.ts\" --cache",
+    "lint:write": "eslint \"*/**/*.ts\" --fix",
     "prepare": "yarn patch-package && yarn build",
     "docgen": "npx solidoc",
     "patch-package": "cd ../.. && yarn patch-package",
@@ -98,6 +98,6 @@
     "write-json-file": "4.2.0"
   },
   "lint-staged": {
-    "{src,test}/**/*.tsx?": "yarn lint:check"
+    "{src,test}/**/*.tsx?": "eslint"
   }
 }

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -98,6 +98,6 @@
     "write-json-file": "4.2.0"
   },
   "lint-staged": {
-    "{src,test}/**/*.tsx?": "eslint"
+    "{src,test}/**/*.{ts,tsx}": "eslint"
   }
 }

--- a/packages/rps/package.json
+++ b/packages/rps/package.json
@@ -30,7 +30,8 @@
     "test:ci": "yarn test:ci:contracts && yarn test:ci:app",
     "test:ci:contracts": "yarn test:contracts --all --ci --runInBand --detectOpenHandles",
     "test:ci:app": "yarn test:app --all --ci --runInBand --detectOpenHandles",
-    "storybook": "start-storybook -p 9001 -c .storybook"
+    "storybook": "start-storybook -p 9001 -c .storybook",
+    "precommit": "lint-staged --quiet"
   },
   "lint-staged": {
     "{src,tests}/**/*.tsx?": "yarn lint:check"
@@ -156,6 +157,7 @@
     "ganache-cli": "^6.1.8",
     "html-webpack-plugin": "4.0.0-beta.5",
     "jest": "24.9.0",
+    "lint-staged": "9.4.0",
     "node-sass": "4.12.0",
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "pnp-webpack-plugin": "1.2.1",

--- a/packages/rps/package.json
+++ b/packages/rps/package.json
@@ -34,7 +34,7 @@
     "precommit": "lint-staged --quiet"
   },
   "lint-staged": {
-    "{src,tests}/**/*.tsx?": "yarn lint:check"
+    "{src,tests}/**/*.{ts,tsx}": "yarn lint:check"
   },
   "dependencies": {
     "@babel/core": "^7.6.2",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -14,8 +14,8 @@
     "build:typescript": "npx tsc -b",
     "build:webpack": "CI=false node scripts/build.js",
     "build": "run-s build:typescript build:webpack",
-    "lint:check": "yarn tslint -c tslint.json -p .",
-    "lint:write": "yarn tslint -c tslint.json -p . --fix ",
+    "lint:check": "tslint -c tslint.json -p .",
+    "lint:write": "tslint -c tslint.json -p . --fix ",
     "patch-package": "cd ../.. && yarn patch-package",
     "postinstall": "rm -f node_modules/web3/index.d.ts",
     "prepare": "yarn patch-package && yarn build:typescript",
@@ -210,6 +210,6 @@
     "yargs": "14.0.0"
   },
   "lint-staged": {
-    "{src,test}/**/*.tsx?": "yarn lint:check"
+    "{src,test}/**/*.{ts,tsx}": "yarn lint:check"
   }
 }

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -14,12 +14,12 @@
     "build:typescript": "npx tsc -b",
     "build:webpack": "CI=false node scripts/build.js",
     "build": "run-s build:typescript build:webpack",
-    "lint:check": "yarn run tslint --config tslint.json  './**/*.{ts,js,tsx,jsx}'",
-    "lint:write": "yarn run tslint --config tslint.json  './**/*.{ts,js,tsx,jsx}' --fix ",
+    "lint:check": "yarn tslint -c tslint.json -p .",
+    "lint:write": "yarn tslint -c tslint.json -p . --fix ",
     "patch-package": "cd ../.. && yarn patch-package",
     "postinstall": "rm -f node_modules/web3/index.d.ts",
     "prepare": "yarn patch-package && yarn build:typescript",
-    "prettier:check": "npx prettier --check  './**/*.{ts,js,tsx,jsx}'",
+    "prettier:check": "npx prettier --check './**/*.{ts,js,tsx,jsx}'",
     "prettier:write": "npx prettier --write './**/*.{ts,js,tsx,jsx}'",
     "start": "node scripts/start.js",
     "storybook": "start-storybook -p 9001 -c .storybook",
@@ -32,7 +32,8 @@
     "test": "run-s 'test:app --all' 'test:contracts --all'",
     "test:puppeteer": "npx jest --runInBand -c ./config/jest/jest.puppeteer.config.js",
     "puppeteer:script": "npx ts-node -O '{\"module\":\"commonjs\"}' ./puppeteer/scripts/funding.ts ",
-    "test:ci:integration": "wait-on http-get://localhost:3055/ && yarn test:puppeteer"
+    "test:ci:integration": "wait-on http-get://localhost:3055/ && yarn test:puppeteer",
+    "precommit": "lint-staged --quiet"
   },
   "dependencies": {
     "@firebase/app-types": "^0.3.2",
@@ -209,6 +210,6 @@
     "yargs": "14.0.0"
   },
   "lint-staged": {
-    "{src,test}/**/*.ts": "yarn lint:check"
+    "{src,test}/**/*.tsx?": "yarn lint:check"
   }
 }

--- a/packages/wallet/tsconfig.json
+++ b/packages/wallet/tsconfig.json
@@ -26,7 +26,7 @@
     "esModuleInterop": true
   },
 
-  "include": ["src/**/*", "src/**/*.json", "types/globals.d.ts", "contracts/**/*.json", "index.ts"],
+  "include": ["src/**/*", "src/**/*.json", "types/globals.d.ts", "contracts/**/*.json"],
   "references": [{"path": "../nitro-protocol"}],
   "exclude": ["src/setupTests.ts"]
 }

--- a/packages/web3torrent/package.json
+++ b/packages/web3torrent/package.json
@@ -103,7 +103,7 @@
     "lint:write": "tslint -c tslint.json -p . --fix"
   },
   "lint-staged": {
-    "src/**/*.tsx?": "yarn lint:check"
+    "src/**/*.ts*": "yarn lint:check"
   },
   "browserslist": [
     ">0.2%",

--- a/packages/web3torrent/package.json
+++ b/packages/web3torrent/package.json
@@ -103,7 +103,7 @@
     "lint:write": "tslint -c tslint.json -p . --fix"
   },
   "lint-staged": {
-    "{src,tests}/**/*.tsx?": "yarn lint:check"
+    "src/**/*.tsx?": "yarn lint:check"
   },
   "browserslist": [
     ">0.2%",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4500,18 +4500,6 @@
     "@types/koa-compose" "*"
     "@types/node" "*"
 
-"@types/koa@2.11.0":
-  version "2.11.0"
-  resolved "https://registry.npmjs.org/@types/koa/-/koa-2.11.0.tgz#394a3e9ec94f796003a6c8374b4dbc2778746f20"
-  integrity sha512-Hgx/1/rVlJvqYBrdeCsS7PDiR2qbxlMt1RnmNWD4Uxi5FF9nwkYqIldo7urjc+dfNpk+2NRGcnAYd4L5xEhCcQ==
-  dependencies:
-    "@types/accepts" "*"
-    "@types/cookies" "*"
-    "@types/http-assert" "*"
-    "@types/keygrip" "*"
-    "@types/koa-compose" "*"
-    "@types/node" "*"
-
 "@types/koa__cors@2.2.3":
   version "2.2.3"
   resolved "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-2.2.3.tgz#227154b4c70439083b33c89627eb780a517cd05b"


### PR DESCRIPTION
Andrew and I noticed that the linting precommit hook wasn't working as expected, so I investigated. Turns out some packages did not have it set at all (i.e., `rps` and `hub`) and others had it set incorrectly (wrong regex to search for staged files). Also, it was implemented incorrectly in the first place in most cases, as if there _were_ a staged filed to be linted, it would run `yarn lint:check` which usually linted _every_ file and not just the sole changed one.