### PR TITLE
Hub: state channel address configuration

### DIFF
--- a/packages/hub/env.js
+++ b/packages/hub/env.js
@@ -1,4 +1,4 @@
 'use strict';
 
 const {configureEnvVariables} = require('@statechannels/devtools');
-configureEnvVariables();
+configureEnvVariables(true);

--- a/packages/hub/readme.md
+++ b/packages/hub/readme.md
@@ -37,7 +37,7 @@ $ yarn hub:watch (will rebuild app on file change)
 
 ```
 
-### Interacting with the hub from a browser
+### Establishing a virtual channel between clients through the hub
 
 **NOTE**: Running this package makes a connection to a shared external Firebase database. So, to avoid colliding with other developers also running this package, set the environment variable `HUB_ADDRESS` to one that is likely not being used by any other developer for local development purposes.
 

--- a/packages/hub/readme.md
+++ b/packages/hub/readme.md
@@ -39,15 +39,16 @@ $ yarn hub:watch (will rebuild app on file change)
 
 ### Interacting with the hub from a browser
 
-**NOTE**: it is important to define a unique `HUB_ADDRESS` if others are running the hub locally since all hub instances use the same Firebase realtime database.
+**NOTE**: Running this package makes a connection to a shared external Firebase database. So, to avoid colliding with other developers also running this package, set the environment variable `HUB_ADDRESS` to one that is likely not being used by any other developer for local development purposes.
 
 To connect to the `hub` from the browser `wallet`, the `hub` and the browser `wallet` need to:
 
 - Share the state-channel address of the hub. A good way to do so is to create a `.env.development.local` in the monorepo root with `HUB_ADDRESS` and `HUB_PRIVATE_KEY` defined.
 - Point to the same local Ganache server. Configure your `.env` files accordingly. This should work without any modifications.
+- Point to the same shared local Ganache server. This should work without any modifications. To see which ports are being used by the `hub` and `wallet`, and to verify they are the same, you can reference the `GANACHE_PORT` environment variable which by default is set in `.env` of each package.
 - Point to the same contract addresses on Ganache. This will be the case if the hub and the client wallet point to the same Ganache server.
 
-You will also need to make sure that the hub's blockchain address has funds. The default hub blockchain address `HUB_SIGNER_ADDRESS` is in [constants.ts](https://github.com/statechannels/monorepo/blob/master/packages/hub/src/constants.ts)
+You will also need to make sure that the hub's blockchain address has funds. The default hub blockchain address `HUB_SIGNER_ADDRESS` is in [constants.ts](https://github.com/statechannels/monorepo/blob/master/packages/hub/src/constants.ts). This address will have funds by default. Ganache is started with [these funded private keys](https://github.com/statechannels/monorepo/blob/hub-address/packages/devtools/src/constants.ts). Consequently, feel free to substitute any of these address/private key pairs for `HUB_SIGNER_ADDRESS` and `HUB_SIGNER_PRIVATE_KEY`.
 
 ## Testing
 

--- a/packages/hub/readme.md
+++ b/packages/hub/readme.md
@@ -41,7 +41,7 @@ $ yarn hub:watch (will rebuild app on file change)
 
 **NOTE**: it is important to define a unique `HUB_ADDRESS` if others are running the hub locally since all hub instances use the same Firebase realtime database.
 
-To play against the hub from the browser client, the hub and the browser need to:
+To connect to the `hub` from the browser `wallet`, the `hub` and the browser `wallet` need to:
 
 - Share the state-channel address of the hub. A good way to do so is to create a `.env.development.local` in the monorepo root with `HUB_ADDRESS` and `HUB_PRIVATE_KEY` defined.
 - Point to the same local Ganache server. Configure your `.env` files accordingly. This should work without any modifications.

--- a/packages/hub/readme.md
+++ b/packages/hub/readme.md
@@ -39,13 +39,15 @@ $ yarn hub:watch (will rebuild app on file change)
 
 ### Interacting with the hub from a browser
 
+**NOTE**: it is important to define a unique `HUB_ADDRESS` if others are running the hub locally since all hub instances use the same Firebase realtime database.
+
 To play against the hub from the browser client, the hub and the browser need to:
 
-- Share the state-channel address of the hub. A good way to do so is to create a `.env.development.local` in the monorepo root with HUB_ADDRESS and HUB_PRIVATE_KEY defined.
-- Point to the same local Ganache server. Configure your `.env.*.local` files accordingly.
-- Point to the same contract addresses on Ganache.
+- Share the state-channel address of the hub. A good way to do so is to create a `.env.development.local` in the monorepo root with `HUB_ADDRESS` and `HUB_PRIVATE_KEY` defined.
+- Point to the same local Ganache server. Configure your `.env` files accordingly. This should work without any modifications.
+- Point to the same contract addresses on Ganache. This will be the case if the hub and the client wallet point to the same Ganache server.
 
-You will also need to make sure that the hub's address has funds. You can find the hub address in [constants.ts](https://github.com/statechannels/monorepo/blob/master/packages/hub/src/constants.ts)
+You will also need to make sure that the hub's blockchain address has funds. The default hub blockchain address `HUB_SIGNER_ADDRESS` is in [constants.ts](https://github.com/statechannels/monorepo/blob/master/packages/hub/src/constants.ts)
 
 ## Testing
 

--- a/packages/wallet/config/env.js
+++ b/packages/wallet/config/env.js
@@ -13,7 +13,7 @@ if (!NODE_ENV) {
   throw new Error("The NODE_ENV environment variable is required but was not specified.");
 }
 
-configureEnvVariables();
+configureEnvVariables(true);
 
 // We support resolving modules according to `NODE_PATH`.
 // This lets you use absolute paths in imports inside large monorepos:

--- a/packages/wallet/src/constants.ts
+++ b/packages/wallet/src/constants.ts
@@ -17,7 +17,7 @@ export const CONSENSUS_LIBRARY_BYTECODE =
 export const NETWORK_ID = getNetworkId();
 export const USE_STORAGE = process.env.USE_STORAGE === "TRUE";
 // TODO: Move top ENV variable
-export const HUB_ADDRESS = "0x100063c326b27f78b2cBb7cd036B8ddE4d4FCa7C";
+export const HUB_ADDRESS = process.env.HUB_ADDRESS || "0x100063c326b27f78b2cBb7cd036B8ddE4d4FCa7C";
 export const CHALLENGE_DURATION = 0x12c; // 5 minutes
 
 export const FUNDING_STRATEGY: FundingStrategy =


### PR DESCRIPTION
With this PR:
- we can define `HUB_ADDRESS` and `HUB_PRIVATE_KEY` once in the root of the monorepo.
- have a clearer readme on starting the hub.