### PR TITLE
[rps] Improve user login / metamask enable experience

### DIFF
--- a/packages/rps/src/gateways/firebase.ts
+++ b/packages/rps/src/gateways/firebase.ts
@@ -14,6 +14,7 @@ const config = {
 };
 
 const fire = firebase.initializeApp(config);
+firebase.auth().setPersistence(firebase.auth.Auth.Persistence.NONE);
 export const reduxSagaFirebase = new ReduxSagaFirebase(fire);
 export const authProvider = new firebase.auth.GoogleAuthProvider();
 export default fire;

--- a/packages/rps/src/redux/login/actions.ts
+++ b/packages/rps/src/redux/login/actions.ts
@@ -5,12 +5,6 @@ export const LOGIN_REQUEST = 'LOGIN.REQUEST';
 export const LOGIN_SUCCESS = 'LOGIN.SUCCESS';
 export const LOGIN_FAILURE = 'LOGIN.FAILURE';
 
-export const INITIALIZE_WALLET_SUCCESS = 'LOGIN.INITIALIZE_WALLET_SUCCESS';
-export const initializeWalletSuccess = () => ({
-  type: INITIALIZE_WALLET_SUCCESS as typeof INITIALIZE_WALLET_SUCCESS,
-});
-export type InitializeWalletSuccess = ReturnType<typeof initializeWalletSuccess>;
-
 export const loginRequest = () => ({
   type: LOGIN_REQUEST as typeof LOGIN_REQUEST,
 });

--- a/packages/rps/src/redux/login/saga.ts
+++ b/packages/rps/src/redux/login/saga.ts
@@ -39,7 +39,6 @@ function* loginStatusWatcherSaga() {
           )
         );
       } else {
-        yield put(loginActions.initializeWalletSuccess());
         yield put(loginActions.loginSuccess(user, libraryAddress));
       }
     } else {
@@ -49,17 +48,17 @@ function* loginStatusWatcherSaga() {
 }
 
 export default function* loginRootSaga() {
-  const metaMask = yield metamaskSaga();
-
-  // If metamask is not properly set up we can halt processing and wait for the reload
-  if (!metaMask) {
-    return;
-  }
   yield fork(loginStatusWatcherSaga);
   yield all([
     takeEvery(loginActions.LOGIN_REQUEST, loginSaga),
     takeEvery(loginActions.LOGOUT_REQUEST, logoutSaga),
   ]);
+  yield take('UpdateProfile');
+  const metaMask = yield metamaskSaga();
+  // If metamask is not properly set up we can halt processing and wait for the reload
+  if (!metaMask) {
+    return;
+  }
 }
 
 function getLibraryAddress() {

--- a/packages/rps/src/redux/metamask/actions.ts
+++ b/packages/rps/src/redux/metamask/actions.ts
@@ -1,5 +1,6 @@
 export const METAMASK_ERROR = 'METAMASK.ERROR';
 export const METAMASK_SUCCESS = 'METAMASK.SUCCESS';
+export const METAMASK_ENABLE = 'METAMASK.ENABLE';
 export const enum MetamaskErrorType {
   WrongNetwork = 'WrongNetwork',
   NoMetaMask = 'NoMetaMask',
@@ -21,7 +22,12 @@ export const metamaskSuccess = () => ({
   type: METAMASK_SUCCESS as typeof METAMASK_SUCCESS,
 });
 
+export const metamaskEnable = () => ({
+  type: METAMASK_ENABLE as typeof METAMASK_ENABLE,
+});
+
 export type MetamaskErrorOccurred = ReturnType<typeof metamaskErrorOccurred>;
 export type MetamaskSuccess = ReturnType<typeof metamaskSuccess>;
+export type MetamaskEnable = ReturnType<typeof metamaskEnable>;
 
-export type MetamaskResponse = MetamaskErrorOccurred | MetamaskSuccess;
+export type MetamaskResponse = MetamaskErrorOccurred | MetamaskSuccess | MetamaskEnable;

--- a/packages/rps/src/redux/metamask/reducer.ts
+++ b/packages/rps/src/redux/metamask/reducer.ts
@@ -8,7 +8,7 @@ export interface MetamaskState {
 }
 
 const initialState: MetamaskState = {
-  loading: true,
+  loading: false,
   error: null,
   success: false,
 };
@@ -30,6 +30,13 @@ export const metamaskReducer: Reducer<MetamaskState> = (
         success: false,
         loading: false,
         error: action.error,
+      };
+    }
+    case metamaskActions.METAMASK_ENABLE: {
+      return {
+        success: false,
+        loading: true,
+        error: null,
       };
     }
     default:

--- a/packages/rps/src/redux/metamask/saga.ts
+++ b/packages/rps/src/redux/metamask/saga.ts
@@ -24,6 +24,7 @@ export default function* checkMetamask() {
   if (typeof window.ethereum !== 'undefined') {
     try {
       window.ethereum.autoRefreshOnNetworkChange = false;
+      yield put(metamaskActions.metamaskEnable());
       yield call([window.ethereum, 'enable']);
     } catch (error) {
       console.error(error);
@@ -39,7 +40,6 @@ export default function* checkMetamask() {
     });
     const targetNetworkName = process.env.TARGET_NETWORK;
     const selectedNetworkId = parseInt(window.ethereum.networkVersion, 10);
-    console.log('selectedNetworkId' + selectedNetworkId);
     // Find the network name that matches the currently selected network id
     const selectedNetworkName =
       Object.keys(networks).find(


### PR DESCRIPTION
![rps-login](https://user-images.githubusercontent.com/1833419/71080639-75dce800-2185-11ea-8dfb-de8fcf29a583.gif)

As per [recommendation](https://gist.github.com/rekmarks/d318677c8fc89e5f7a2f526e00a0768a#file-newprovider-js-L71-L73), metamask will not pop up until the user has confirmed they want to use the app. 

Note that metamask will remember the approval for a connection to `localhost` (or `rps.com`) and therefore will not re-prompt next time unless you delete the connection.

<img width="152" alt="Screenshot 2019-12-18 at 11 07 58" src="https://user-images.githubusercontent.com/1833419/71081204-aa9d6f00-2186-11ea-8d42-01b9da447634.png">

I also disabled persistence for firebase auth, which was causing any user who had previously logged in to be bumped straight past the homepage to the "Name / Twitter Handle" modal without clicking anything.

References
---
See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1102.md