### PR TITLE
[monorepo] chore: Remove usages of Magmo in files

### DIFF
--- a/packages/devtools/README.md
+++ b/packages/devtools/README.md
@@ -1,35 +1,3 @@
 # devtools
 
 Developer tooling, used by statechannels packages.
-
-## Usage
-
-From a node project, install as a dev dependency:
-
-```
-$ npm i -D https://github.com/statechannels/monorepo/blob/master/packages/devtools
-```
-
-or
-
-```
-$ yarn add -D https://github.com/statechannels/monorepo/blob/master/packages/devtools
-```
-
-This will install binaries in your project that can be run, eg. with `npx`.
-
-```
-// you must have installed npx globally via `npm i -g npx`
-$ npx start-ganache
-```
-
-It also exports functions that can be executed, eg
-
-```
-$ node -e "require('@statechannels/devtools').startGanache()"
-```
-
-## Dependencies
-
-You are responsible for installing the dependencies required for executing the binaries.
-We will not force your scripts to use a specific version of truffle, for instance.

--- a/packages/devtools/README.md
+++ b/packages/devtools/README.md
@@ -7,13 +7,13 @@ Developer tooling, used by statechannels packages.
 From a node project, install as a dev dependency:
 
 ```
-$ npm i -D https://github.com/magmo/devtools
+$ npm i -D https://github.com/statechannels/monorepo/blob/master/packages/devtools
 ```
 
 or
 
 ```
-$ yarn add -D https://github.com/magmo/devtools
+$ yarn add -D https://github.com/statechannels/monorepo/blob/master/packages/devtools
 ```
 
 This will install binaries in your project that can be run, eg. with `npx`.

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -16,7 +16,10 @@
   },
   "author": "Andrew Stewart",
   "license": "MIT",
-  "repository": "https://github.com/magmo/devtools",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/statechannels/monorepo/blob/master/packages/devtools"
+  },
   "dependencies": {
     "chai": "4.2.0",
     "detect-port": "1.3.0",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/statechannels/monorepo/blob/master/packages/devtools"
+    "url": "git+https://github.com/statechannels/monorepo.git"
   },
   "dependencies": {
     "chai": "4.2.0",

--- a/packages/hub/readme.md
+++ b/packages/hub/readme.md
@@ -45,7 +45,7 @@ To play against the hub from the browser client, the hub and the browser need to
 - Point to the same local Ganache server. Configure your `.env.*.local` files accordingly.
 - Point to the same contract addresses on Ganache.
 
-You will also need to make sure that the hub's address has funds. You can find the hub address in [constants.ts](https://github.com/magmo/node-bot/blob/master/src/constants.ts)
+You will also need to make sure that the hub's address has funds. You can find the hub address in [constants.ts](https://github.com/statechannels/monorepo/blob/master/packages/hub/src/constants.ts)
 
 ## Testing
 

--- a/packages/jest-gas-reporter/package.json
+++ b/packages/jest-gas-reporter/package.json
@@ -4,7 +4,10 @@
   "description": "A jest reporter that reports the gas used by various calls to ethereum contracts.",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
-  "repository": "https://github.com/magmo/jest-gas-reporter.git",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/statechannels/monorepo/blob/master/packages/jest-gas-reporter"
+  },
   "author": "Alex Gap <alex@magmo.com>",
   "license": "MIT",
   "scripts": {

--- a/packages/jest-gas-reporter/package.json
+++ b/packages/jest-gas-reporter/package.json
@@ -6,7 +6,7 @@
   "types": "lib/src/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "http://github.com/statechannels/monorepo/blob/master/packages/jest-gas-reporter"
+    "url": "git+https://github.com/statechannels/monorepo.git"
   },
   "author": "Alex Gap <alex@magmo.com>",
   "license": "MIT",

--- a/packages/nitro-protocol/docs/forcemove-and-nitro/force-move.md
+++ b/packages/nitro-protocol/docs/forcemove-and-nitro/force-move.md
@@ -183,7 +183,7 @@ contract CountingApp is ForceMoveApp {
 }
 ```
 
-but other examples exist: such as a[ payment channel](https://github.com/magmo/force-move-protocol/blob/master/packages/fmg-payments/contracts/PaymentApp.sol), or games of [Rock Paper Scissors](https://github.com/magmo/apps/blob/master/packages/rps/contracts/RockPaperScissorsGame.sol) and [Tic Tac Toe](https://github.com/magmo/apps/blob/master/packages/tictactoe/contracts/TicTacToeGame.sol).
+but other examples exist: such as a [payment channel](https://github.com/magmo/force-move-protocol/blob/master/packages/fmg-payments/contracts/PaymentApp.sol), or games of [Rock Paper Scissors](https://github.com/statechannels/monorepo/blob/master/packages/rps/contracts/RockPaperScissors.sol) and [Tic Tac Toe](https://github.com/magmo/apps/blob/master/packages/tictactoe/contracts/TicTacToeGame.sol).
 
 :::note
 The linked examples conform to a legacy ForceMoveApp interface.

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:statechannels/nitro-protocol.git"
+    "url": "git+https://github.com/statechannels/monorepo.git"
   },
   "keywords": [
     "state",


### PR DESCRIPTION
### Description

Lots of ♥ for Magmo but links were pointing to incorrect places 😅

This fixes usages of Magmo in files such as package.json and READMEs.

There are still a few links pointing to places that don't have a corresponding file in StateChannels

### Related issues

Closes #533 
