### PR TITLE
Add circle failure slack notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
 version: 2.1
 orbs:
+  slack: circleci/slack@3.4.1
   puppeteer: threetreeslight/puppeteer@0.1.2
+
 defaults: &defaults
   working_directory: /home/circleci/project
   resource_class: medium
@@ -10,7 +12,7 @@ defaults: &defaults
       environment:
         POSTGRES_USER: root
         POSTGRES_DB: hub_wallet_test
-        POSTGRES_PASSWORD: ""
+        POSTGRES_PASSWORD: ''
 
 save_dep: &save_dep
   save_cache:
@@ -25,7 +27,7 @@ restore_dep: &restore_dep
 
 commands:
   log_stats:
-    description: "Log stats "
+    description: 'Log stats '
     parameters:
       file:
         type: string
@@ -35,7 +37,7 @@ commands:
           command: bash bin/log_memory.sh <<parameters.file>>
           background: true
   upload_logs:
-    description: "Upload logs "
+    description: 'Upload logs '
     parameters:
       file:
         type: string
@@ -44,6 +46,15 @@ commands:
       - store_artifacts:
           path: /home/circleci/<< parameters.file >>.txt
           destination: << parameters.file >>
+
+  notify_slack:
+    description: 'Notify slack '
+    steps:
+      - slack/status:
+          failure_message: 'A $CIRCLE_JOB job has failed on master!'
+          fail_only: true
+          mentions: 'SRHGGRGS0' # Group ID for ActiveDevs
+          only_for_branches: 'master'
 
 jobs:
   prepare:
@@ -67,6 +78,7 @@ jobs:
             - node_modules
       - upload_logs:
           file: prepare-stats
+      - notify_slack
 
   build:
     <<: *defaults
@@ -76,6 +88,7 @@ jobs:
           at: /home/circleci/project
       - run: yarn lint:check
       - run: yarn build:ci
+      - notify_slack
 
   test:
     <<: *defaults
@@ -90,6 +103,7 @@ jobs:
           no_output_timeout: 30m
       - upload_logs:
           file: test-stats
+      - notify_slack
 
   integration-test:
     <<: *defaults
@@ -107,6 +121,7 @@ jobs:
       - run: (cd packages/wallet && yarn run test:ci:integration)
       - upload_logs:
           file: integration-test-stats
+      - notify_slack
 
 workflows:
   statechannels:


### PR DESCRIPTION
If a job on `master` fails, then #sc-general-chat Slack channel receives a notification mentioning the @devs user group.