### PR TITLE
[build] Wait for wallet page to load in puppeteer

### DIFF
--- a/packages/wallet/puppeteer/helpers.ts
+++ b/packages/wallet/puppeteer/helpers.ts
@@ -50,7 +50,7 @@ export async function loadWallet(page: puppeteer.Page, messageListener: (message
   const web3JsFile = fs.readFileSync(path.resolve(__dirname, "web3/web3.min.js"), "utf8");
   await page.evaluateOnNewDocument(web3JsFile);
   await page.evaluateOnNewDocument(`window.web3 = new Web3("http://localhost:${port}")`);
-  await page.goto("http://localhost:3055/");
+  await page.goto("http://localhost:3055/", {waitUntil: "domcontentloaded"});
   page.on("pageerror", error => {
     throw error;
   });
@@ -60,7 +60,6 @@ export async function loadWallet(page: puppeteer.Page, messageListener: (message
     }
   });
 
-  await page.waitFor(1000); // Delay lets things load
   // interceptMessage gets called in puppeteer's context
   await page.exposeFunction("interceptMessage", message => {
     messageListener(message);


### PR DESCRIPTION
Hopefully this addresses #721. Instead of waiting 1 second for the wallet to load, we now wait until `DOMContentLoaded` is fired when accessing the wallet page.