### PR TITLE
[rps] Use window.ethereum if available

### DIFF
--- a/packages/rps/src/redux/login/saga.ts
+++ b/packages/rps/src/redux/login/saga.ts
@@ -55,7 +55,6 @@ export default function* loginRootSaga() {
   if (!metaMask) {
     return;
   }
-  ethereum.enable();
   yield fork(loginStatusWatcherSaga);
   yield all([
     takeEvery(loginActions.LOGIN_REQUEST, loginSaga),


### PR DESCRIPTION
Fixes #718.

Uses `window.ethereum.enable` when available instead of `web3.eth.getAccounts` as this seemed to just return an empty array when using firefox and metamask.