### PR TITLE
[hub] Jest setup script asserts for expected NODE_ENV env var

### DIFF
--- a/packages/hub/jest/test-setup.ts
+++ b/packages/hub/jest/test-setup.ts
@@ -3,6 +3,15 @@ import {GanacheServer} from '@statechannels/devtools';
 import {deploy} from '../deployment/deploy';
 
 export default async function setup() {
+  if (!process.env.NODE_ENV) {
+    throw Error(`The NODE_ENV env var must be set to "test"`);
+  }
+  if (process.env.NODE_ENV != 'test') {
+    throw Error(
+      `Run "yarn db:testSetup" and rerun the attempted script prefixed with "NODE_ENV=test"`
+    );
+  }
+
   const ganacheServer = new GanacheServer(
     Number(process.env.GANACHE_PORT),
     Number(process.env.CHAIN_NETWORK_ID)

--- a/packages/hub/readme.md
+++ b/packages/hub/readme.md
@@ -26,7 +26,7 @@ Make sure a local ganache instance is running by following [the instructions at 
 
 ## Run the hub
 
-```
+```shell
 $ npm i -g yarn
 $ yarn install
 // you will need to run `yarn db:drop` if the database already exists
@@ -57,12 +57,26 @@ NODE_ENV=test yarn db:create
 yarn test:ci
 ```
 
+### Troubleshooting Test Errors
+
+If you run into the following error
+
+```shell
+   getaddrinfo ENOTFOUND RequiredInLocalDotenv RequiredInLocalDotenv:5432
+```
+
+Make sure you have a local .env file dedicated to testing, by running the following:
+
+```shell
+cp .env.development.local .env.test.local
+```
+
 ## Deploying
 
 Heroku is configured to automatically deploy from the watched `deploy` branch.
 To run a test deploy, run
 
-```
+```shell
  // only needs to be run once to create a local "production" database
 $ NODE_ENV=production yarn db:create
 // Starts a local server serving the app


### PR DESCRIPTION
Fixes #679 

Replaces https://github.com/statechannels/monorepo/pull/683