### PR TITLE
[wallet] Allow RPS to properly exchange states

### DIFF
--- a/packages/wallet/src/redux/sagas/ganache-miner.ts
+++ b/packages/wallet/src/redux/sagas/ganache-miner.ts
@@ -1,12 +1,9 @@
-import {delay} from "redux-saga/effects";
 import {JsonRpcProvider} from "ethers/providers";
+import {call, delay} from "redux-saga/effects";
+import {getProvider} from "../../utils/contract-utils";
 
 export function* ganacheMiner() {
-  const provider: JsonRpcProvider = new JsonRpcProvider(
-    // TODO: Figure out why we use process here
-    /* eslint:disable */
-    `http://localhost:${process.env.GANACHE_PORT}`
-  );
+  const provider: JsonRpcProvider = yield call(getProvider);
   const DELAY_TIME = 30000; // 30 seconds
   while (true) {
     const timeStamp = Math.round(Date.now() / 1000);

--- a/packages/wallet/src/redux/sagas/messaging/__tests__/message-handler.test.ts
+++ b/packages/wallet/src/redux/sagas/messaging/__tests__/message-handler.test.ts
@@ -97,7 +97,7 @@ describe("message listener", () => {
       });
 
       expect(effects.fork[0].payload.args[0]).toMatchObject({
-        type: "WALLET.POST_MESSAGE_RESPONSE",
+        type: "WALLET.PUSH_MESSAGE_RESPONSE",
         id: 1
       });
 
@@ -179,7 +179,13 @@ describe("message listener", () => {
         type: "WALLET.APPLICATION.OPPONENT_STATE_RECEIVED",
         signedState
       });
+
       expect(effects.fork[0].payload.args[0]).toMatchObject({
+        type: "WALLET.PUSH_MESSAGE_RESPONSE",
+        id: 1
+      });
+      
+      expect(effects.fork[1].payload.args[0]).toMatchObject({
         type: "WALLET.CHANNEL_UPDATED_EVENT",
         channelId: expect.any(String)
       });

--- a/packages/wallet/src/redux/sagas/messaging/__tests__/message-sender.test.ts
+++ b/packages/wallet/src/redux/sagas/messaging/__tests__/message-sender.test.ts
@@ -13,7 +13,7 @@ import {
   channelUpdatedEvent,
   createChannelResponse,
   noContractError,
-  postMessageResponse,
+  pushMessageResponse,
   relayActionWithMessage,
   sendChannelJoinedMessage,
   sendChannelProposedMessage,
@@ -76,8 +76,8 @@ describe("message sender", () => {
       jsonrpc: "2.0",
       method: "MessageQueued",
       params: {
-        recipient: "A",
-        sender: "B",
+        recipient: "B",
+        sender: "A",
         data: {type: "Channel.Updated", signedState: state}
       }
     });
@@ -204,7 +204,7 @@ describe("message sender", () => {
   });
 
   it("sends a correct response message for WALLET.POST_MESSAGE", async () => {
-    const message = postMessageResponse({id: 5});
+    const message = pushMessageResponse({id: 5});
     const {effects} = await expectSaga(messageSender, message)
       .provide([[matchers.call.fn(window.parent.postMessage), 0]])
 

--- a/packages/wallet/src/redux/sagas/messaging/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-handler.ts
@@ -115,99 +115,101 @@ function* handlePushMessage(payload: RequestObject) {
   // TODO: We need to handle the case where we receive an invalid wallet message
   const {id} = payload;
   const message = payload.params as PushMessageParams;
-
-  switch (message.data.type) {
-    case "Channel.Updated":
-      yield put(
-        actions.application.opponentStateReceived({
-          processId: APPLICATION_PROCESS_ID,
-          signedState: message.data.signedState
-        })
-      );
-      yield fork(messageSender, outgoingMessageActions.pushMessageResponse({id}));
-
-      yield fork(
-        messageSender,
-        outgoingMessageActions.channelUpdatedEvent({
-          channelId: getChannelId(message.data.signedState.state.channel)
-        })
-      );
-
-      break;
-    case "Channel.Joined":
-      yield put(
-        actions.application.opponentStateReceived({
-          processId: APPLICATION_PROCESS_ID,
-          signedState: message.data.signedState
-        })
-      );
-
-      yield put(
-        fundingRequested({
-          channelId: getChannelId(message.data.signedState.state.channel),
-          playerIndex: TwoPartyPlayerIndex.A
-        })
-      );
-      yield fork(
-        messageSender,
-        outgoingMessageActions.channelUpdatedEvent({
-          channelId: getChannelId(message.data.signedState.state.channel)
-        })
-      );
-      yield fork(messageSender, outgoingMessageActions.pushMessageResponse({id}));
-      break;
-    case "Channel.Open":
-      const {signedState, participants} = message.data;
-      // The channel gets initialized and the state will be pushed into the app protocol
-      // If the client doesn't want to join the channel then we dispose of these on that API call
-      // Since only our wallet can progress the app protocol from this point by signing the next state
-      // we're safe to initialize the channel before the client has called JoinChannel
-      // The only limitation is that our client cannot propose a new channel with the same channelId
-      // before they decline the opponent's proposed channel
-      const provider: Web3Provider = yield call(getProvider);
-
-      if (!bigNumberify(signedState.state.appDefinition).isZero()) {
-        const bytecode = yield call([provider, provider.getCode], signedState.state.appDefinition);
-
+  if (isRelayableAction(message.data)) {
+    yield put(message.data);
+    yield fork(messageSender, outgoingMessageActions.pushMessageResponse({id}));
+  } else {
+    switch (message.data.type) {
+      case "Channel.Updated":
         yield put(
-          actions.appDefinitionBytecodeReceived({
-            appDefinition: signedState.state.appDefinition,
-            bytecode
+          actions.application.opponentStateReceived({
+            processId: APPLICATION_PROCESS_ID,
+            signedState: message.data.signedState
           })
         );
-      }
-
-      yield put(
-        actions.protocol.initializeChannel({
-          channelId: getChannelId(signedState.state.channel),
-          participants
-        })
-      );
-
-      yield put(
-        actions.application.opponentStateReceived({
-          processId: APPLICATION_PROCESS_ID,
-          signedState
-        })
-      );
-
-      yield fork(messageSender, outgoingMessageActions.pushMessageResponse({id}));
-
-      const channelId = getChannelId(signedState.state.channel);
-      yield fork(
-        messageSender,
-        outgoingMessageActions.channelProposedEvent({
-          channelId
-        })
-      );
-      break;
-    default:
-      if (isRelayableAction(message.data)) {
-        yield put(message.data);
         yield fork(messageSender, outgoingMessageActions.pushMessageResponse({id}));
-      } else {
+
+        yield fork(
+          messageSender,
+          outgoingMessageActions.channelUpdatedEvent({
+            channelId: getChannelId(message.data.signedState.state.channel)
+          })
+        );
+
+        break;
+      case "Channel.Joined":
+        yield put(
+          actions.application.opponentStateReceived({
+            processId: APPLICATION_PROCESS_ID,
+            signedState: message.data.signedState
+          })
+        );
+
+        yield put(
+          fundingRequested({
+            channelId: getChannelId(message.data.signedState.state.channel),
+            playerIndex: TwoPartyPlayerIndex.A
+          })
+        );
+        yield fork(
+          messageSender,
+          outgoingMessageActions.channelUpdatedEvent({
+            channelId: getChannelId(message.data.signedState.state.channel)
+          })
+        );
+        yield fork(messageSender, outgoingMessageActions.pushMessageResponse({id}));
+        break;
+      case "Channel.Open":
+        const {signedState, participants} = message.data;
+        // The channel gets initialized and the state will be pushed into the app protocol
+        // If the client doesn't want to join the channel then we dispose of these on that API call
+        // Since only our wallet can progress the app protocol from this point by signing the next state
+        // we're safe to initialize the channel before the client has called JoinChannel
+        // The only limitation is that our client cannot propose a new channel with the same channelId
+        // before they decline the opponent's proposed channel
+        const provider: Web3Provider = yield call(getProvider);
+
+        if (!bigNumberify(signedState.state.appDefinition).isZero()) {
+          const bytecode = yield call(
+            [provider, provider.getCode],
+            signedState.state.appDefinition
+          );
+
+          yield put(
+            actions.appDefinitionBytecodeReceived({
+              appDefinition: signedState.state.appDefinition,
+              bytecode
+            })
+          );
+        }
+
+        yield put(
+          actions.protocol.initializeChannel({
+            channelId: getChannelId(signedState.state.channel),
+            participants
+          })
+        );
+
+        yield put(
+          actions.application.opponentStateReceived({
+            processId: APPLICATION_PROCESS_ID,
+            signedState
+          })
+        );
+
+        yield fork(messageSender, outgoingMessageActions.pushMessageResponse({id}));
+
+        const channelId = getChannelId(signedState.state.channel);
+        yield fork(
+          messageSender,
+          outgoingMessageActions.channelProposedEvent({
+            channelId
+          })
+        );
+        break;
+      default:
         console.error(`Could not handle message data with type ${message.data.type}`);
-      }
+    }
   }
 }
 

--- a/packages/wallet/src/redux/sagas/messaging/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-handler.ts
@@ -115,96 +115,99 @@ function* handlePushMessage(payload: RequestObject) {
   // TODO: We need to handle the case where we receive an invalid wallet message
   const {id} = payload;
   const message = payload.params as PushMessageParams;
-  if (isRelayableAction(message.data)) {
-    yield put(message.data);
-    yield fork(messageSender, outgoingMessageActions.postMessageResponse({id}));
-  } else {
-    switch (message.data.type) {
-      case "Channel.Updated":
-        yield put(
-          actions.application.opponentStateReceived({
-            processId: APPLICATION_PROCESS_ID,
-            signedState: message.data.signedState
-          })
-        );
-        yield fork(
-          messageSender,
-          outgoingMessageActions.channelUpdatedEvent({
-            channelId: getChannelId(message.data.signedState.state.channel)
-          })
-        );
-        break;
-      case "Channel.Joined":
-        yield put(
-          actions.application.opponentStateReceived({
-            processId: APPLICATION_PROCESS_ID,
-            signedState: message.data.signedState
-          })
-        );
+
+  switch (message.data.type) {
+    case "Channel.Updated":
+      yield put(
+        actions.application.opponentStateReceived({
+          processId: APPLICATION_PROCESS_ID,
+          signedState: message.data.signedState
+        })
+      );
+      yield fork(messageSender, outgoingMessageActions.pushMessageResponse({id}));
+
+      yield fork(
+        messageSender,
+        outgoingMessageActions.channelUpdatedEvent({
+          channelId: getChannelId(message.data.signedState.state.channel)
+        })
+      );
+
+      break;
+    case "Channel.Joined":
+      yield put(
+        actions.application.opponentStateReceived({
+          processId: APPLICATION_PROCESS_ID,
+          signedState: message.data.signedState
+        })
+      );
+
+      yield put(
+        fundingRequested({
+          channelId: getChannelId(message.data.signedState.state.channel),
+          playerIndex: TwoPartyPlayerIndex.A
+        })
+      );
+      yield fork(
+        messageSender,
+        outgoingMessageActions.channelUpdatedEvent({
+          channelId: getChannelId(message.data.signedState.state.channel)
+        })
+      );
+      yield fork(messageSender, outgoingMessageActions.pushMessageResponse({id}));
+      break;
+    case "Channel.Open":
+      const {signedState, participants} = message.data;
+      // The channel gets initialized and the state will be pushed into the app protocol
+      // If the client doesn't want to join the channel then we dispose of these on that API call
+      // Since only our wallet can progress the app protocol from this point by signing the next state
+      // we're safe to initialize the channel before the client has called JoinChannel
+      // The only limitation is that our client cannot propose a new channel with the same channelId
+      // before they decline the opponent's proposed channel
+      const provider: Web3Provider = yield call(getProvider);
+
+      if (!bigNumberify(signedState.state.appDefinition).isZero()) {
+        const bytecode = yield call([provider, provider.getCode], signedState.state.appDefinition);
 
         yield put(
-          fundingRequested({
-            channelId: getChannelId(message.data.signedState.state.channel),
-            playerIndex: TwoPartyPlayerIndex.A
+          actions.appDefinitionBytecodeReceived({
+            appDefinition: signedState.state.appDefinition,
+            bytecode
           })
         );
-        yield fork(
-          messageSender,
-          outgoingMessageActions.channelUpdatedEvent({
-            channelId: getChannelId(message.data.signedState.state.channel)
-          })
-        );
-        yield fork(messageSender, outgoingMessageActions.postMessageResponse({id}));
-        break;
-      case "Channel.Open":
-        const {signedState, participants} = message.data;
-        // The channel gets initialized and the state will be pushed into the app protocol
-        // If the client doesn't want to join the channel then we dispose of these on that API call
-        // Since only our wallet can progress the app protocol from this point by signing the next state
-        // we're safe to initialize the channel before the client has called JoinChannel
-        // The only limitation is that our client cannot propose a new channel with the same channelId
-        // before they decline the opponent's proposed channel
-        const provider: Web3Provider = yield call(getProvider);
+      }
 
-        if (!bigNumberify(signedState.state.appDefinition).isZero()) {
-          const bytecode = yield call(
-            [provider, provider.getCode],
-            signedState.state.appDefinition
-          );
+      yield put(
+        actions.protocol.initializeChannel({
+          channelId: getChannelId(signedState.state.channel),
+          participants
+        })
+      );
 
-          yield put(
-            actions.appDefinitionBytecodeReceived({
-              appDefinition: signedState.state.appDefinition,
-              bytecode
-            })
-          );
-        }
+      yield put(
+        actions.application.opponentStateReceived({
+          processId: APPLICATION_PROCESS_ID,
+          signedState
+        })
+      );
 
-        yield put(
-          actions.protocol.initializeChannel({
-            channelId: getChannelId(signedState.state.channel),
-            participants
-          })
-        );
+      yield fork(messageSender, outgoingMessageActions.pushMessageResponse({id}));
 
-        yield put(
-          actions.application.opponentStateReceived({
-            processId: APPLICATION_PROCESS_ID,
-            signedState
-          })
-        );
-
-        yield fork(messageSender, outgoingMessageActions.postMessageResponse({id}));
-
-        const channelId = getChannelId(signedState.state.channel);
-        yield fork(
-          messageSender,
-          outgoingMessageActions.channelProposedEvent({
-            channelId
-          })
-        );
-        break;
-    }
+      const channelId = getChannelId(signedState.state.channel);
+      yield fork(
+        messageSender,
+        outgoingMessageActions.channelProposedEvent({
+          channelId
+        })
+      );
+      break;
+    default:
+      if (isRelayableAction(message.data)) {
+        yield put(message.data);
+        yield fork(messageSender, outgoingMessageActions.pushMessageResponse({id}));
+      } else {
+        console.error(`Could not handle message data with type ${message.data.type}`);
+      }
   }
 }
 

--- a/packages/wallet/src/redux/sagas/messaging/message-sender.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-sender.ts
@@ -75,15 +75,15 @@ function* createResponseMessage(action: OutgoingApiAction) {
         signedState: yield select(getLastSignedStateForChannel, action.channelId)
       };
       return jrs.notification("MessageQueued", {
-        recipient: action.fromParticipantId,
-        sender: action.toParticipantId,
+        recipient: action.toParticipantId,
+        sender: action.fromParticipantId,
         data: channelUpdated
       });
     case "WALLET.CHANNEL_UPDATED_EVENT":
       return jrs.notification("ChannelUpdated", yield getChannelInfo(action.channelId));
     case "WALLET.CHANNEL_PROPOSED_EVENT":
       return jrs.notification("ChannelProposed", yield getChannelInfo(action.channelId));
-    case "WALLET.POST_MESSAGE_RESPONSE":
+    case "WALLET.PUSH_MESSAGE_RESPONSE":
       return jrs.success(action.id, {success: true});
     case "WALLET.UNKNOWN_CHANNEL_ID_ERROR":
       return jrs.error(

--- a/packages/wallet/src/redux/sagas/messaging/outgoing-api-actions.ts
+++ b/packages/wallet/src/redux/sagas/messaging/outgoing-api-actions.ts
@@ -97,13 +97,13 @@ export const channelProposedEvent: ActionConstructor<ChannelProposedEvent> = p =
   type: "WALLET.CHANNEL_PROPOSED_EVENT"
 });
 
-export interface PostMessageResponse extends ApiResponseAction {
-  type: "WALLET.POST_MESSAGE_RESPONSE";
+export interface PushMessageResponse extends ApiResponseAction {
+  type: "WALLET.PUSH_MESSAGE_RESPONSE";
 }
 
-export const postMessageResponse: ActionConstructor<PostMessageResponse> = p => ({
+export const pushMessageResponse: ActionConstructor<PushMessageResponse> = p => ({
   ...p,
-  type: "WALLET.POST_MESSAGE_RESPONSE"
+  type: "WALLET.PUSH_MESSAGE_RESPONSE"
 });
 
 export interface JoinChannelResponse extends ApiResponseAction {
@@ -173,7 +173,7 @@ export type OutgoingApiAction =
   | SendChannelProposedMessage
   | SendChannelJoinedMessage
   | ChannelProposedEvent
-  | PostMessageResponse
+  | PushMessageResponse
   | UnknownChannelId
   | NoContractError
   | JoinChannelResponse


### PR DESCRIPTION
Fixes #722. Fixes two issues that were stopping RPS from exchanging moves:
- The `recipient` and `sender` were swapped when sending a ChannelUpdated message to your opponent.
- When a `pushMessage` was called with a `ChannelUpdated` message it was not returning success, so `channel-client` would timeout and retry 5 times, messing up the state.