### PR TITLE
[wallet] Send out json-rpc notifications for hiding/showing the wallet

### DIFF
--- a/packages/wallet/src/json-rpc-validation/schema/notification.json
+++ b/packages/wallet/src/json-rpc-validation/schema/notification.json
@@ -30,6 +30,24 @@
       "allOf": [
         {
           "if": {
+            "properties": {
+              "method": {
+                "const": "UIUpdate"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "showWallet": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
             "properties": {"method": {"const": "MessageQueued"}}
           },
           "then": {

--- a/packages/wallet/src/redux/sagas/__tests__/display-sender.test.ts
+++ b/packages/wallet/src/redux/sagas/__tests__/display-sender.test.ts
@@ -1,8 +1,9 @@
 import {displaySender} from "../display-sender";
 import * as matchers from "redux-saga-test-plan/matchers";
 import {expectSaga} from "redux-saga-test-plan";
-describe("message listener", () => {
-  it("creates a notification for displaying the wallet", async () => {
+
+describe("display sender", () => {
+  it("sends a notification for displaying the wallet", async () => {
     const {effects} = await expectSaga(displaySender, "Show")
       .provide([[matchers.call.fn(window.parent.postMessage), 0]])
       .run();
@@ -19,7 +20,7 @@ describe("message listener", () => {
     });
   });
 
-  it("creates a notification for hiding the wallet", async () => {
+  it("sends a notification for hiding the wallet", async () => {
     const {effects} = await expectSaga(displaySender, "Hide")
       .provide([[matchers.call.fn(window.parent.postMessage), 0]])
       .run();

--- a/packages/wallet/src/redux/sagas/__tests__/display-sender.test.ts
+++ b/packages/wallet/src/redux/sagas/__tests__/display-sender.test.ts
@@ -1,0 +1,38 @@
+import {displaySender} from "../display-sender";
+import * as matchers from "redux-saga-test-plan/matchers";
+import {expectSaga} from "redux-saga-test-plan";
+describe("message listener", () => {
+  it("creates a notification for displaying the wallet", async () => {
+    const {effects} = await expectSaga(displaySender, "Show")
+      .provide([[matchers.call.fn(window.parent.postMessage), 0]])
+      .run();
+
+    expect(effects.put[0].payload.action).toMatchObject({
+      type: "WALLET.DISPLAY_MESSAGE_SENT"
+    });
+    expect(effects.call[0].payload.args[0]).toMatchObject({
+      jsonrpc: "2.0",
+      method: "UIUpdate",
+      params: {
+        showWallet: true
+      }
+    });
+  });
+
+  it("creates a notification for hiding the wallet", async () => {
+    const {effects} = await expectSaga(displaySender, "Hide")
+      .provide([[matchers.call.fn(window.parent.postMessage), 0]])
+      .run();
+
+    expect(effects.put[0].payload.action).toMatchObject({
+      type: "WALLET.DISPLAY_MESSAGE_SENT"
+    });
+    expect(effects.call[0].payload.args[0]).toMatchObject({
+      jsonrpc: "2.0",
+      method: "UIUpdate",
+      params: {
+        showWallet: false
+      }
+    });
+  });
+});

--- a/packages/wallet/src/redux/sagas/display-sender.ts
+++ b/packages/wallet/src/redux/sagas/display-sender.ts
@@ -1,7 +1,13 @@
-import {put} from "redux-saga/effects";
+import {put, call} from "redux-saga/effects";
 import {displayMessageSent} from "../actions";
+import jrs from "jsonrpc-lite";
+import {validateNotification} from "../../json-rpc-validation/validator";
 
-export function* displaySender(displayMessage) {
-  console.log(`The wallet wants to ${displayMessage} itself`);
+export function* displaySender(displayMessage: "Show" | "Hide") {
+  const showWallet = displayMessage === "Show";
+
+  const message = jrs.notification("UIUpdate", {showWallet});
+  yield validateNotification(message);
+  yield call(window.parent.postMessage, message, "*");
   yield put(displayMessageSent({}));
 }


### PR DESCRIPTION
Fixes #444 

This will allow the `ChannelProvider` to show/hide the wallet appropriately.