### PR TITLE
Hub: env vars

### DIFF
--- a/packages/hub/config/env.js
+++ b/packages/hub/config/env.js
@@ -1,7 +1,4 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const {configureEnvVariables} = require('magmo-devtools');
-
+const {configureEnvVariables} = require('@statechannels/devtools');
 configureEnvVariables();

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@koa/cors": "2.2.3",
     "@statechannels/nitro-protocol": "0.0.1",
+    "@statechannels/wallet": "0.0.1",
     "async-lock": "1.2.2",
     "dotenv": "6.2.0",
     "dotenv-expand": "4.2.0",
@@ -42,12 +43,11 @@
     "koa-body": "4.1.1",
     "koa-router": "7.4.0",
     "lodash": "^4.17.15",
-    "magmo-devtools": "git+https://github.com/magmo/devtools.git#v0.1.20",
     "objection": "1.6.11",
     "pg": "7.12.1"
   },
   "devDependencies": {
-    "@statechannels/wallet": "0.0.1",
+    "@statechannels/devtools": "0.1.21",
     "@types/async-lock": "1.1.1",
     "@types/dotenv": "6.1.1",
     "@types/eslint": "^6.1.3",

--- a/packages/hub/src/hub/server.ts
+++ b/packages/hub/src/hub/server.ts
@@ -1,5 +1,3 @@
-import '../../config/env';
-
 import {fork} from 'child_process';
 import {Model} from 'objection';
 import {RelayableAction} from '../communication';

--- a/packages/hub/src/start-dev-server.ts
+++ b/packages/hub/src/start-dev-server.ts
@@ -1,5 +1,6 @@
 import {setupGanache} from '@statechannels/devtools';
 import {deploy} from '../deployment/deploy';
+import '../config/env'; // Note: importing this module has the side effect of modifying env vars
 import {startServer} from './hub/server';
 
 async function setupGanacheAndContracts() {

--- a/packages/hub/src/start-dev-server.ts
+++ b/packages/hub/src/start-dev-server.ts
@@ -1,6 +1,7 @@
+import '../config/env'; // Note: importing this module has the side effect of modifying env vars
+
 import {setupGanache} from '@statechannels/devtools';
 import {deploy} from '../deployment/deploy';
-import '../config/env'; // Note: importing this module has the side effect of modifying env vars
 import {startServer} from './hub/server';
 
 async function setupGanacheAndContracts() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8325,7 +8325,7 @@ chai@4.1.2:
     pathval "^1.0.0"
     type-detect "^4.0.0"
 
-chai@4.2.0, chai@^4.0.1, chai@^4.1.2, chai@^4.2.0:
+chai@4.2.0, chai@^4.0.1, chai@^4.1.2:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
   integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
@@ -10568,7 +10568,7 @@ dotenv-webpack@^1.7.0:
   dependencies:
     dotenv-defaults "^1.0.2"
 
-dotenv@6.2.0, dotenv@^6.1.0, dotenv@^6.2.0:
+dotenv@6.2.0, dotenv@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
   integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
@@ -11976,7 +11976,7 @@ ethers@4.0.0-beta.3:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@4.0.39, ethers@^4.0.15, ethers@^4.0.26, ethers@^4.0.27, ethers@^4.0.39, ethers@~4.0.4:
+ethers@4.0.39, ethers@^4.0.26, ethers@^4.0.27, ethers@^4.0.39, ethers@~4.0.4:
   version "4.0.39"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.39.tgz#5ce9dfffedb03936415743f63b37d96280886a47"
   integrity sha512-QVtC8TTUgTrnlQjQvdFJ7fkSWKwp8HVTbKRmrdbVryrPzJHMTf3WSeRNvLF2enGyAFtyHJyFNnjN0fSshcEr9w==
@@ -15872,7 +15872,7 @@ jest-worker@^24.6.0, jest-worker@^24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
-jest@24.9.0, jest@^24.0.6:
+jest@24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-24.9.0.tgz#987d290c05a08b52c56188c1002e368edb007171"
   integrity sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==
@@ -17262,20 +17262,6 @@ magic-string@^0.22.4:
   integrity sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==
   dependencies:
     vlq "^0.2.2"
-
-"magmo-devtools@git+https://github.com/magmo/devtools.git#v0.1.20":
-  version "0.1.20"
-  resolved "git+https://github.com/magmo/devtools.git#ea3029e7aeb013724805906faff43b2c00fe7799"
-  dependencies:
-    chai "^4.2.0"
-    detect-port "^1.3.0"
-    dotenv "^6.1.0"
-    dotenv-expand "^5.1.0"
-    ethers "^4.0.15"
-    fs-extra "^8.0.1"
-    jest "^24.0.6"
-    solc "^0.5.4"
-    yargs "^12.0.5"
 
 magmo-wallet-client@0.0.3:
   version "0.0.3"
@@ -24023,7 +24009,7 @@ socks@~2.3.2:
     ip "^1.1.5"
     smart-buffer "4.0.2"
 
-solc@0.5.13, solc@^0.5.1, solc@^0.5.4, solc@^0.5.5:
+solc@0.5.13, solc@^0.5.1, solc@^0.5.5:
   version "0.5.13"
   resolved "https://registry.npmjs.org/solc/-/solc-0.5.13.tgz#2a5ba2b7681898c6293759441e0a768fb6955def"
   integrity sha512-osybDVPGjAqcmSKLU3vh5iHuxbhGlJjQI5ZvI7nRDR0fgblQqYte4MGvNjbew8DPvCrmoH0ZBiz/KBBLlPxfMg==


### PR DESCRIPTION
- migrate away from the depricated `magmo-devtools` dependency.
- do not populate environment variables in the hub application. Expect the environment variables to be populated before application start.