### PR TITLE
[rps] Resintate tests

### DIFF
--- a/packages/channel-client/src/channel-client.ts
+++ b/packages/channel-client/src/channel-client.ts
@@ -11,9 +11,7 @@ import {
 } from './types';
 
 export class ChannelClient implements ChannelClientInterface<ChannelResult> {
-  constructor(private readonly provider: ChannelProviderInterface) {
-    console.info("[INFO] ChannelClient constructor assumes provider is 'enabled'");
-  }
+  constructor(private readonly provider: ChannelProviderInterface) {}
 
   onMessageQueued(callback: (message: Message<ChannelResult>) => void): UnsubscribeFunction {
     this.provider.on('MessageQueued', callback);

--- a/packages/channel-client/src/index.ts
+++ b/packages/channel-client/src/index.ts
@@ -9,3 +9,5 @@ export {
 } from './types';
 
 export {ChannelClient} from './channel-client';
+
+export {FakeChannelClient} from './fake-channel-client';

--- a/packages/rps/src/redux/auto-opponent/__tests__/auto-opponent.test.ts
+++ b/packages/rps/src/redux/auto-opponent/__tests__/auto-opponent.test.ts
@@ -8,6 +8,7 @@ import {gameReducer} from '../../game/reducer';
 import {openGamesReducer} from '../../open-games/reducer';
 import {channelUpdatedListener} from '../../message-service/channel-updated-listener';
 import {autoPlayer, autoOpponent} from '../';
+import {FakeChannelClient} from '@statechannels/channel-client';
 
 const SUFFICIENT_TIME_TO_GET_TO_TURNUM_16 = 7000; // test will take at least this long to run
 const reducer = combineReducers({
@@ -16,10 +17,10 @@ const reducer = combineReducers({
 });
 
 // TODO: Get this working with a mock for channel-client
-it.skip(
+it(
   'runs to GameOver',
   async () => {
-    const client = new RPSChannelClient();
+    const client = new RPSChannelClient(new FakeChannelClient('0xOpponent'));
     function* saga() {
       yield fork(gameSaga, client);
       yield fork(autoPlayer, 'A');

--- a/packages/rps/src/redux/auto-opponent/auto-opponent.ts
+++ b/packages/rps/src/redux/auto-opponent/auto-opponent.ts
@@ -12,6 +12,7 @@ import {combineReducers} from 'redux';
 import {gameReducer} from '../game/reducer';
 import {openGamesReducer} from '../open-games/reducer';
 import {WeiPerEther} from 'ethers/constants';
+import {FakeChannelClient} from '@statechannels/channel-client';
 
 // The auto-opponent simulates the actions of the opponent in an RPS game.
 //
@@ -38,7 +39,7 @@ export function* autoOpponent(player: 'A' | 'B', externalClient: RPSChannelClien
     } as GameState,
     openGames: [],
   };
-  const internalClient = new RPSChannelClient();
+  const internalClient = new RPSChannelClient(new FakeChannelClient('0xDoesNotMatter'));
   function* internalSaga() {
     yield fork(gameSaga, internalClient);
     yield fork(autoPlayer, player);

--- a/packages/rps/src/redux/game/__tests__/player-a.test.ts
+++ b/packages/rps/src/redux/game/__tests__/player-a.test.ts
@@ -16,13 +16,14 @@ import * as match from 'redux-saga-test-plan/matchers';
 import {RPSChannelClient} from '../../../utils/rps-channel-client';
 import {randomHex} from '../../../utils/randomHex';
 import {rpsChannelClientMocks} from './helpers';
+import {FakeChannelClient} from '@statechannels/channel-client';
 
 // need to get the same shape, so that selecting state in the saga works
 const reducer = combineReducers({
   game: gameReducer,
 });
 
-const client = new RPSChannelClient();
+const client = new RPSChannelClient(new FakeChannelClient('0xOpponent'));
 const {callCreateChannel, callUpdateChannel, callCloseChannel} = rpsChannelClientMocks(client);
 
 const gameState = (localState, channelState?: ChannelState) => ({

--- a/packages/rps/src/redux/game/__tests__/player-b.test.ts
+++ b/packages/rps/src/redux/game/__tests__/player-b.test.ts
@@ -17,13 +17,14 @@ import {
 import {ChannelState} from '../../../core';
 import {RPSChannelClient} from '../../../utils/rps-channel-client';
 import {rpsChannelClientMocks} from './helpers';
+import {FakeChannelClient} from '@statechannels/channel-client';
 
 // need to get the same shape, so that selecting state in the saga works
 const reducer = combineReducers({
   game: gameReducer,
 });
 
-const client = new RPSChannelClient();
+const client = new RPSChannelClient(new FakeChannelClient('0xOpponent'));
 const {callJoinChannel, callUpdateChannel, callCloseChannel} = rpsChannelClientMocks(client);
 
 const gameState = (localState, channelState?: ChannelState) => ({

--- a/packages/rps/src/redux/store.ts
+++ b/packages/rps/src/redux/store.ts
@@ -1,5 +1,5 @@
 import {applyMiddleware, compose, createStore} from 'redux';
-import {fork, call} from 'redux-saga/effects';
+import {fork} from 'redux-saga/effects';
 import createSagaMiddleware from 'redux-saga';
 
 import reducer from './reducer';

--- a/packages/rps/src/redux/store.ts
+++ b/packages/rps/src/redux/store.ts
@@ -14,6 +14,7 @@ import {channelUpdatedListener} from './message-service/channel-updated-listener
 import {messageQueuedListener} from './message-service/message-queued-listener';
 import {gameSaga} from './game/saga';
 import {autoPlayer, autoOpponent} from './auto-opponent';
+import {ChannelClient} from '@statechannels/channel-client';
 
 const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const enhancers = composeEnhancers(applyMiddleware(sagaMiddleware));
@@ -26,7 +27,7 @@ function* rootSaga() {
   const channelProviderEnabled = yield stateChannelWalletSaga();
 
   if (channelProviderEnabled) {
-    const client = new RPSChannelClient(window.channelProvider);
+    const client = new RPSChannelClient(new ChannelClient(window.channelProvider));
     yield fork(channelUpdatedListener, client);
     yield fork(messageQueuedListener, client);
     yield fork(gameSaga, client);

--- a/packages/rps/src/redux/store.ts
+++ b/packages/rps/src/redux/store.ts
@@ -26,9 +26,7 @@ function* rootSaga() {
   const channelProviderEnabled = yield stateChannelWalletSaga();
 
   if (channelProviderEnabled) {
-    const client = new RPSChannelClient();
-
-    yield call([client, client.enable]);
+    const client = new RPSChannelClient(window.channelProvider);
     yield fork(channelUpdatedListener, client);
     yield fork(messageQueuedListener, client);
     yield fork(gameSaga, client);

--- a/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
+++ b/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
@@ -14,10 +14,11 @@ class MockChannelProvider implements ChannelProviderInterface {
       /*empty*/
     });
   }
-  async send<ResultType = any>(method: string, params: any): Promise<ResultType> {
+  send = jest.fn().mockImplementationOnce(async (method: string, params: any) => {
     const response = await params;
+    this.events.emit('MessageQueued', '');
     return response;
-  }
+  });
   on(event: string, callback) {
     this.events.on(event, callback);
   }
@@ -35,9 +36,7 @@ class MockChannelProvider implements ChannelProviderInterface {
     });
   }
 }
-// TODO move this mock somewhere else
 
-// TODO: Get this working with a mock for channel-client
 it('works', async () => {
   const client = new RPSChannelClient(new MockChannelProvider());
 

--- a/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
+++ b/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
@@ -11,21 +11,19 @@ import {RPS_ADDRESS} from '../../constants';
 
 const MOCK_ADDRESS = '0xAddress';
 const MOCK_CHANNEL_ID = '0xChannelId';
-const ON_MESSAGE_QUEUED_MOCK_RETURN = () => '0xOMQReturn';
+const onMessageQueuedMockReturn = () => '0xOMQReturn';
+const onChannelUpdatedMockReturn = jest.fn(() => '0xOCUReturn');
+const onChannelProposedmMockReturn = jest.fn(() => '0xOCPReturn');
 class MockChannelClient implements ChannelClientInterface {
   onMessageQueued = jest.fn(function(callback) {
-    return ON_MESSAGE_QUEUED_MOCK_RETURN;
+    return onMessageQueuedMockReturn;
   });
-  onChannelUpdated(callback) {
-    return () => {
-      /* */
-    };
-  }
-  onChannelProposed(callback) {
-    return () => {
-      /* */
-    };
-  }
+  onChannelUpdated = jest.fn(function(callback) {
+    return onChannelUpdatedMockReturn;
+  });
+  onChannelProposed = jest.fn(function(callback) {
+    return onChannelProposedmMockReturn;
+  });
   createChannel = jest.fn(async function(participants, allocations, appDefinition, appData) {
     const channelResult: ChannelResult = {
       participants,
@@ -139,6 +137,24 @@ describe('when onMessageQueued is called with a callback', () => {
     expect(mockChannelClient.onMessageQueued).toHaveBeenCalledWith(callback);
   });
   it('and returns the result', async () => {
-    expect(result).toEqual(ON_MESSAGE_QUEUED_MOCK_RETURN);
+    expect(result).toEqual(onMessageQueuedMockReturn);
+  });
+});
+
+describe('when onChannelUpdated is called with an rps callback', () => {
+  let result: Function;
+  const rpsCallback = jest.fn();
+  beforeAll(async () => {
+    result = await client.onChannelUpdated(rpsCallback);
+  });
+  it('calls channelClient.onChannelUpdated() AND channelClient.onChannelProposed with a wrapper callback', async () => {
+    // TODO: somehow check the argument is a wrapper callback
+    expect(mockChannelClient.onChannelUpdated).toHaveBeenCalled();
+    expect(mockChannelClient.onChannelProposed).toHaveBeenCalled();
+  });
+  it('and returns a function that runs both returned (unsubscribe) functions', async () => {
+    result();
+    expect(onChannelUpdatedMockReturn).toHaveBeenCalled();
+    expect(onChannelProposedmMockReturn).toHaveBeenCalled();
   });
 });

--- a/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
+++ b/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
@@ -1,9 +1,45 @@
 import {RPSChannelClient} from '../rps-channel-client';
 import {aAddress, bAddress, aBal, bBal, appData} from '../../redux/game/__tests__/scenarios';
+import {ChannelProviderInterface} from '@statechannels/channel-provider';
+import EventEmitter = require('eventemitter3');
+
+class MockChannelProvider implements ChannelProviderInterface {
+  protected readonly events: EventEmitter;
+  constructor() {
+    this.events = new EventEmitter();
+  }
+
+  enable(url?: string) {
+    return new Promise<void>(() => {
+      /*empty*/
+    });
+  }
+  async send<ResultType = any>(method: string, params: any): Promise<ResultType> {
+    const response = await params;
+    return response;
+  }
+  on(event: string, callback) {
+    this.events.on(event, callback);
+  }
+  off(event: string, callback) {
+    this.events.off(event, callback);
+  }
+  subscribe(subscriptionType: string, params?: any) {
+    return new Promise<string>(() => {
+      /*empty*/
+    });
+  }
+  unsubscribe(subscriptionId: string) {
+    return new Promise<boolean>(() => {
+      /*empty*/
+    });
+  }
+}
+// TODO move this mock somewhere else
 
 // TODO: Get this working with a mock for channel-client
-it.skip('works', async () => {
-  const client = new RPSChannelClient();
+it('works', async () => {
+  const client = new RPSChannelClient(new MockChannelProvider());
 
   const spy = jest.fn();
 

--- a/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
+++ b/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
@@ -5,10 +5,12 @@ import {
   ChannelResult,
   PushMessageResult,
 } from '@statechannels/channel-client';
-import {encodeAppData} from '../../core';
+import {encodeAppData, ChannelState} from '../../core';
 import {bigNumberify} from 'ethers/utils';
 import {RPS_ADDRESS} from '../../constants';
 
+const MOCK_ADDRESS = '0xAddress';
+const MOCK_CHANNEL_ID = '0xChannelId';
 class MockChannelClient implements ChannelClientInterface {
   onMessageQueued = jest.fn(function(callback) {
     return () => {
@@ -31,7 +33,7 @@ class MockChannelClient implements ChannelClientInterface {
       allocations,
       appData,
       appDefinition,
-      channelId: '0x123',
+      channelId: MOCK_CHANNEL_ID,
       status: 'opening',
       turnNum: '0',
     };
@@ -57,38 +59,73 @@ class MockChannelClient implements ChannelClientInterface {
       /* */
     });
   }
-  getAddress() {
-    return new Promise<string>(() => {
-      /* */
-    });
-  }
+  getAddress = jest.fn(async function() {
+    return await MOCK_ADDRESS;
+  });
 }
 
-it('calls channelClient.createChannel with appropriately encoded date', async () => {
-  const mockChannelClient = new MockChannelClient();
-  const client = new RPSChannelClient(mockChannelClient);
+let mockChannelClient;
+let client;
 
-  await client.createChannel(aAddress, bAddress, aBal, bBal, appData.start);
+beforeAll(() => {
+  mockChannelClient = new MockChannelClient();
+  client = new RPSChannelClient(mockChannelClient);
+});
 
-  const participants = [
-    {participantId: aAddress, signingAddress: aAddress, destination: aAddress},
-    {participantId: bAddress, signingAddress: bAddress, destination: bAddress},
-  ];
-  const allocations = [
-    {
-      token: '0x0',
-      allocationItems: [
-        {destination: aAddress, amount: bigNumberify(aBal).toHexString()},
-        {destination: bAddress, amount: bigNumberify(bBal).toHexString()},
-      ],
-    },
-  ];
-  const appDefinition = RPS_ADDRESS;
+describe('when getAddress() is called', () => {
+  let result;
+  beforeAll(async () => {
+    result = await client.getAddress();
+  });
+  it('calls channelClient.getAddress()', async () => {
+    expect(mockChannelClient.getAddress).toHaveBeenCalled();
+  });
+  it('and returns the result', async () => {
+    expect(result).toEqual(MOCK_ADDRESS);
+  });
+});
 
-  expect(mockChannelClient.createChannel).toHaveBeenCalledWith(
-    participants,
-    allocations,
-    appDefinition,
-    encodeAppData(appData.start)
-  );
+describe('when createChannel() is called', () => {
+  let result;
+  beforeAll(async () => {
+    result = await client.createChannel(aAddress, bAddress, aBal, bBal, appData.start);
+  });
+  it('calls channelClient.createChannel() with appropriately encoded data', async () => {
+    const participants = [
+      {participantId: aAddress, signingAddress: aAddress, destination: aAddress},
+      {participantId: bAddress, signingAddress: bAddress, destination: bAddress},
+    ];
+    const allocations = [
+      {
+        token: '0x0',
+        allocationItems: [
+          {destination: aAddress, amount: bigNumberify(aBal).toHexString()},
+          {destination: bAddress, amount: bigNumberify(bBal).toHexString()},
+        ],
+      },
+    ];
+    const appDefinition = RPS_ADDRESS;
+
+    expect(mockChannelClient.createChannel).toHaveBeenCalledWith(
+      participants,
+      allocations,
+      appDefinition,
+      encodeAppData(appData.start)
+    );
+  });
+  it('decodes and returns the result', async () => {
+    const channelState: ChannelState = {
+      channelId: MOCK_CHANNEL_ID,
+      turnNum: '0',
+      status: 'opening',
+      aUserId: aAddress,
+      bUserId: bAddress,
+      aAddress: aAddress,
+      bAddress: bAddress,
+      aBal: aBal,
+      bBal: bBal,
+      appData: appData.start,
+    };
+    expect(result).toEqual(channelState);
+  });
 });

--- a/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
+++ b/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
@@ -11,11 +11,10 @@ import {RPS_ADDRESS} from '../../constants';
 
 const MOCK_ADDRESS = '0xAddress';
 const MOCK_CHANNEL_ID = '0xChannelId';
+const ON_MESSAGE_QUEUED_MOCK_RETURN = () => '0xOMQReturn';
 class MockChannelClient implements ChannelClientInterface {
   onMessageQueued = jest.fn(function(callback) {
-    return () => {
-      /* */
-    };
+    return ON_MESSAGE_QUEUED_MOCK_RETURN;
   });
   onChannelUpdated(callback) {
     return () => {
@@ -127,5 +126,19 @@ describe('when createChannel() is called', () => {
       appData: appData.start,
     };
     expect(result).toEqual(channelState);
+  });
+});
+
+describe('when onMessageQueued is called with a callback', () => {
+  let result;
+  const callback = jest.fn();
+  beforeAll(async () => {
+    result = await client.onMessageQueued(callback);
+  });
+  it('calls channelClient.onMessageQueued() with the same callback', async () => {
+    expect(mockChannelClient.onMessageQueued).toHaveBeenCalledWith(callback);
+  });
+  it('and returns the result', async () => {
+    expect(result).toEqual(ON_MESSAGE_QUEUED_MOCK_RETURN);
   });
 });

--- a/packages/rps/src/utils/rps-channel-client.ts
+++ b/packages/rps/src/utils/rps-channel-client.ts
@@ -7,15 +7,18 @@ import {
 } from '@statechannels/channel-client';
 import {RPS_ADDRESS} from '../constants';
 import {bigNumberify} from 'ethers/utils';
+import {ChannelProviderInterface} from '@statechannels/channel-provider';
 
 // This class wraps the channel client converting the request/response formats to those used in the app
 
 export class RPSChannelClient {
   channelClient: ChannelClientInterface;
 
+  constructor(provider: ChannelProviderInterface) {
+    this.channelClient = new ChannelClient(provider);
+  }
   async enable() {
-    // might want to pass this in later
-    this.channelClient = new ChannelClient(window.channelProvider);
+    /* empty */
   }
 
   async createChannel(

--- a/packages/rps/src/utils/rps-channel-client.ts
+++ b/packages/rps/src/utils/rps-channel-client.ts
@@ -1,22 +1,13 @@
 import {AppData, ChannelState, encodeAppData, decodeAppData} from '../core';
-import {
-  ChannelClient,
-  ChannelResult,
-  Message,
-  ChannelClientInterface,
-} from '@statechannels/channel-client';
+import {ChannelResult, Message, ChannelClientInterface} from '@statechannels/channel-client';
 import {RPS_ADDRESS} from '../constants';
 import {bigNumberify} from 'ethers/utils';
-import {ChannelProviderInterface} from '@statechannels/channel-provider';
 
 // This class wraps the channel client converting the request/response formats to those used in the app
 
 export class RPSChannelClient {
-  channelClient: ChannelClientInterface;
+  constructor(private readonly channelClient: ChannelClientInterface) {}
 
-  constructor(provider: ChannelProviderInterface) {
-    this.channelClient = new ChannelClient(provider);
-  }
   async enable() {
     /* empty */
   }

--- a/packages/rps/src/utils/rps-channel-client.ts
+++ b/packages/rps/src/utils/rps-channel-client.ts
@@ -33,7 +33,6 @@ export class RPSChannelClient {
     const appDefinition = RPS_ADDRESS;
     const appData = encodeAppData(appAttrs);
 
-    // ignore return val for now and stub out response
     const channelResult = await this.channelClient.createChannel(
       participants,
       allocations,

--- a/packages/rps/src/utils/rps-channel-client.ts
+++ b/packages/rps/src/utils/rps-channel-client.ts
@@ -119,8 +119,8 @@ const convertToChannelState = (channelResult: ChannelResult): ChannelState => {
     bUserId: participants[1].participantId,
     aAddress: participants[0].destination,
     bAddress: participants[1].destination,
-    aBal: allocations[0].allocationItems[0].amount.toString(),
-    bBal: allocations[0].allocationItems[1].amount.toString(),
+    aBal: bigNumberify(allocations[0].allocationItems[0].amount).toString(),
+    bBal: bigNumberify(allocations[0].allocationItems[1].amount).toString(),
   };
 };
 


### PR DESCRIPTION
Closes #713 .

This PR undisables these tests, which were set to "skip" recently. 

1. The auto-opponent and test use the `FakeChannelClient`

2. The test for `RPSChannelClient` class mocks up a `ChannelClient` and does not assert anything that requires the underlying provider to exist (for example, an event being emitted). It also expands the test coverage to 

 - [x] `onMessageQueued()`
 - [x] `onChannelUpdated()`
 - [x] `createChannel()`
 - [x] `joinChannel()`
 - [x] `closeChannel()`
 - [x] `updateChannel()`
 - [x] `pushMessage()`
 - [x] `getAddress()`

👀 Additional modifications to non-test code:
- A wrapper `Client` will not spawn the underlying `Client`: it must be passed in, instead (makes testing via mocks far easier)
- (related) Channel Client's `enable` method no longer does anything.
- Encoding mismatch fixed (uncovered by new testing approach).
- Wrapper client's `pushMessage` method passes through (i.e. returns) the return value of the inner class instance's `pushMessage`