### PR TITLE
[rps] Use <script> to import window.channelProvider

### DIFF
--- a/packages/rps/.eslintrc.js
+++ b/packages/rps/.eslintrc.js
@@ -52,11 +52,6 @@ module.exports = {
     es6: true,
   },
   parser: '@typescript-eslint/parser',
-  parserOptions: {
-    project: 'tsconfig.json',
-    ecmaVersion: 2018,
-    sourceType: 'module',
-  },
   plugins: ['@typescript-eslint', 'prettier', 'jest', 'react'],
   settings: {
     react: {

--- a/packages/rps/public/channel-provider.min.js
+++ b/packages/rps/public/channel-provider.min.js
@@ -1,0 +1,1 @@
+../../channel-provider/dist/channel-provider.min.js

--- a/packages/rps/public/index.html
+++ b/packages/rps/public/index.html
@@ -22,6 +22,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
   <title>Rock Paper Scissors</title>
+  <script src="%PUBLIC_URL%/channel-provider.min.js"></script>
 </head>
 
 <body>

--- a/packages/rps/src/globals.d.ts
+++ b/packages/rps/src/globals.d.ts
@@ -1,0 +1,7 @@
+import {ChannelProviderInterface} from '@statechannels/channel-provider';
+
+declare global {
+  interface Window {
+    channelProvider: ChannelProviderInterface;
+  }
+}

--- a/packages/rps/src/utils/rps-channel-client.ts
+++ b/packages/rps/src/utils/rps-channel-client.ts
@@ -6,7 +6,7 @@ import {
   ChannelClientInterface,
 } from '@statechannels/channel-client';
 import {RPS_ADDRESS} from '../constants';
-import {ChannelProviderInterface, channelProvider} from '@statechannels/channel-provider';
+import {ChannelProviderInterface} from '@statechannels/channel-provider';
 import {bigNumberify} from 'ethers/utils';
 
 // This class wraps the channel client converting the request/response formats to those used in the app
@@ -15,11 +15,7 @@ export class RPSChannelClient {
   channelClient: ChannelClientInterface;
 
   async enable() {
-    // TODO: This is really ugly!!
-    // TODO: Use webpack to import channelProvider
-    // tslint:disable-next-line: no-unused-expression
-    channelProvider;
-    const provider: ChannelProviderInterface = (window as any).channelProvider;
+    const provider: ChannelProviderInterface = window.channelProvider;
     await provider.enable(process.env.WALLET_URL);
     // might want to pass this in later
     this.channelClient = new ChannelClient(provider);


### PR DESCRIPTION
The `channel-provider` README states this is the recommended way of using it.

In the future perhaps somehow the embedded iframe might inject it in the page. 