### PR TITLE
[channel-client] Run FakeChannelClient tests in CI

### DIFF
--- a/packages/channel-client/package.json
+++ b/packages/channel-client/package.json
@@ -7,6 +7,7 @@
     "prepare": "yarn build",
     "precommit": "lint-staged --quiet",
     "test": "jest",
+    "test:ci": "jest",
     "build": "yarn build:typescript",
     "build:typescript": "tsc -b .",
     "lint:check": "eslint {src,tests}/**/*.ts",

--- a/packages/channel-client/src/fake-channel-client.ts
+++ b/packages/channel-client/src/fake-channel-client.ts
@@ -15,8 +15,8 @@ import {
 import {calculateChannelId} from './utils';
 
 export class FakeChannelClient implements ChannelClientInterface<ChannelResult> {
-  playerIndex = 0 | 1;
-  opponentIndex = 0 | 1;
+  playerIndex?: number;
+  opponentIndex?: number;
   opponentAddress?: string;
   latestState?: ChannelResult;
   protected events = new EventEmitter<EventsWithArgs>();
@@ -32,18 +32,34 @@ export class FakeChannelClient implements ChannelClientInterface<ChannelResult> 
   }
 
   updatePlayerIndex(playerIndex: number): void {
-    this.playerIndex = playerIndex;
-    this.opponentIndex = playerIndex == 1 ? 0 : 1;
+    if (this.playerIndex === undefined) {
+      this.playerIndex = playerIndex;
+      this.opponentIndex = playerIndex == 1 ? 0 : 1;
+    }
   }
 
   verifyTurnNum(turnNum: string): Promise<void> {
     const currentTurnNum = bigNumberify(turnNum);
-    if (currentTurnNum.mod(2).eq(this.playerIndex)) {
+    if (currentTurnNum.mod(2).eq(this.getPlayerIndex())) {
       return Promise.reject(
         `Not your turn: currentTurnNum = ${currentTurnNum}, index = ${this.playerIndex}`
       );
     }
     return Promise.resolve();
+  }
+
+  getPlayerIndex(): number {
+    if (this.playerIndex === undefined) {
+      throw Error(`This client does not have its player index set yet`);
+    }
+    return this.playerIndex;
+  }
+
+  getOpponentIndex(): number {
+    if (this.opponentIndex === undefined) {
+      throw Error(`This client does not have its opponent player index set yet`);
+    }
+    return this.opponentIndex;
   }
 
   getNextTurnNum(latestState: ChannelResult) {
@@ -78,7 +94,7 @@ export class FakeChannelClient implements ChannelClientInterface<ChannelResult> 
   async joinChannel(channelId: string): Promise<ChannelResult> {
     const latestState = this.findChannel(channelId);
     this.updatePlayerIndex(1);
-    log.debug(`Player ${this.playerIndex} joining channel ${channelId}`);
+    log.debug(`Player ${this.getPlayerIndex()} joining channel ${channelId}`);
     await this.verifyTurnNum(latestState.turnNum);
 
     // skip funding by setting the channel to 'running' the moment it is joined
@@ -100,14 +116,14 @@ export class FakeChannelClient implements ChannelClientInterface<ChannelResult> 
     allocations: Allocation[],
     appData: string
   ): Promise<ChannelResult> {
-    log.debug(`Player ${this.playerIndex} updating channel ${channelId}`);
+    log.debug(`Player ${this.getPlayerIndex()} updating channel ${channelId}`);
     const latestState = this.findChannel(channelId);
 
     const nextState = {...latestState, participants, allocations, appData};
     if (nextState !== latestState) {
       await this.verifyTurnNum(nextState.turnNum);
       nextState.turnNum = this.getNextTurnNum(latestState);
-      log.debug(`Player ${this.playerIndex} updated channel to turnNum ${nextState.turnNum}`);
+      log.debug(`Player ${this.getPlayerIndex()} updated channel to turnNum ${nextState.turnNum}`);
     }
 
     this.latestState = nextState;
@@ -124,7 +140,7 @@ export class FakeChannelClient implements ChannelClientInterface<ChannelResult> 
 
     this.latestState = {...latestState, turnNum, status};
     log.debug(
-      `Player ${this.playerIndex} updated channel to status ${status} on turnNum ${turnNum}`
+      `Player ${this.getPlayerIndex()} updated channel to status ${status} on turnNum ${turnNum}`
     );
     this.notifyOpponent(this.latestState, 'closeChannel');
 
@@ -133,7 +149,7 @@ export class FakeChannelClient implements ChannelClientInterface<ChannelResult> 
 
   protected notifyOpponent(data: ChannelResult, notificationType: string): void {
     log.debug(
-      `${this.playerIndex} notifying opponent ${this.opponentIndex} about ${notificationType}`
+      `${this.getPlayerIndex()} notifying opponent ${this.getOpponentIndex()} about ${notificationType}`
     );
     const sender = this.address;
     const recipient = this.opponentAddress;
@@ -158,7 +174,7 @@ export class FakeChannelClient implements ChannelClientInterface<ChannelResult> 
   onMessageQueued(callback: (message: Message<ChannelResult>) => void): UnsubscribeFunction {
     this.events.on('MessageQueued', message => {
       log.debug(
-        `Sending message from ${this.playerIndex} to ${this.opponentIndex}: ${JSON.stringify(
+        `Sending message from ${this.getPlayerIndex()} to ${this.getOpponentIndex()}: ${JSON.stringify(
           message,
           undefined,
           4
@@ -185,7 +201,7 @@ export class FakeChannelClient implements ChannelClientInterface<ChannelResult> 
 
   async pushMessage(parameters: Message<ChannelResult>): Promise<PushMessageResult> {
     log.debug(
-      `${this.playerIndex} pushing message from app to wallet: ${JSON.stringify(
+      `${this.getPlayerIndex()} pushing message from app to wallet: ${JSON.stringify(
         parameters,
         undefined,
         4
@@ -202,7 +218,7 @@ export class FakeChannelClient implements ChannelClientInterface<ChannelResult> 
       // auto-close, if we received a close
       case 'closing':
         log.debug(
-          `${this.playerIndex} auto-closing channel on close request from ${this.opponentIndex}`
+          `${this.getPlayerIndex()} auto-closing channel on close request from ${this.getOpponentIndex()}`
         );
         this.latestState = {...this.latestState, turnNum, status: 'closed'};
         this.notifyOpponent(this.latestState, 'pushMessage');

--- a/packages/channel-client/src/fake-channel-client.ts
+++ b/packages/channel-client/src/fake-channel-client.ts
@@ -200,13 +200,6 @@ export class FakeChannelClient implements ChannelClientInterface<ChannelResult> 
   }
 
   async pushMessage(parameters: Message<ChannelResult>): Promise<PushMessageResult> {
-    log.debug(
-      `${this.getPlayerIndex()} pushing message from app to wallet: ${JSON.stringify(
-        parameters,
-        undefined,
-        4
-      )}`
-    );
     this.latestState = parameters.data;
     this.notifyApp(this.latestState);
     const turnNum = this.getNextTurnNum(this.latestState);

--- a/packages/channel-client/tests/fake-channel-client.test.ts
+++ b/packages/channel-client/tests/fake-channel-client.test.ts
@@ -93,7 +93,6 @@ describe('FakeChannelClient', () => {
   });
 
   describe('creates a channel', () => {
-    expect.assertions(2);
     let proposalMessage: Message<ChannelResult>;
 
     it('client A produces the right channel result', async () => {
@@ -128,7 +127,8 @@ describe('FakeChannelClient', () => {
 
   describe('joins a channel', () => {
     it('the player whose turn it is can accept proposal to join the channel', async () => {
-      setClientStates([clientA, clientB], states['proposed']);
+      setClientStates([clientA], states['running']);
+      setClientStates([clientB], states['proposed']);
       const channelResult = await clientB.joinChannel(channelId);
       expect(channelResult).toEqual(states['running']);
       expect(clientA.latestState).toEqual(states['running']);

--- a/packages/rps/package.json
+++ b/packages/rps/package.json
@@ -93,6 +93,7 @@
   },
   "devDependencies": {
     "@babel/runtime": "^7.0.0-beta.53",
+    "@statechannels/channel-client": "^0.0.1",
     "@statechannels/devtools": "0.1.21",
     "@statechannels/jest-gas-reporter": "0.0.2",
     "@storybook/react": "5.2.6",


### PR DESCRIPTION
The `test:ci` was missing from the original PR that introduced the `FakeChannelClient`.