### PR TITLE
[channel-provider] Update ChannelProvider JSON-RPC Schema

### DIFF
--- a/packages/channel-provider/package.json
+++ b/packages/channel-provider/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "version": "0.0.3",
   "main": "dist/channel-provider.min.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "dependencies": {
     "debug": "4.1.1",
     "eventemitter3": "4.0.0"

--- a/packages/channel-provider/src/channel-provider.ts
+++ b/packages/channel-provider/src/channel-provider.ts
@@ -38,7 +38,7 @@ class ChannelProvider implements IChannelProvider {
     this.events.emit('connect');
   }
 
-  async send<ResultType = any>(method: string, params: any[] = []): Promise<ResultType> {
+  async send<ResultType = any>(method: string, params: object = {}): Promise<ResultType> {
     const target = await this.ui.getTarget();
     const response = (await this.messaging.request(target, {
       jsonrpc: '2.0',
@@ -49,7 +49,7 @@ class ChannelProvider implements IChannelProvider {
     return response;
   }
 
-  async subscribe(subscriptionType: string, params: any[] = []): Promise<string> {
+  async subscribe(subscriptionType: string, params: object = {}): Promise<string> {
     const response = await this.send<JsonRpcSubscribeResult>('chan_subscribe', [
       subscriptionType,
       ...params

--- a/packages/channel-provider/src/types.ts
+++ b/packages/channel-provider/src/types.ts
@@ -4,7 +4,7 @@ export type JsonRpcRequest = {
   id?: number;
   jsonrpc: '2.0';
   method: string;
-  params: any[];
+  params: object;
 };
 
 export type JsonRpcResponse<ResultType = any> = {
@@ -29,8 +29,8 @@ export type JsonRpcErrorResponse = {
 
 export interface IChannelProvider {
   enable(url?: string): Promise<void>;
-  send<ResultType = any>(method: string, params?: any[]): Promise<ResultType>;
-  subscribe(subscriptionType: string, params?: any[]): Promise<string>;
+  send<ResultType = any>(method: string, params?: object): Promise<ResultType>;
+  subscribe(subscriptionType: string, params?: object): Promise<string>;
   unsubscribe(subscriptionId: string): Promise<boolean>;
   on(event: string, callback: ListenerFn): void;
   off(event: string, callback?: ListenerFn): void;

--- a/packages/channel-provider/tests/messaging-service.test.ts
+++ b/packages/channel-provider/tests/messaging-service.test.ts
@@ -13,7 +13,7 @@ describe('MessagingService', () => {
     jsonrpc: '2.0',
     id: 123,
     method: 'foo',
-    params: ['bar', 1, true]
+    params: {0: 'bar', 1: 1, 2: true}
   } as JsonRpcRequest;
 
   const response = {


### PR DESCRIPTION
Apparently `params` can either be an array or an object but not both.

Object is better I think. Also it's easier to type it.

See: https://www.jsonrpc.org/specification

Also this PR fixes a path mistake for the package's types.