### PR TITLE
[wallet] Add state to track in-progress JSON-RPC responses

### DIFF
--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -18,6 +18,7 @@ import {LOAD as LOAD_FROM_STORAGE} from "redux-storage";
 import {SignedState, State} from "@statechannels/nitro-protocol";
 import {BigNumber} from "ethers/utils";
 import {CloseLedgerChannelAction} from "./protocols/close-ledger-channel";
+import {MessageBeingHandled, MessageHasBeenHandled} from "./sagas/messaging/outgoing-api-actions";
 export * from "./protocols/transaction-submission/actions";
 
 // -------
@@ -252,6 +253,8 @@ export type WalletAction =
   | BlockMined
   | DisplayMessageSent
   | MessageSent
+  | MessageBeingHandled
+  | MessageHasBeenHandled
   | ProtocolAction
   | protocol.NewProcessAction
   | RelayableAction
@@ -266,13 +269,16 @@ export {directFunding as funding, NewLedgerChannel, protocol, application, advan
 export type SharedDataUpdateAction =
   | AdjudicatorEventAction
   | AssetHolderEventAction
-  | AppDefinitionBytecodeReceived;
+  | AppDefinitionBytecodeReceived
+  | MessageBeingHandled
+  | MessageHasBeenHandled;
 
 export function isSharedDataUpdateAction(action: WalletAction): action is SharedDataUpdateAction {
   return (
     isAdjudicatorEventAction(action) ||
     isAssetHolderEventAction(action) ||
-    action.type === "WALLET.APP_DEFINITION_BYTECODE_RECEIVED"
+    action.type === "WALLET.APP_DEFINITION_BYTECODE_RECEIVED" ||
+    action.type === "WALLET.MESSAGE_BEING_HANDLED"
   );
 }
 

--- a/packages/wallet/src/redux/reducer.ts
+++ b/packages/wallet/src/redux/reducer.ts
@@ -67,6 +67,19 @@ function updateSharedData(
       ...state,
       bytecodeStorage: {...state.bytecodeStorage, [action.appDefinition]: action.bytecode}
     };
+  } else if (action.type === "WALLET.MESSAGE_BEING_HANDLED") {
+    return {
+      ...state,
+      messagesBeingHandled: {...state.messagesBeingHandled, [action.id.toString()]: true}
+    };
+  } else if (action.type === "WALLET.MESSAGE_HAS_BEEN_HANDLED") {
+    return {
+      ...state,
+      messagesBeingHandled: Object.keys(state.messagesBeingHandled).reduce(
+        (o, k) => (k !== action.id.toString() ? {...o, [k]: true} : o),
+        {}
+      )
+    };
   } else {
     return state;
   }

--- a/packages/wallet/src/redux/sagas/messaging/__tests__/message-handler.test.ts
+++ b/packages/wallet/src/redux/sagas/messaging/__tests__/message-handler.test.ts
@@ -44,6 +44,38 @@ describe("message listener", () => {
     );
   });
 
