### PR TITLE
[wallet] Integration Test Changes

### DIFF
--- a/packages/wallet/puppeteer/__tests__/funding.test.ts
+++ b/packages/wallet/puppeteer/__tests__/funding.test.ts
@@ -44,6 +44,7 @@ describe("Funding", () => {
   });
 
   afterAll(async () => {
+    walletMessages.clearListeners();
     if (browserA) {
       await browserA.close();
     }

--- a/packages/wallet/puppeteer/__tests__/update-state.test.ts
+++ b/packages/wallet/puppeteer/__tests__/update-state.test.ts
@@ -115,7 +115,7 @@ describe("State Updating", () => {
   });
 
   afterAll(async () => {
-    walletMessages.clearListeners;
+    walletMessages.clearListeners();
     if (browserA) {
       await browserA.close();
     }

--- a/packages/wallet/puppeteer/__tests__/update-state.test.ts
+++ b/packages/wallet/puppeteer/__tests__/update-state.test.ts
@@ -115,6 +115,7 @@ describe("State Updating", () => {
   });
 
   afterAll(async () => {
+    walletMessages.clearListeners;
     if (browserA) {
       await browserA.close();
     }

--- a/packages/wallet/puppeteer/helpers.ts
+++ b/packages/wallet/puppeteer/helpers.ts
@@ -50,7 +50,7 @@ export async function loadWallet(page: puppeteer.Page, messageListener: (message
   const web3JsFile = fs.readFileSync(path.resolve(__dirname, "web3/web3.min.js"), "utf8");
   await page.evaluateOnNewDocument(web3JsFile);
   await page.evaluateOnNewDocument(`window.web3 = new Web3("http://localhost:${port}")`);
-  await page.goto("http://localhost:3055/", {waitUntil: "domcontentloaded"});
+  await page.goto("http://localhost:3055/", {waitUntil: "networkidle0"});
   page.on("pageerror", error => {
     throw error;
   });


### PR DESCRIPTION
Two changes here to help (hopefully) with the stability of the `wallet` integration tests.

- Switched to the `networkidle0` condition when loading the `wallet` page to hopefully ensure it's fully loaded before being used.
- Clear the message listeners when the test is done before we close the browsers to prevent an error being thrown by a message listener trying to call `window.Postmessage` after the browsers have been closed. 