### PR TITLE
Wallet store cleanup

### DIFF
--- a/packages/wallet-specs/src/ChannelStoreEntry.ts
+++ b/packages/wallet-specs/src/ChannelStoreEntry.ts
@@ -100,7 +100,7 @@ export class ChannelStoreEntry implements IChannelStoreEntry {
     if (!this.latestSupportedState) {
       return [];
     } else {
-      return this.states.slice(this.states.map(s => s.state).indexOf(this.latestSupportedState));
+      return this.states.slice(this.states.map(s => s.state).indexOf(this.latestSupportedState) + 1);
     }
   }
 

--- a/packages/wallet-specs/src/ChannelStoreEntry.ts
+++ b/packages/wallet-specs/src/ChannelStoreEntry.ts
@@ -36,17 +36,22 @@ export function isGuarantee(funding: Funding): funding is Guaranteed {
 }
 
 export interface IChannelStoreEntry {
-  supportedState: SignedState[];
-  unsupportedStates: SignedState[];
+  states: SignedState[];
   privateKey: string;
   participants: Participant[];
   channel: Channel;
   funding?: Funding;
 }
 
+function supported(signedState: SignedState) {
+  // TODO: temporarily just check the required length
+  return (
+    signedState.signatures.filter(Boolean).length === signedState.state.channel.participants.length
+  );
+}
+
 export class ChannelStoreEntry implements IChannelStoreEntry {
-  public supportedState: SignedState[];
-  public unsupportedStates: SignedState[];
+  public states: SignedState[] = [];
   public privateKey: string;
   public participants: Participant[];
   public funding?: Funding;
@@ -61,41 +66,26 @@ export class ChannelStoreEntry implements IChannelStoreEntry {
     } else {
       throw new Error('Required arguments missing');
     }
-    this.supportedState = args.supportedState || [];
-    this.unsupportedStates = args.unsupportedStates || [];
+    this.states = args.states || [];
     this.funding = args.funding;
   }
 
   get args(): IChannelStoreEntry {
-    const {
-      supportedState,
-      unsupportedStates,
-      privateKey,
-      participants,
-      channel,
-      funding,
-    }: IChannelStoreEntry = this;
-    return {
-      supportedState,
-      unsupportedStates,
-      privateKey,
-      participants,
-      channel,
-      funding,
-    };
+    const { states, privateKey, participants, channel, funding }: IChannelStoreEntry = this;
+    return { states, privateKey, participants, channel, funding };
   }
 
   get ourIndex() {
     return this.participants.findIndex(p => p.signingAddress === this.privateKey);
   }
 