+  // TODO: Figure out how to test this behaviour
+  // it("does not execute code twice for the same request ID before responding", async () => {
+  //   const requestMessage = {
+  //     jsonrpc: "2.0",
+  //     method: "GetAddress",
+  //     id: 1,
+  //     params: {}
+  //   };
+
+  //   let responses = 0;
+
+  //   expectSaga(messageHandler, requestMessage, "localhost")
+  //     .withState(initialState)
+  //     .provide([
+  //       [matchers.fork.fn(messageSender), 0],
+  //       [matchers.select(getAddress), "poop"]
+  //     ])
+  //     .fork(messageSender, addressResponse({id: 1, address: "poop"}))
+  //     .run();
+
+  //   await expectSaga(messageHandler, requestMessage, "localhost")
+  //     .withState(initialState)
+  //     .provide([
+  //       [matchers.fork.fn(messageSender), 0],
+  //       [matchers.select(getAddress), "not poop"]
+  //     ])
+  //     .fork(messageSender, addressResponse({id: 1, address: "poop"}))
+  //     .run();
+
+  //   expect(responses).toBe(1);
+  // });
+
   describe("PushMessage", () => {
     it("handles a pushMessage with a channel open message", async () => {
       const signedState = appState({turnNum: 0});
@@ -91,7 +123,7 @@ describe("message listener", () => {
         ])
         .run();
 
-      expect(effects.put[1].payload.action).toMatchObject({
+      expect(effects.put[2].payload.action).toMatchObject({
         type: "WALLET.APPLICATION.OPPONENT_STATE_RECEIVED",
         signedState
       });
@@ -138,7 +170,7 @@ describe("message listener", () => {
         ])
         .run();
 
-      expect(effects.put[0].payload.action).toMatchObject({
+      expect(effects.put[1].payload.action).toMatchObject({
         type: "WALLET.APPLICATION.OPPONENT_STATE_RECEIVED",
         signedState
       });
@@ -175,7 +207,7 @@ describe("message listener", () => {
         ])
         .run();
 
-      expect(effects.put[0].payload.action).toMatchObject({
+      expect(effects.put[1].payload.action).toMatchObject({
         type: "WALLET.APPLICATION.OPPONENT_STATE_RECEIVED",
         signedState
       });
@@ -224,7 +256,7 @@ describe("message listener", () => {
         ])
         .run();
 
-      expect(effects.put[0].payload.action).toMatchObject(actionToRelay);
+      expect(effects.put[1].payload.action).toMatchObject(actionToRelay);
     });
   });
 
@@ -286,7 +318,7 @@ describe("message listener", () => {
         ])
         .run();
 
-      expect(effects.put[2].payload.action).toMatchObject({
+      expect(effects.put[3].payload.action).toMatchObject({
         type: "WALLET.APPLICATION.OWN_STATE_RECEIVED",
         state: {
           channel: {participants: [signingAddressA, signingAddressB]},
@@ -493,7 +525,7 @@ describe("message listener", () => {
         ]
       };
 
-      expect(effects.put[0].payload.action).toMatchObject({
+      expect(effects.put[1].payload.action).toMatchObject({
         type: "WALLET.APPLICATION.OWN_STATE_RECEIVED",
         state
       });
@@ -620,11 +652,11 @@ describe("message listener", () => {
         turnNum: 1
       };
 
-      expect(effects.put[0].payload.action).toMatchObject({
+      expect(effects.put[1].payload.action).toMatchObject({
         type: "WALLET.APPLICATION.OWN_STATE_RECEIVED",
         state: nextState
       });
-      expect(effects.put[1].payload.action).toMatchObject({
+      expect(effects.put[2].payload.action).toMatchObject({
         type: "WALLET.NEW_PROCESS.FUNDING_REQUESTED"
       });
 

--- a/packages/wallet/src/redux/sagas/messaging/message-sender.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-sender.ts
@@ -8,8 +8,8 @@ import {unreachable} from "../../../utils/reducer-utils";
 import {ChannelState, getLastState, getPenultimateState} from "../../channel-store";
 import {getChannelHoldings, getLastSignedStateForChannel} from "../../selectors";
 import {getChannelStatus} from "../../state";
-import {OutgoingApiAction} from "./outgoing-api-actions";
 import {State} from "@statechannels/nitro-protocol";
+import {OutgoingApiAction, messageHasBeenHandled} from "./outgoing-api-actions";
 
 export function* messageSender(action: OutgoingApiAction) {
   const message = yield createResponseMessage(action);
@@ -20,6 +20,8 @@ export function* messageSender(action: OutgoingApiAction) {
 }
 
 function* createResponseMessage(action: OutgoingApiAction) {
+  if ("id" in action) yield put(messageHasBeenHandled(action));
+
   switch (action.type) {
     case "WALLET.JOIN_CHANNEL_RESPONSE":
       return jrs.success(action.id, yield getChannelInfo(action.channelId));

--- a/packages/wallet/src/redux/sagas/messaging/message-sender.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-sender.ts
@@ -1,6 +1,6 @@
 import {bigNumberify} from "ethers/utils";
 import jrs from "jsonrpc-lite";
-import {call, select} from "redux-saga/effects";
+import {call, select, put} from "redux-saga/effects";
 import {validateNotification, validateResponse} from "../../../json-rpc-validation/validator";
 import {createJsonRpcAllocationsFromOutcome} from "../../../utils/json-rpc-utils";
 import {unreachable} from "../../../utils/reducer-utils";

--- a/packages/wallet/src/redux/sagas/messaging/outgoing-api-actions.ts
+++ b/packages/wallet/src/redux/sagas/messaging/outgoing-api-actions.ts
@@ -1,5 +1,6 @@
 import {ActionConstructor} from "../../utils";
 import {RelayableAction} from "../../../communication";
+import {ID} from "jsonrpc-lite";
 
 export interface ApiResponseAction {
   id: number | string; // Either a string or number is technically valid
@@ -10,6 +11,26 @@ export interface ApiMessageNotificationAction {
   toParticipantId: string;
   fromParticipantId: string;
 }
+
+export interface MessageBeingHandled extends ApiResponseAction {
+  type: "WALLET.MESSAGE_BEING_HANDLED";
+  jsonRpcId: ID;
+}
+
+export const messageBeingHandled = p => ({
+  ...p,
+  type: "WALLET.MESSAGE_BEING_HANDLED"
+});
+
+export interface MessageHasBeenHandled extends ApiResponseAction {
+  type: "WALLET.MESSAGE_HAS_BEEN_HANDLED";
+  jsonRpcId: ID;
+}
+
+export const messageHasBeenHandled = p => ({
+  ...p,
+  type: "WALLET.MESSAGE_HAS_BEEN_HANDLED"
+});
 
 export interface CreateChannelResponse extends ApiResponseAction {
   type: "WALLET.CREATE_CHANNEL_RESPONSE";

--- a/packages/wallet/src/redux/selectors.ts
+++ b/packages/wallet/src/redux/selectors.ts
@@ -12,6 +12,7 @@ import {CONSENSUS_LIBRARY_ADDRESS, ETH_ASSET_HOLDER_ADDRESS, HUB_ADDRESS} from "
 import {bigNumberify} from "ethers/utils";
 import {State, SignedState} from "@statechannels/nitro-protocol";
 import {AddressZero} from "ethers/constants";
+import {ID} from "jsonrpc-lite";
 
 export const getOpenedChannelState = (state: SharedData, channelId: string): OpenChannelState => {
   const channelStatus = getChannelState(state, channelId);
@@ -88,6 +89,10 @@ export const getPrivateKey = (state: walletStates.Initialized) => {
 
 export const getAddress = (state: walletStates.Initialized) => {
   return state.address;
+};
+
+export const messageBeingHandled = (state: SharedData, id: ID) => {
+  return state.messagesBeingHandled[id.toString()];
 };
 
 export const getAdjudicatorState = (state: SharedData) => {

--- a/packages/wallet/src/redux/state.ts
+++ b/packages/wallet/src/redux/state.ts
@@ -72,6 +72,7 @@ export interface SharedData {
   fundingState: FundingState;
   assetHoldersState: AssetHoldersState;
   currentProcessId?: string;
+  messagesBeingHandled: {[id: string]: true};
 }
 
 export interface ChannelSubscriptions {
@@ -161,7 +162,8 @@ export const EMPTY_SHARED_DATA: SharedData = {
   assetHoldersState: {},
   bytecodeStorage: {
     [CONSENSUS_LIBRARY_ADDRESS]: CONSENSUS_LIBRARY_BYTECODE
-  }
+  },
+  messagesBeingHandled: {}
 };
 
 export function sharedData(params: SharedData): SharedData {
@@ -172,7 +174,8 @@ export function sharedData(params: SharedData): SharedData {
     fundingState,
     assetHoldersState,
     channelSubscriptions,
-    bytecodeStorage
+    bytecodeStorage,
+    messagesBeingHandled
   } = params;
   return {
     outboxState,
@@ -181,7 +184,8 @@ export function sharedData(params: SharedData): SharedData {
     fundingState,
     assetHoldersState,
     channelSubscriptions,
-    bytecodeStorage
+    bytecodeStorage,
+    messagesBeingHandled
   };
 }
 


### PR DESCRIPTION
Handles #710. Not sure how best to test this.

**Question**. Is storing this in `SharedData` the "right" strategy?