### PR TITLE
Cache `lib` directories in circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ save_lib: &save_lib
       - packages/jest-gas-reporter/lib
       - packages/channel-provider/lib
       - packages/channel-client/lib
-      - packages/engine/lib
       - packages/hub/lib
       - packages/wallet-specs/lib
 restore_lib: &restore_lib

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,17 +20,38 @@ defaults: &defaults
 
 save_dep: &save_dep
   save_cache:
-    key: dependency-cache-{{ checksum "yarn.lock" }}
+    key: v1-dependency-cache-{{ checksum "yarn.lock" }}
     paths:
       - node_modules
-      - packages/*/node_modules
-
 restore_dep: &restore_dep
   restore_cache:
-    key: dependency-cache-{{ checksum "yarn.lock" }}
+    key: v1-dependency-cache-{{ checksum "yarn.lock" }}
+
+save_lib: &save_lib
+  save_cache:
+    # Force a new cache on each build
+    key: v1-lib-cache-{{ epoch }}
+    paths:
+      - packages/nitro-protocol/lib
+      - packages/rps/lib
+      - packages/client-api-schema/lib
+      - packages/e2e-tests/lib
+      - packages/web3torrent/lib
+      - packages/embedded-wallet/lib
+      - packages/devtools/lib
+      - packages/wallet/lib
+      - packages/jest-gas-reporter/lib
+      - packages/channel-provider/lib
+      - packages/channel-client/lib
+      - packages/engine/lib
+      - packages/hub/lib
+      - packages/wallet-specs/lib
+restore_lib: &restore_lib
+  restore_cache:
+    # Restore from the most recently cached version of lib, using a partial key match
+    key: v1-lib-cache-
 
 commands:
-
   log_stats:
     description: 'Log stats '
     parameters:
@@ -76,7 +97,6 @@ commands:
           only_for_branches: 'master'
 
 jobs:
-
   prepare:
     <<: *defaults
     steps:
@@ -84,8 +104,10 @@ jobs:
       - log_stats:
           file: prepare-stats
       - <<: *restore_dep
+      - <<: *restore_lib
       - run: yarn --frozen-lockfile
       - <<: *save_dep
+      - <<: *save_lib
 
       - persist_to_workspace:
           root: /home/circleci/project

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -33,11 +33,9 @@
   "homepage": "https://github.com/statechannels/nitro-protocol/",
   "scripts": {
     "precommit": "lint-staged --quiet",
-    "build": "run-s clearContracts clearLib contract:compile build:typescript",
+    "build": "run-s contract:compile build:typescript",
     "build:typescript": "tsc -b .",
     "contract:compile": "node ./bin/compile.js",
-    "clearContracts": "rm -rf build/contracts",
-    "clearLib": "rm -rf lib",
     "lint:check": "eslint \"*/**/*.ts\" --cache",
     "lint:write": "eslint \"*/**/*.ts\" --fix",
     "prepare": "yarn patch-package && yarn build",


### PR DESCRIPTION
`tsc` is much, much faster on the second run. This PR caches `packages/*/lib` after running `yarn prepare`.