-  get latestSupportedState(): State | undefined {
-    const numStates = this.supportedState.length;
-    if (numStates > 0) {
-      return this.supportedState[numStates - 1].state;
-    } else {
-      return undefined;
+  get latestSupportedState(): State {
+    const signedState = this.states.find(supported);
+    if (!signedState) {
+      throw 'No supported state found';
     }
+
+    return signedState.state;
   }
 
   get ourAddress(): string {
@@ -106,9 +96,14 @@ export class ChannelStoreEntry implements IChannelStoreEntry {
     return getChannelId(this.channel);
   }
 
-  get states(): SignedState[] {
-    return this.unsupportedStates.concat(this.supportedState);
+  get unsupportedStates(): SignedState[] {
+    if (!this.latestSupportedState) {
+      return [];
+    } else {
+      return this.states.slice(this.states.map(s => s.state).indexOf(this.latestSupportedState));
+    }
   }
+
   get latestState(): State {
     if (!this.states.length) {
       throw new Error('No states found');

--- a/packages/wallet-specs/src/protocols/conclude-channel/protocol.ts
+++ b/packages/wallet-specs/src/protocols/conclude-channel/protocol.ts
@@ -13,9 +13,8 @@ function finalState({ channelId }: Init): State {
   // Only works for wallet channels
   // (and even doesn't really work reliably there)
   const latestState = store
-    .getUnsupportedStates(channelId)
-    .concat(store.getLatestConsensus(channelId))
-    .filter(({ state }) => store.signedByMe(state))
+    .getEntry(channelId)
+    .states.filter(({ state }) => store.signedByMe(state))
     .sort(({ state }) => state.turnNum)
     .pop();
 
@@ -79,7 +78,10 @@ const virtualDefunding = {
   states: {
     start: {
       on: {
-        '': [{ target: 'asLeaf', cond: 'amLeaf' }, { target: 'asHub', cond: 'amHub' }],
+        '': [
+          { target: 'asLeaf', cond: 'amLeaf' },
+          { target: 'asHub', cond: 'amHub' },
+        ],
       },
     },
     asLeaf: {

--- a/packages/wallet-specs/src/protocols/create-channel/protocol.ts
+++ b/packages/wallet-specs/src/protocols/create-channel/protocol.ts
@@ -120,8 +120,7 @@ export const machine: MachineFactory<Init, any> = (store: Store, init: Init) => 
 
     const entry = new ChannelStoreEntry({
       channel,
-      supportedState: [],
-      unsupportedStates: [{ state: firstState, signatures: [] }],
+      states: [{ state: firstState, signatures: [] }],
       privateKey: store.getPrivateKey(ctx.participants.map(p => p.participantId)),
       participants: ctx.participants,
     });

--- a/packages/wallet-specs/src/protocols/create-channel/protocol.ts
+++ b/packages/wallet-specs/src/protocols/create-channel/protocol.ts
@@ -136,7 +136,7 @@ export const machine: MachineFactory<Init, any> = (store: Store, init: Init) => 
   const guards = {};
   const actions = {
     sendOpenChannelMessage: ({ channelId }: SetChannel) => {
-      const state = store.getLatestState(channelId);
+      const state = store.getEntry(channelId).latestState;
       if (state.turnNum !== 0) {
         throw new Error('Wrong state');
       }

--- a/packages/wallet-specs/src/protocols/create-null-channel/protocol.ts
+++ b/packages/wallet-specs/src/protocols/create-null-channel/protocol.ts
@@ -79,7 +79,7 @@ export const machine: MachineFactory<Init, any> = (store, context: Init) => {
       signingAddress: p,
     }));
     const privateKey = store.getPrivateKey(participants.map(p => p.participantId));
-    const unsupportedStates: SignedState[] = [
+    const states: SignedState[] = [
       {
         state: {
           turnNum: 0,
@@ -96,7 +96,7 @@ export const machine: MachineFactory<Init, any> = (store, context: Init) => {
         channel,
         privateKey,
         participants,
-        unsupportedStates,
+        states,
       })
     );
 

--- a/packages/wallet-specs/src/protocols/direct-funding/protocol.ts
+++ b/packages/wallet-specs/src/protocols/direct-funding/protocol.ts
@@ -61,7 +61,7 @@ function uniqueDestinations(outcome: Allocation): string[] {
 }
 
 function preDepositOutcome(channelId: string, minimalOutcome: Allocation): Outcome {
-  const { state } = store.getLatestConsensus(channelId);
+  const state = store.getEntry(channelId).latestSupportedState;
   const outcome = store.getLatestSupportedAllocation(channelId);
 
   const destinations = uniqueDestinations(outcome.concat(minimalOutcome));

--- a/packages/wallet-specs/src/protocols/direct-funding/protocol.ts
+++ b/packages/wallet-specs/src/protocols/direct-funding/protocol.ts
@@ -62,7 +62,7 @@ function uniqueDestinations(outcome: Allocation): string[] {
 
 function preDepositOutcome(channelId: string, minimalOutcome: Allocation): Outcome {
   const state = store.getEntry(channelId).latestSupportedState;
-  const outcome = store.getLatestSupportedAllocation(channelId);
+  const outcome = checkThat(store.getEntry(channelId).latestSupportedState.outcome, isAllocation);
 
   const destinations = uniqueDestinations(outcome.concat(minimalOutcome));
   return outcome.concat(
@@ -78,7 +78,7 @@ function amount(item: AllocationItem): string {
 }
 
 function postDepositOutcome(channelId: string): Outcome {
-  const outcome = store.getLatestSupportedAllocation(channelId);
+  const outcome = checkThat(store.getEntry(channelId).latestSupportedState.outcome, isAllocation);
   const destinations = uniqueDestinations(outcome);
 
   return destinations.map(destination => ({

--- a/packages/wallet-specs/src/protocols/ledger-defunding/protocol.ts
+++ b/packages/wallet-specs/src/protocols/ledger-defunding/protocol.ts
@@ -1,6 +1,6 @@
 import { store } from '../..';
 import { isIndirectFunding } from '../../ChannelStoreEntry';
-import { checkThat } from '../../store';
+import { checkThat, isAllocation } from '../../store';
 import * as LedgerUpdate from '../ledger-update/protocol';
 
 const PROTOCOL = 'ledger-defunding';
@@ -12,11 +12,11 @@ export interface Init {
 
 function ledgerUpdateArgs({ targetChannelId }: Init): LedgerUpdate.Init {
   const { ledgerId } = checkThat(store.getEntry(targetChannelId).funding, isIndirectFunding);
-  const outcome = store.getLatestSupportedAllocation(ledgerId);
-  const concludedOutcome = store.getLatestSupportedAllocation(targetChannelId);
-  const targetOutcome = outcome
+  const { outcome } = store.getEntry(ledgerId).latestSupportedState;
+  const { outcome: concludedOutcome } = store.getEntry(targetChannelId).latestSupportedState;
+  const targetOutcome = checkThat(outcome, isAllocation)
     .filter(item => item.destination !== targetChannelId)
-    .concat(concludedOutcome);
+    .concat(checkThat(concludedOutcome, isAllocation));
   return {
     channelId: ledgerId,
     targetOutcome,

--- a/packages/wallet-specs/src/protocols/ledger-funding/protocol.ts
+++ b/packages/wallet-specs/src/protocols/ledger-funding/protocol.ts
@@ -131,7 +131,7 @@ export const machine: MachineFactory<Init, any> = (store: Store, context: Init) 
   function directFundingArgs(ctx: LedgerExists): DirectFunding.Init {
     return {
       channelId: ctx.ledgerChannelId,
-      minimalOutcome: store.getLatestState(ctx.targetChannelId).outcome,
+      minimalOutcome: store.getEntry(ctx.targetChannelId).latestState.outcome,
     };
   }
 

--- a/packages/wallet-specs/src/protocols/partial-withdrawal/protocol.ts
+++ b/packages/wallet-specs/src/protocols/partial-withdrawal/protocol.ts
@@ -26,7 +26,7 @@ function replacementChannelArgs({
   newOutcome,
   participantMapping,
 }: Init): CreateNullChannel.Init {
-  const { channel, outcome } = store.getLatestConsensus(ledgerId).state;
+  const { channel, outcome } = store.getEntry(ledgerId).latestSupportedState;
   const newParticipants = channel.participants
     .filter(p => newOutcome.find(allocation => allocation.destination === p))
     .map(p => participantMapping[p]);
@@ -63,7 +63,7 @@ export function concludeOutcome({
   newOutcome,
   newChannelId,
 }: NewChannelCreated): LedgerUpdate.Init {
-  const { state } = store.getLatestConsensus(ledgerId);
+  const state = store.getEntry(ledgerId).latestSupportedState;
   const currentlyAllocated = checkThat(state.outcome, isAllocation)
     .map(a => a.amount)
     .reduce(add, 0);

--- a/packages/wallet-specs/src/protocols/virtual-defunding-as-leaf/protocol.ts
+++ b/packages/wallet-specs/src/protocols/virtual-defunding-as-leaf/protocol.ts
@@ -88,7 +88,7 @@ export function defundGuarantorInLedger({
   Goal: targetOutcome == [(B, b), (H, a)]
   */
 
-  const jointOutcome = store.getLatestSupportedAllocation(jointChannelId);
+  const { outcome: jointOutcome } = store.getEntry(jointChannelId).latestSupportedState;
 
   const targetOutcome: Allocation = [
     {

--- a/packages/wallet-specs/src/protocols/virtual-defunding-as-leaf/protocol.ts
+++ b/packages/wallet-specs/src/protocols/virtual-defunding-as-leaf/protocol.ts
@@ -47,7 +47,7 @@ function finalJointChannelUpdate({
   if (!targetChannelState || !targetChannelState.isFinal) {
     throw new Error('Target channel not finalized');
   }
-  const { state: jointState } = store.getLatestConsensus(jointChannelId);
+  const jointState = store.getEntry(jointChannelId).latestSupportedState;
 
   const jointOutcome = checkThat(jointState.outcome, isAllocation);
   const targetChannelIdx = jointOutcome.findIndex(a => a.destination === targetChannelId);

--- a/packages/wallet-specs/src/protocols/virtual-defunding-as-leaf/protocol.ts
+++ b/packages/wallet-specs/src/protocols/virtual-defunding-as-leaf/protocol.ts
@@ -43,8 +43,8 @@ function finalJointChannelUpdate({
   jointChannelId,
   targetChannelId,
 }: ChannelsSet): LedgerUpdate.Init {
-  const { state: targetChannelState } = store.getLatestSupport(targetChannelId)[0];
-  if (!targetChannelState.isFinal) {
+  const targetChannelState = store.getEntry(targetChannelId).latestSupportedState;
+  if (!targetChannelState || !targetChannelState.isFinal) {
     throw new Error('Target channel not finalized');
   }
   const { state: jointState } = store.getLatestConsensus(jointChannelId);

--- a/packages/wallet-specs/src/protocols/virtual-fund-as-hub/protocol.ts
+++ b/packages/wallet-specs/src/protocols/virtual-fund-as-hub/protocol.ts
@@ -27,8 +27,8 @@ type ChannelsKnown = Init & {
 export const assignChannels = assign(
   (init: Init): ChannelsKnown => {
     const { leftLedgerId, rightLedgerId, targetChannelId } = init;
-    const { channel: leftLedgerChannel } = store.getLatestState(leftLedgerId);
-    const { channel: rightLedgerChannel } = store.getLatestState(rightLedgerId);
+    const { channel: leftLedgerChannel } = store.getEntry(leftLedgerId).latestState;
+    const { channel: rightLedgerChannel } = store.getEntry(rightLedgerId).latestState;
 
     const jointParticipants = [
       ...leftLedgerChannel.participants,

--- a/packages/wallet-specs/src/protocols/virtual-funding/protocol.ts
+++ b/packages/wallet-specs/src/protocols/virtual-funding/protocol.ts
@@ -37,7 +37,7 @@ const chooseHub = {
 type HubKnown = Init & { hubAddress: string };
 
 function virtualFundAsLeafArgs({ targetChannelId, hubAddress }: HubKnown): VirtualFundAsLeafArgs {
-  const { channel, outcome } = store.getLatestState(targetChannelId);
+  const { channel, outcome } = store.getEntry(targetChannelId).latestState;
   const balances: Balance[] = checkThat(outcome, isAllocation).map(o => ({
     address: o.destination,
     wei: o.amount,

--- a/packages/wallet-specs/src/protocols/wallet/protocol.ts
+++ b/packages/wallet-specs/src/protocols/wallet/protocol.ts
@@ -1,4 +1,4 @@
-import { AnyEventObject, assign, AssignAction, Interpreter, Machine, spawn } from 'xstate';
+import { assign, AssignAction, Interpreter, Machine, spawn } from 'xstate';
 import { CreateChannel, JoinChannel } from '..';
 import { getChannelId, pretty, Store, unreachable } from '../..';
 import { ChannelUpdated } from '../../store';

--- a/packages/wallet-specs/src/store.ts
+++ b/packages/wallet-specs/src/store.ts
@@ -3,7 +3,6 @@ import { ChannelStoreEntry, IChannelStoreEntry } from './ChannelStoreEntry';
 import { messageService } from './messaging';
 import { AddressableMessage, FundingStrategyProposed } from './wire-protocol';
 export interface IStore {
-  getLatestSupportedAllocation: (channelId: string) => Allocation;
   getEntry: (channelId: string) => ChannelStoreEntry;
   getIndex: (channelId: string) => 0 | 1;
 
@@ -110,12 +109,6 @@ export class Store implements IStore {
 
   public participantIds(channelId: string): string[] {
     return this.getEntry(channelId).participants.map(p => p.participantId);
-  }
-
-  public getLatestSupportedAllocation(channelId): Allocation {
-    // TODO: Check the use of this. (Sometimes you want the latest outcome)
-    const { outcome } = this.getEntry(channelId).latestState;
-    return checkThat(outcome, isAllocation);
   }
 
   public getUnsupportedStates(channelId: string) {

--- a/packages/wallet-specs/src/store.ts
+++ b/packages/wallet-specs/src/store.ts
@@ -3,7 +3,6 @@ import { ChannelStoreEntry, IChannelStoreEntry } from './ChannelStoreEntry';
 import { messageService } from './messaging';
 import { AddressableMessage, FundingStrategyProposed } from './wire-protocol';
 export interface IStore {
-  getLatestState: (channelId: string) => State;
   getLatestConsensus: (channelId: string) => SignedState; // Used for null channels, whose support must be a single state
   getLatestSupport: (channelId: string) => SignedState[]; //  Used for application channels, which would typically have multiple states in its support
   getLatestSupportedAllocation: (channelId: string) => Allocation;
@@ -115,18 +114,9 @@ export class Store implements IStore {
     return this.getEntry(channelId).participants.map(p => p.participantId);
   }
 
-  public getLatestState(channelId) {
-    const { supportedState, unsupportedStates } = this.getEntry(channelId);
-    if (unsupportedStates.length) {
-      return unsupportedStates.map(s => s.state).sort(s => -s.turnNum)[0];
-    } else {
-      return supportedState[supportedState.length - 1].state;
-    }
-  }
-
   public getLatestSupportedAllocation(channelId): Allocation {
     // TODO: Check the use of this. (Sometimes you want the latest outcome)
-    const { outcome } = this.getLatestState(channelId);
+    const { outcome } = this.getEntry(channelId).latestState;
     return checkThat(outcome, isAllocation);
   }
 

--- a/packages/wallet-specs/src/store.ts
+++ b/packages/wallet-specs/src/store.ts
@@ -4,7 +4,6 @@ import { messageService } from './messaging';
 import { AddressableMessage, FundingStrategyProposed } from './wire-protocol';
 export interface IStore {
   getLatestConsensus: (channelId: string) => SignedState; // Used for null channels, whose support must be a single state
-  getLatestSupport: (channelId: string) => SignedState[]; //  Used for application channels, which would typically have multiple states in its support
   getLatestSupportedAllocation: (channelId: string) => Allocation;
   getEntry: (channelId: string) => ChannelStoreEntry;
   getIndex: (channelId: string) => 0 | 1;
@@ -128,9 +127,6 @@ export class Store implements IStore {
     return supportedState[0];
   }
 
-  public getLatestSupport(channelId: string) {
-    return this.getEntry(channelId).supportedState;
-  }
   public getUnsupportedStates(channelId: string) {
     return this.getEntry(channelId).unsupportedStates;
   }

--- a/packages/wallet-specs/src/store.ts
+++ b/packages/wallet-specs/src/store.ts
@@ -3,7 +3,6 @@ import { ChannelStoreEntry, IChannelStoreEntry } from './ChannelStoreEntry';
 import { messageService } from './messaging';
 import { AddressableMessage, FundingStrategyProposed } from './wire-protocol';
 export interface IStore {
-  getLatestConsensus: (channelId: string) => SignedState; // Used for null channels, whose support must be a single state
   getLatestSupportedAllocation: (channelId: string) => Allocation;
   getEntry: (channelId: string) => ChannelStoreEntry;
   getIndex: (channelId: string) => 0 | 1;
@@ -117,10 +116,6 @@ export class Store implements IStore {
     // TODO: Check the use of this. (Sometimes you want the latest outcome)
     const { outcome } = this.getEntry(channelId).latestState;
     return checkThat(outcome, isAllocation);
-  }
-
-  public getLatestConsensus(channelId: string) {
-    return { state: this.getEntry(channelId).latestSupportedState, signatures: [] };
   }
 
   public getUnsupportedStates(channelId: string) {


### PR DESCRIPTION
- An array of signed states is stored, rather than two arrays of supported and unsupported signed states
- Some getter functions are removed from the store; the channel's store entry can instead expose these getters or alternatives.