### PR TITLE
Add missing types to satifsy typesync

### DIFF
--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -106,6 +106,8 @@
     "@types/detect-port": "1.1.0",
     "@types/enzyme": "3.10.0",
     "@types/enzyme-adapter-react-16": "1.0.5",
+    "@types/eslint": "^6.1.3",
+    "@types/eslint-plugin-prettier": "^2.2.0",
     "@types/extract-text-webpack-plugin": "3.0.4",
     "@types/file-loader": "4.2.0",
     "@types/fs-extra": "8.0.1",


### PR DESCRIPTION
These `typings` were being added by `TypeSync` when running `yarn`.