### PR TITLE
[wallet] Send state to opponent when calling UpdateState

### DIFF
--- a/packages/wallet/puppeteer/__tests__/funding.test.ts
+++ b/packages/wallet/puppeteer/__tests__/funding.test.ts
@@ -34,7 +34,7 @@ describe("Funding", () => {
 
     await loadWallet(walletA, createMessageHandler(walletMessages, "A"));
     await loadWallet(walletB, createMessageHandler(walletMessages, "B"));
-    // Automatically deliver messageQueued message to opponent's wallet
+    //  Automatically deliver messageQueued message to opponent's wallet
     walletMessages.on(MessageType.PlayerAMessage, async message => {
       await pushMessage(walletB, (message as any).params);
     });

--- a/packages/wallet/puppeteer/__tests__/funding.test.ts
+++ b/packages/wallet/puppeteer/__tests__/funding.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../helpers";
 import Emittery from "emittery";
 
-jest.setTimeout(10000);
+jest.setTimeout(30000);
 
 describe("Funding", () => {
   let browserA;

--- a/packages/wallet/puppeteer/__tests__/state-updating.test.ts
+++ b/packages/wallet/puppeteer/__tests__/state-updating.test.ts
@@ -1,0 +1,61 @@
+import {
+  loadWallet,
+  setUpBrowser,
+  MessageEventTypes,
+  createMessageHandler,
+  completeFunding,
+  sendUpdateState,
+  MessageType
+} from "../helpers";
+import Emittery from "emittery";
+jest.setTimeout(100000);
+describe("State Updating", () => {
+  let browserA;
+  let browserB;
+  let walletA;
+  let walletB;
+  let channelId;
+  let playerAAddress;
+  let playerBAddress;
+  let walletMessages: Emittery.Typed<MessageEventTypes>;
+  // let messageQueueFromA;
+  // let messageQueueFromB;
+  beforeAll(async () => {
+    browserA = await setUpBrowser(true);
+    browserB = await setUpBrowser(true);
+
+    walletA = await browserA.newPage();
+    walletB = await browserB.newPage();
+
+    walletMessages = new Emittery.Typed<MessageEventTypes>();
+    // messageQueueFromA = walletMessages.events(MessageType.PlayerAMessage);
+    // messageQueueFromB = walletMessages.events(MessageType.PlayerBMessage);
+
+    await loadWallet(walletA, createMessageHandler(walletMessages, "A"));
+    await loadWallet(walletB, createMessageHandler(walletMessages, "B"));
+    const fundingResult = await completeFunding(walletA, walletB, walletMessages);
+    channelId = fundingResult.channelId;
+    playerAAddress = fundingResult.playerAAddress;
+    playerBAddress = fundingResult.playerBAddress;
+  });
+
+  it("updates the state for player A", async () => {
+    const updateStatePromise: Promise<any> = walletMessages.once(MessageType.PlayerAResult);
+    await sendUpdateState(walletA, channelId, playerAAddress, playerBAddress);
+    expect(await updateStatePromise).toBeDefined();
+  });
+  it("updates the state for player B", async () => {
+    const updateStatePromise: Promise<any> = walletMessages.once(MessageType.PlayerBResult);
+    await sendUpdateState(walletB, channelId, playerAAddress, playerBAddress);
+    expect(await updateStatePromise).toBeDefined();
+  });
+
+  afterAll(async () => {
+    if (browserA) {
+      await browserA.close();
+    }
+    if (browserB) {
+      await browserB.close();
+    }
+  });
+});

--- a/packages/wallet/puppeteer/__tests__/update-state.test.ts
+++ b/packages/wallet/puppeteer/__tests__/update-state.test.ts
@@ -20,6 +20,8 @@ describe("State Updating", () => {
   let walletMessages: Emittery.Typed<MessageEventTypes>;
   let messageQueueFromA;
   let messageQueueFromB;
+  let notificationQueueFromA;
+  let notificationQueueFromB;
   beforeAll(async () => {
     browserA = await setUpBrowser(true);
     browserB = await setUpBrowser(true);
@@ -30,7 +32,8 @@ describe("State Updating", () => {
     walletMessages = new Emittery.Typed<MessageEventTypes>();
     messageQueueFromA = walletMessages.events(MessageType.PlayerAMessage);
     messageQueueFromB = walletMessages.events(MessageType.PlayerBMessage);
-
+    notificationQueueFromA = walletMessages.events(MessageType.PlayerANotification);
+    notificationQueueFromB = walletMessages.events(MessageType.PlayerBNotification);
     await loadWallet(walletA, createMessageHandler(walletMessages, "A"));
     await loadWallet(walletB, createMessageHandler(walletMessages, "B"));
     const fundingResult = await completeFunding(walletA, walletB, walletMessages);
@@ -50,16 +53,36 @@ describe("State Updating", () => {
       channelId
     });
   });
+  it("sends a channel updated message to player B", async () => {
+    const channelUpdatedMessage = (await messageQueueFromA.next()).value;
+    expect(channelUpdatedMessage.params.data.type).toEqual("Channel.Updated");
+  });
+
+  it("sends a channel updated event", async () => {
+    const channelUpdatedEvent = (await notificationQueueFromB.next()).value;
+    expect(channelUpdatedEvent.method).toEqual("ChannelUpdated");
+  });
+
   it("updates the state for player B", async () => {
     const updateStatePromise: Promise<any> = walletMessages.once(MessageType.PlayerBResult);
     await sendUpdateState(walletB, channelId, playerAAddress, playerBAddress);
     const response = await updateStatePromise;
 
     expect(response).toMatchObject({
-      turnNum: 4,
+      turnNum: 5,
       status: "Running",
       channelId
     });
+  });
+
+  it("sends a channel updated message to player A", async () => {
+    const channelUpdatedMessage = (await messageQueueFromB.next()).value;
+    expect(channelUpdatedMessage.params.data.type).toEqual("Channel.Updated");
+  });
+
+  it("sends a channel updated event", async () => {
+    const channelUpdatedEvent = (await notificationQueueFromA.next()).value;
+    expect(channelUpdatedEvent.method).toEqual("ChannelUpdated");
   });
 
   afterAll(async () => {

--- a/packages/wallet/puppeteer/__tests__/update-state.test.ts
+++ b/packages/wallet/puppeteer/__tests__/update-state.test.ts
@@ -18,8 +18,8 @@ describe("State Updating", () => {
   let playerAAddress;
   let playerBAddress;
   let walletMessages: Emittery.Typed<MessageEventTypes>;
-  // let messageQueueFromA;
-  // let messageQueueFromB;
+  let messageQueueFromA;
+  let messageQueueFromB;
   beforeAll(async () => {
     browserA = await setUpBrowser(true);
     browserB = await setUpBrowser(true);
@@ -28,8 +28,8 @@ describe("State Updating", () => {
     walletB = await browserB.newPage();
 
     walletMessages = new Emittery.Typed<MessageEventTypes>();
-    // messageQueueFromA = walletMessages.events(MessageType.PlayerAMessage);
-    // messageQueueFromB = walletMessages.events(MessageType.PlayerBMessage);
+    messageQueueFromA = walletMessages.events(MessageType.PlayerAMessage);
+    messageQueueFromB = walletMessages.events(MessageType.PlayerBMessage);
 
     await loadWallet(walletA, createMessageHandler(walletMessages, "A"));
     await loadWallet(walletB, createMessageHandler(walletMessages, "B"));
@@ -42,12 +42,24 @@ describe("State Updating", () => {
   it("updates the state for player A", async () => {
     const updateStatePromise: Promise<any> = walletMessages.once(MessageType.PlayerAResult);
     await sendUpdateState(walletA, channelId, playerAAddress, playerBAddress);
-    expect(await updateStatePromise).toBeDefined();
+    const response = await updateStatePromise;
+
+    expect(response).toMatchObject({
+      turnNum: 4,
+      status: "Running",
+      channelId
+    });
   });
   it("updates the state for player B", async () => {
     const updateStatePromise: Promise<any> = walletMessages.once(MessageType.PlayerBResult);
     await sendUpdateState(walletB, channelId, playerAAddress, playerBAddress);
-    expect(await updateStatePromise).toBeDefined();
+    const response = await updateStatePromise;
+
+    expect(response).toMatchObject({
+      turnNum: 4,
+      status: "Running",
+      channelId
+    });
   });
 
   afterAll(async () => {

--- a/packages/wallet/puppeteer/helpers.ts
+++ b/packages/wallet/puppeteer/helpers.ts
@@ -60,7 +60,7 @@ export async function loadWallet(page: puppeteer.Page, messageListener: (message
     }
   });
 
-  await page.waitFor(500); // Delay lets things load
+  await page.waitFor(1000); // Delay lets things load
   // interceptMessage gets called in puppeteer's context
   await page.exposeFunction("interceptMessage", message => {
     messageListener(message);

--- a/packages/wallet/puppeteer/helpers.ts
+++ b/packages/wallet/puppeteer/helpers.ts
@@ -56,7 +56,7 @@ export async function loadWallet(page: puppeteer.Page, messageListener: (message
   });
   page.on("console", msg => {
     if (msg.type() === "error") {
-      throw new Error(`Error was logged into the console ${msg.text}`);
+      throw new Error(`Error was logged into the console ${msg.text()}`);
     }
   });
 
@@ -157,6 +157,40 @@ export async function sendGetAddress(page: puppeteer.Page) {
   });
 }
 
+export async function sendUpdateState(
+  page: puppeteer.Page,
+  channelId: string,
+  playerAAddress,
+  playerBAddress
+) {
+  await page.evaluate(
+    (a, b, cId) => {
+      const allocations = [
+        {
+          token: "0x0",
+          allocationItems: [{destination: a, amount: "0x1"}, {destination: b, amount: "0x1"}]
+        }
+      ];
+      window.postMessage(
+        {
+          jsonrpc: "2.0",
+          method: "UpdateChannel",
+          id: 1,
+          params: {
+            channelId: cId,
+            allocations,
+            appData: "0x0"
+          }
+        },
+        "*"
+      );
+    },
+    playerAAddress,
+    playerBAddress,
+    channelId
+  );
+}
+
 export async function pushMessage(page: puppeteer.Page, message: any) {
   await page.evaluate(m => {
     window.postMessage(
@@ -169,4 +203,46 @@ export async function pushMessage(page: puppeteer.Page, message: any) {
       "*"
     );
   }, message);
+}
+
+export async function completeFunding(
+  walletA: puppeteer.Page,
+  walletB: puppeteer.Page,
+  walletMessages
+): Promise<{playerAAddress: string; playerBAddress: string; channelId: string}> {
+  //  Automatically deliver messageQueued message to opponent's wallet
+  walletMessages.on(MessageType.PlayerAMessage, async message => {
+    await pushMessage(walletB, (message as any).params);
+  });
+  walletMessages.on(MessageType.PlayerBMessage, async message => {
+    await pushMessage(walletA, (message as any).params);
+  });
+
+  const playerAAddressPromise: Promise<any> = walletMessages.once(MessageType.PlayerAResult);
+  const playerBAddressPromise: Promise<any> = walletMessages.once(MessageType.PlayerBResult);
+
+  await sendGetAddress(walletA);
+  await sendGetAddress(walletB);
+
+  const playerAAddress = (await playerAAddressPromise).result;
+  const playerBAddress = (await playerBAddressPromise).result;
+
+  const createChannelPromise: Promise<any> = walletMessages.once(MessageType.PlayerAResult);
+  await sendCreateChannel(walletA, playerAAddress, playerBAddress);
+  const channelId = (await createChannelPromise).result.channelId;
+
+  const joinChannelPromise: Promise<any> = walletMessages.once(MessageType.PlayerBResult);
+  await sendJoinChannel(walletB, channelId);
+  await joinChannelPromise;
+
+  await walletA.waitFor("button");
+  await walletA.click("button");
+  await walletB.waitFor("button");
+  await walletB.click("button");
+
+  await walletA.waitFor("button");
+  await walletA.click("button");
+  await walletB.waitFor("button");
+  await walletB.click("button");
+  return {playerAAddress, playerBAddress, channelId};
 }

--- a/packages/wallet/src/redux/channel-store/channel-state/states.ts
+++ b/packages/wallet/src/redux/channel-store/channel-state/states.ts
@@ -22,8 +22,11 @@ export interface ChannelState {
 
 export type OpenChannelState = ChannelState;
 
+export function getLastSignedState(state: ChannelState): SignedState {
+  return state.signedStates.slice(-1)[0];
+}
 export function getLastState(state: ChannelState): State {
-  return state.signedStates.slice(-1)[0].state;
+  return getLastSignedState(state).state;
 }
 
 export function getPenultimateState(state: ChannelState): State {

--- a/packages/wallet/src/redux/sagas/messaging/__tests__/message-handler.test.ts
+++ b/packages/wallet/src/redux/sagas/messaging/__tests__/message-handler.test.ts
@@ -144,6 +144,43 @@ describe("message listener", () => {
       });
     });
 
+    it("handles a pushMessage with a channel updated message", async () => {
+      const signedState = appState({turnNum: 5});
+
+      const pushMessage = {
+        jsonrpc: "2.0",
+        method: "PushMessage",
+        id: 1,
+        params: {
+          recipient: "user-a",
+          sender: "user-b",
+          data: {type: "Channel.Updated", signedState}
+        }
+      };
+
+      const {effects} = await expectSaga(messageHandler, pushMessage, "localhost")
+        .withState(initialState)
+        // Mock out the fork call so we don't actually try to post the message
+        .provide([
+          [matchers.fork.fn(messageSender), 0],
+          [matchers.select.selector(getAddress), asAddress],
+          [
+            matchers.call.fn(getProvider),
+            {
+              getCode: address => {
+                return "0x12345";
+              }
+            }
+          ]
+        ])
+        .run();
+
+      expect(effects.put[0].payload.action).toMatchObject({
+        type: "WALLET.APPLICATION.OPPONENT_STATE_RECEIVED",
+        signedState
+      });
+    });
+
     it("handles a pushMessage with a relay action message", async () => {
       const actionToRelay = strategyApproved({
         strategy: "IndirectFundingStrategy",
@@ -452,6 +489,11 @@ describe("message listener", () => {
       expect(effects.fork[0].payload.args[0]).toMatchObject({
         type: "WALLET.UPDATE_CHANNEL_RESPONSE",
         id: 1,
+        channelId: stateHelpers.channelId
+      });
+
+      expect(effects.fork[1].payload.args[0]).toMatchObject({
+        type: "WALLET.SEND_CHANNEL_UPDATED_MESSAGE",
         channelId: stateHelpers.channelId
       });
     });

--- a/packages/wallet/src/redux/sagas/messaging/__tests__/message-handler.test.ts
+++ b/packages/wallet/src/redux/sagas/messaging/__tests__/message-handler.test.ts
@@ -179,6 +179,10 @@ describe("message listener", () => {
         type: "WALLET.APPLICATION.OPPONENT_STATE_RECEIVED",
         signedState
       });
+      expect(effects.fork[0].payload.args[0]).toMatchObject({
+        type: "WALLET.CHANNEL_UPDATED_EVENT",
+        channelId: expect.any(String)
+      });
     });
 
     it("handles a pushMessage with a relay action message", async () => {

--- a/packages/wallet/src/redux/sagas/messaging/__tests__/message-sender.test.ts
+++ b/packages/wallet/src/redux/sagas/messaging/__tests__/message-sender.test.ts
@@ -9,7 +9,9 @@ import {
   updateChannelResponse,
   unknownChannelId,
   sendChannelJoinedMessage,
-  relayActionWithMessage
+  relayActionWithMessage,
+  sendChannelUpdatedMessage,
+  channelUpdatedEvent
 } from "../outgoing-api-actions";
 import {Wallet} from "ethers";
 import {expectSaga} from "redux-saga-test-plan";
@@ -22,6 +24,65 @@ import {strategyApproved} from "../../../../communication";
 import {ETH_ASSET_HOLDER_ADDRESS} from "../../../../constants";
 
 describe("message sender", () => {
+  it("creates a notification for WALLET.CHANNEL_UPDATED_EVENT", async () => {
+    const state = stateHelpers.appState({turnNum: 5});
+
+    const initialState = setChannel(
+      EMPTY_SHARED_DATA,
+      channelFromStates([state], stateHelpers.asAddress, stateHelpers.asPrivateKey)
+    );
+    const channelId = stateHelpers.channelId;
+    const message = channelUpdatedEvent({
+      channelId
+    });
+
+    const {effects} = await expectSaga(messageSender, message)
+      .withState(initialState)
+      .provide([[matchers.call.fn(window.parent.postMessage), 0]])
+      .run();
+
+    expect(effects.call[0].payload.args[0]).toMatchObject({
+      jsonrpc: "2.0",
+      method: "ChannelUpdated",
+      params: {
+        funding: [],
+        turnNum: 5,
+        status: "Running",
+        channelId
+      }
+    });
+  });
+
+  it("creates a notification for WALLET.SEND_CHANNEL_UPDATED_MESSAGE", async () => {
+    const state = stateHelpers.appState({turnNum: 0});
+
+    const initialState = setChannel(
+      EMPTY_SHARED_DATA,
+      channelFromStates([state], stateHelpers.asAddress, stateHelpers.asPrivateKey)
+    );
+    const channelId = stateHelpers.channelId;
+    const message = sendChannelUpdatedMessage({
+      channelId,
+      fromParticipantId: "A",
+      toParticipantId: "B"
+    });
+
+    const {effects} = await expectSaga(messageSender, message)
+      .withState(initialState)
+      .provide([[matchers.call.fn(window.parent.postMessage), 0]])
+      .run();
+
+    expect(effects.call[0].payload.args[0]).toMatchObject({
+      jsonrpc: "2.0",
+      method: "MessageQueued",
+      params: {
+        recipient: "A",
+        sender: "B",
+        data: {type: "Channel.Updated", signedState: state}
+      }
+    });
+  });
+
   it("creates a notification for WALLET.SEND_CHANNEL_PROPOSED_MESSAGE", async () => {
     const state = stateHelpers.appState({turnNum: 0});
 
@@ -141,6 +202,7 @@ describe("message sender", () => {
       }
     });
   });
+
   it("sends a correct response message for WALLET.POST_MESSAGE", async () => {
     const message = postMessageResponse({id: 5});
     const {effects} = await expectSaga(messageSender, message)

--- a/packages/wallet/src/redux/sagas/messaging/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-handler.ts
@@ -121,6 +121,12 @@ function* handlePushMessage(payload: RequestObject) {
             signedState: message.data.signedState
           })
         );
+        yield fork(
+          messageSender,
+          outgoingMessageActions.channelUpdatedEvent({
+            channelId: getChannelId(message.data.signedState.state.channel)
+          })
+        );
         break;
       case "Channel.Joined":
         yield put(

--- a/packages/wallet/src/redux/sagas/messaging/message-sender.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-sender.ts
@@ -83,7 +83,7 @@ function* createResponseMessage(action: OutgoingApiAction) {
         )
       );
     case "WALLET.API_NOT_IMPLEMENTED":
-      console.error(`No API method implemented for ${action.apiMethod}`);
+      console.warn(`No API method implemented for ${action.apiMethod}`);
       return undefined;
       break;
     default:

--- a/packages/wallet/src/redux/sagas/messaging/outgoing-api-actions.ts
+++ b/packages/wallet/src/redux/sagas/messaging/outgoing-api-actions.ts
@@ -1,12 +1,17 @@
 import {ActionConstructor} from "../../utils";
 import {RelayableAction} from "../../../communication";
 
-export interface ApiAction {
+export interface ApiResponseAction {
   id: number | string; // Either a string or number is technically valid
   type: string;
 }
+export interface ApiMessageNotificationAction {
+  type: string;
+  toParticipantId: string;
+  fromParticipantId: string;
+}
 
-export interface CreateChannelResponse extends ApiAction {
+export interface CreateChannelResponse extends ApiResponseAction {
   type: "WALLET.CREATE_CHANNEL_RESPONSE";
   channelId: string;
 }
@@ -15,7 +20,7 @@ export const createChannelResponse: ActionConstructor<CreateChannelResponse> = p
   type: "WALLET.CREATE_CHANNEL_RESPONSE"
 });
 
-export interface UpdateChannelResponse extends ApiAction {
+export interface UpdateChannelResponse extends ApiResponseAction {
   type: "WALLET.UPDATE_CHANNEL_RESPONSE";
   channelId: string;
 }
@@ -24,7 +29,7 @@ export const updateChannelResponse: ActionConstructor<UpdateChannelResponse> = p
   type: "WALLET.UPDATE_CHANNEL_RESPONSE"
 });
 
-export interface AddressResponse extends ApiAction {
+export interface AddressResponse extends ApiResponseAction {
   type: "WALLET.ADDRESS_RESPONSE";
   address: string;
 }
@@ -33,7 +38,7 @@ export const addressResponse: ActionConstructor<AddressResponse> = p => ({
   type: "WALLET.ADDRESS_RESPONSE"
 });
 
-export interface UnknownSigningAddress extends ApiAction {
+export interface UnknownSigningAddress extends ApiResponseAction {
   type: "WALLET.UNKNOWN_SIGNING_ADDRESS_ERROR";
   signingAddress: string;
 }
@@ -43,7 +48,7 @@ export const unknownSigningAddress: ActionConstructor<UnknownSigningAddress> = p
   type: "WALLET.UNKNOWN_SIGNING_ADDRESS_ERROR"
 });
 
-export interface UnknownChannelId extends ApiAction {
+export interface UnknownChannelId extends ApiResponseAction {
   type: "WALLET.UNKNOWN_CHANNEL_ID_ERROR";
   channelId: string;
 }
@@ -53,7 +58,7 @@ export const unknownChannelId: ActionConstructor<UnknownChannelId> = p => ({
   type: "WALLET.UNKNOWN_CHANNEL_ID_ERROR"
 });
 
-export interface NoContractError extends ApiAction {
+export interface NoContractError extends ApiResponseAction {
   address: string;
   type: "WALLET.NO_CONTRACT_ERROR";
 }
@@ -62,11 +67,9 @@ export const noContractError: ActionConstructor<NoContractError> = p => ({
   type: "WALLET.NO_CONTRACT_ERROR"
 });
 
-export interface SendChannelProposedMessage {
+export interface SendChannelProposedMessage extends ApiMessageNotificationAction {
   type: "WALLET.SEND_CHANNEL_PROPOSED_MESSAGE";
   channelId: string;
-  toParticipantId: string;
-  fromParticipantId: string;
 }
 
 export const sendChannelProposedMessage: ActionConstructor<SendChannelProposedMessage> = p => ({
@@ -74,11 +77,9 @@ export const sendChannelProposedMessage: ActionConstructor<SendChannelProposedMe
   type: "WALLET.SEND_CHANNEL_PROPOSED_MESSAGE"
 });
 
-export interface SendChannelJoinedMessage {
+export interface SendChannelJoinedMessage extends ApiMessageNotificationAction {
   type: "WALLET.SEND_CHANNEL_JOINED_MESSAGE";
   channelId: string;
-  toParticipantId: string;
-  fromParticipantId: string;
 }
 
 export const sendChannelJoinedMessage: ActionConstructor<SendChannelJoinedMessage> = p => ({
@@ -96,7 +97,7 @@ export const channelProposedEvent: ActionConstructor<ChannelProposedEvent> = p =
   type: "WALLET.CHANNEL_PROPOSED_EVENT"
 });
 
-export interface PostMessageResponse extends ApiAction {
+export interface PostMessageResponse extends ApiResponseAction {
   type: "WALLET.POST_MESSAGE_RESPONSE";
 }
 
@@ -105,7 +106,7 @@ export const postMessageResponse: ActionConstructor<PostMessageResponse> = p => 
   type: "WALLET.POST_MESSAGE_RESPONSE"
 });
 
-export interface JoinChannelResponse extends ApiAction {
+export interface JoinChannelResponse extends ApiResponseAction {
   type: "WALLET.JOIN_CHANNEL_RESPONSE";
   channelId: string;
 }
@@ -114,7 +115,7 @@ export const joinChannelResponse: ActionConstructor<JoinChannelResponse> = p => 
   type: "WALLET.JOIN_CHANNEL_RESPONSE"
 });
 
-export interface ValidationError extends ApiAction {
+export interface ValidationError extends ApiResponseAction {
   type: "WALLET.VALIDATION_ERROR";
 }
 export const validationError: ActionConstructor<ValidationError> = p => ({
@@ -122,10 +123,8 @@ export const validationError: ActionConstructor<ValidationError> = p => ({
   type: "WALLET.VALIDATION_ERROR"
 });
 
-export interface RelayActionWithMessage {
+export interface RelayActionWithMessage extends ApiMessageNotificationAction {
   type: "WALLET.RELAY_ACTION_WITH_MESSAGE";
-  toParticipantId: string;
-  fromParticipantId: string;
   actionToRelay: RelayableAction;
 }
 
@@ -146,6 +145,25 @@ export const apiNotImplemented: ActionConstructor<ApiNotImplemented> = p => ({
   type: "WALLET.API_NOT_IMPLEMENTED"
 });
 
+export interface SendChannelUpdatedMessage extends ApiMessageNotificationAction {
+  type: "WALLET.SEND_CHANNEL_UPDATED_MESSAGE";
+  channelId: string;
+}
+
+export const sendChannelUpdatedMessage: ActionConstructor<SendChannelUpdatedMessage> = p => ({
+  ...p,
+  type: "WALLET.SEND_CHANNEL_UPDATED_MESSAGE"
+});
+
+export interface ChannelUpdatedEvent {
+  type: "WALLET.CHANNEL_UPDATED_EVENT";
+  channelId: string;
+}
+export const channelUpdatedEvent: ActionConstructor<ChannelUpdatedEvent> = p => ({
+  ...p,
+  type: "WALLET.CHANNEL_UPDATED_EVENT"
+});
+
 export type OutgoingApiAction =
   | AddressResponse
   | CreateChannelResponse
@@ -161,4 +179,6 @@ export type OutgoingApiAction =
   | JoinChannelResponse
   | ValidationError
   | RelayActionWithMessage
-  | ApiNotImplemented;
+  | ApiNotImplemented
+  | SendChannelUpdatedMessage
+  | ChannelUpdatedEvent;

--- a/packages/wallet/src/redux/selectors.ts
+++ b/packages/wallet/src/redux/selectors.ts
@@ -2,15 +2,15 @@ import {
   OpenChannelState,
   ChannelState,
   isFullyOpen,
-  getLastState,
-  ChannelParticipant
+  ChannelParticipant,
+  getLastSignedState
 } from "./channel-store";
 import * as walletStates from "./state";
 import {SharedData, FundingState} from "./state";
 import {ProcessProtocol} from "../communication";
 import {CONSENSUS_LIBRARY_ADDRESS, ETH_ASSET_HOLDER_ADDRESS} from "../constants";
 import {bigNumberify} from "ethers/utils";
-import {State} from "@statechannels/nitro-protocol";
+import {State, SignedState} from "@statechannels/nitro-protocol";
 import {AddressZero} from "ethers/constants";
 
 export const getOpenedChannelState = (state: SharedData, channelId: string): OpenChannelState => {
@@ -40,9 +40,13 @@ export const getChannelState = (state: SharedData, channelId: string): ChannelSt
   return channelStatus;
 };
 
-export const getLastStateForChannel = (state: SharedData, channelId: string): State => {
+export const getLastSignedStateForChannel = (state: SharedData, channelId: string): SignedState => {
   const channelState = getChannelState(state, channelId);
-  return getLastState(channelState);
+  return getLastSignedState(channelState);
+};
+
+export const getLastStateForChannel = (state: SharedData, channelId: string): State => {
+  return getLastSignedStateForChannel(state, channelId).state;
 };
 
 export const getFundedLedgerChannelForParticipants = (

--- a/packages/wallet/src/utils/json-rpc-utils.ts
+++ b/packages/wallet/src/utils/json-rpc-utils.ts
@@ -51,7 +51,12 @@ interface ChannelJoined {
   type: "Channel.Joined";
   signedState: SignedState;
 }
-type WalletMessage = OpenChannel | ChannelJoined | RelayableAction;
+
+interface ChannelUpdated {
+  type: "Channel.Updated";
+  signedState: SignedState;
+}
+type WalletMessage = OpenChannel | ChannelJoined | RelayableAction | ChannelUpdated;
 
 export interface JsonRpcUpdateChannelParams {
   allocations: JsonRpcAllocations;


### PR DESCRIPTION
Fixes #661 

Updates the wallet to send a state to the opponent's wallet when calling `UpdateState`. The opponent's wallet will dispatch a `ChannelUpdated` notification so the `app` knows about the new state.

Also added an integration test for updating states.