### PR TITLE
Turn off formatOnSave

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,5 @@
     {"directory": "packages/jest-gas-reporter", "changeProcessCWD": true},
     {"directory": "packages/nitro-protocol", "changeProcessCWD": true}
   ],
-  "editor.formatOnSave": true
+  "editor.formatOnSave": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,5 @@
     {"directory": "packages/hub", "changeProcessCWD": true},
     {"directory": "packages/jest-gas-reporter", "changeProcessCWD": true},
     {"directory": "packages/nitro-protocol", "changeProcessCWD": true}
-  ],
-  "editor.formatOnSave": false
+  ]
 }


### PR DESCRIPTION
For me, this was affecting files in the `wallet` folder while I had open the `monorepo` as a root folder in my workspace. It was applying the `bracketSpacing: true` rule in particular every time I hit save.

Turning this flag off fixed the issue.