### PR TITLE
[monorepo] Shared .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,24 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  plugins: [
+    // All packages in this monorepo use TypeScript
+    '@typescript-eslint',
+    // All packages in this monorepo use Prettier
+    'prettier'
+  ],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended'
+  ],
+  rules: {
+    /**
+     * The default setting for Prettier is 'warn' because then it shows as yellow squiggly lines
+     * in the VS Code IDE. However, it means `eslint` will not have an error code if there is warning
+     * due to prettier unles you also add the `--max-warnings=0` flag in front of it. So, in the `lint-staged`
+     * scripts in the packages within this monorepo, we add that flag so that the precommit hooks
+     * associated with that script will fail when run.
+     */
+    'prettier/prettier': 'warn'
+  }
+};

--- a/packages/hub/.eslintrc.js
+++ b/packages/hub/.eslintrc.js
@@ -1,3 +1,5 @@
+const baseConfig = require('../../.eslintrc.js');
+
 // From the tslint.json we used previously
 const leftoverTsLintRules = {
   '@typescript-eslint/no-explicit-any': 'off',
@@ -6,7 +8,6 @@ const leftoverTsLintRules = {
   '@typescript-eslint/no-unused-vars': 'off'
 };
 
-// Jest violations
 const jestViolations = {
   'jest/no-disabled-tests': 'off',
   'jest/expect-expect': 'off'
@@ -17,29 +18,20 @@ const otherViolations = {
 };
 
 module.exports = {
+  ...baseConfig,
   env: {
     node: true,
     es6: true
   },
-  parser: '@typescript-eslint/parser',
-  parserOptions: {
-    project: 'tsconfig.json'
-  },
-  plugins: ['@typescript-eslint', 'prettier', 'jest'],
+  plugins: [...baseConfig.plugins, 'jest'],
   extends: [
-    'eslint:recommended',
-    'plugin:@typescript-eslint/recommended',
     'plugin:jest/recommended',
     'plugin:jest/style',
     'plugin:import/errors',
     'plugin:import/warnings',
-    'plugin:import/typescript',
-    'plugin:prettier/recommended'
+    'plugin:import/typescript'
   ],
   rules: {
-    // Prettier violations should result in linting errors
-    'prettier/prettier': 'warn',
-
     ...leftoverTsLintRules,
     ...jestViolations,
     ...otherViolations

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -87,6 +87,6 @@
     "typescript": "3.7.2"
   },
   "lint-staged": {
-    "src/**/*.ts": "eslint"
+    "src/**/*.ts": "eslint --max-warnings=0"
   }
 }

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -71,6 +71,7 @@
     "eslint": "^6.6.0",
     "eslint-config-prettier": "^6.7.0",
     "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jest": "^23.1.1",
     "eslint-plugin-prettier": "^3.1.0",
     "ganache-cli": "6.7.0",
     "jest": "24.9.0",

--- a/packages/jest-gas-reporter/.eslintrc.js
+++ b/packages/jest-gas-reporter/.eslintrc.js
@@ -1,16 +1,7 @@
 module.exports = {
+  ...require('../../.eslintrc.js'),
   env: {
-    node: true,
+    node: true, // Jest Gas Reporter is meant to be used in a `jest` process
     es6: true
-  },
-  parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint', 'prettier'],
-  extends: [
-    'eslint:recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended'
-  ],
-  rules: {
-    'prettier/prettier': 'warn'
   }
 };

--- a/packages/wallet/.eslintrc.js
+++ b/packages/wallet/.eslintrc.js
@@ -1,3 +1,5 @@
+const baseConfig = require("../../.eslintrc.js");
+
 const generalRules = {
   "no-var": "off",
   "no-async-promise-executor": "off",
@@ -45,34 +47,28 @@ const reactRules = {
 };
 
 module.exports = {
+  ...baseConfig,
   env: {
     browser: true,
     es6: true
   },
-  parser: "@typescript-eslint/parser",
-  parserOptions: {
-    project: "tsconfig.json"
-  },
-  plugins: ["@typescript-eslint", "prettier", "jest", "react"],
+  plugins: [...baseConfig.plugins, "jest", "react"],
   settings: {
     react: {
       version: "detect"
     }
   },
   extends: [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
+    ...baseConfig.extends,
     "plugin:jest/recommended",
     "plugin:jest/style",
     "plugin:import/errors",
     "plugin:import/warnings",
     "plugin:import/typescript",
-    "plugin:react/recommended",
-    "plugin:prettier/recommended"
+    "plugin:react/recommended"
   ],
   rules: {
-    // Prettier violations should result in linting errors
-    "prettier/prettier": "warn",
+    ...baseConfig.rules,
 
     // @typescript-eslint/no-unused-vars overrides this
     "no-unused-vars": "off",


### PR DESCRIPTION
Adds a shared `.eslintrc.js` in the monorepo root.