### PR TITLE
[Wallet] Return funding array from API

### DIFF
--- a/packages/wallet/src/redux/sagas/__tests__/message-sender.test.ts
+++ b/packages/wallet/src/redux/sagas/__tests__/message-sender.test.ts
@@ -17,8 +17,9 @@ import * as matchers from "redux-saga-test-plan/matchers";
 import {messageSender} from "../message-sender";
 import {channelFromStates} from "../../channel-store/channel-state/__tests__";
 import * as stateHelpers from "../../__tests__/state-helpers";
-import {setChannel, EMPTY_SHARED_DATA} from "../../state";
+import {setChannel, EMPTY_SHARED_DATA, SharedData} from "../../state";
 import {strategyApproved} from "../../../communication";
+import {ETH_ASSET_HOLDER_ADDRESS} from "../../../constants";
 
 describe("message sender", () => {
   it("creates a notification for WALLET.SEND_CHANNEL_PROPOSED_MESSAGE", async () => {
@@ -200,12 +201,16 @@ describe("message sender", () => {
 
   it("creates a correct response message for WALLET.UPDATE_CHANNEL_RESPONSE", async () => {
     const {state, signature} = stateHelpers.appState({turnNum: 1});
-
+    const channelId = stateHelpers.channelId;
+    const testSharedData: SharedData = {
+      ...EMPTY_SHARED_DATA,
+      assetHoldersState: {[ETH_ASSET_HOLDER_ADDRESS]: {[channelId]: {holdings: "0x5", channelId}}}
+    };
     const initialState = setChannel(
-      EMPTY_SHARED_DATA,
+      testSharedData,
       channelFromStates([{state, signature}], stateHelpers.asAddress, stateHelpers.asPrivateKey)
     );
-    const channelId = stateHelpers.channelId;
+
     const message = updateChannelResponse({
       id: 1,
       channelId
@@ -220,7 +225,7 @@ describe("message sender", () => {
       jsonrpc: "2.0",
       id: 1,
       result: {
-        funding: [],
+        funding: [{token: "0x0", amount: "0x5"}],
         turnNum: 1,
         status: "Running",
         channelId

--- a/packages/wallet/src/redux/sagas/message-sender.ts
+++ b/packages/wallet/src/redux/sagas/message-sender.ts
@@ -7,6 +7,8 @@ import {createJsonRpcAllocationsFromOutcome} from "../../utils/json-rpc-utils";
 import jrs from "jsonrpc-lite";
 import {unreachable} from "../../utils/reducer-utils";
 import {validateResponse, validateNotification} from "../../json-rpc-validation/validator";
+import {getChannelHoldings} from "../selectors";
+import {bigNumberify} from "ethers/utils";
 
 export function* messageSender(action: OutgoingApiAction) {
   const message = yield createResponseMessage(action);
@@ -113,7 +115,13 @@ function* getChannelInfo(channelId: string) {
 
   const {participants} = channelStatus;
   const {appData, appDefinition, turnNum} = state;
-  const funding = [];
+
+  const channelHoldings = yield select(getChannelHoldings, channelId);
+  let funding: any[] = [];
+  // TODO: For now we assume ETH
+  if (!bigNumberify(channelHoldings).isZero()) {
+    funding = [{token: "0x0", amount: channelHoldings}];
+  }
   const status = channelStatus.turnNum < participants.length - 1 ? "Opening" : "Running";
   return {
     participants,

--- a/packages/wallet/src/redux/selectors.ts
+++ b/packages/wallet/src/redux/selectors.ts
@@ -8,7 +8,7 @@ import {
 import * as walletStates from "./state";
 import {SharedData, FundingState} from "./state";
 import {ProcessProtocol} from "../communication";
-import {CONSENSUS_LIBRARY_ADDRESS} from "../constants";
+import {CONSENSUS_LIBRARY_ADDRESS, ETH_ASSET_HOLDER_ADDRESS} from "../constants";
 import {bigNumberify} from "ethers/utils";
 import {State} from "@statechannels/nitro-protocol";
 import {AddressZero} from "ethers/constants";
@@ -195,4 +195,18 @@ export const getParticipantIdForAddress = (state: SharedData, address: string): 
     }
   }
   throw new Error(`Could not find a participant id for address ${address}`);
+};
+
+export const getChannelHoldings = (
+  state: SharedData,
+  channelId: string,
+  assetHolderAddress = ETH_ASSET_HOLDER_ADDRESS
+): string => {
+  if (!state.assetHoldersState[assetHolderAddress]) {
+    return "0x0";
+  }
+  if (!state.assetHoldersState[assetHolderAddress][channelId]) {
+    return "0x0";
+  }
+  return state.assetHoldersState[assetHolderAddress][channelId].holdings;
 };


### PR DESCRIPTION
Fixes #645 

Sets the `funding` array on the API response for `UpdateState`. Currently only supports ETH.