### PR TITLE
[hub] use migrations based on location of knexfile

### DIFF
--- a/packages/hub/.env.test
+++ b/packages/hub/.env.test
@@ -1,0 +1,2 @@
+HUB_DB_HOST=localhost
+HUB_DB_PORT=5432

--- a/packages/hub/readme.md
+++ b/packages/hub/readme.md
@@ -49,7 +49,7 @@ You will also need to make sure that the hub's address has funds. You can find t
 
 ## Testing
 
-For any environment variables specific to local setup, such as postgres host or port, do not modify `.env` files checked into the repository. Instead, add the variables to `.env.test.local` (or to other local `.env` files).
+For any environment variables specific to local setup, such as postgres host or port, do not modify `.env` files checked into the repository. Instead, add the variables to `.env.test.local` (or to other local `.env` files). Specifically, you might want to override `HUB_DB_HOST` and `HUB_DB_PORT`.
 
 ```
 yarn install

--- a/packages/hub/src/db-admin/knexfile.ts
+++ b/packages/hub/src/db-admin/knexfile.ts
@@ -6,11 +6,7 @@ import {Config} from 'knex';
 import {dbCofig} from '../db-config';
 
 const BASE_PATH = path.join(__dirname, '..', 'wallet', 'db');
-
-let extensions = ['js'];
-if (process.env.NODE_ENV === 'test') {
-  extensions = ['.ts'];
-}
+const extensions = [path.extname(__filename)];
 
 let knexConfig: Config = {
   ...dbCofig,


### PR DESCRIPTION
Fixes https://github.com/statechannels/monorepo/issues/693.

`knexfile` is executed both as a `ts` file (through ts-node) and as a compiled `js` file. With this PR, `knexfile` references migrations files that match the execution environment.