### PR TITLE
Fix protocols crashing when there is no supported state

### DIFF
--- a/packages/wallet-specs/src/ChannelStoreEntry.ts
+++ b/packages/wallet-specs/src/ChannelStoreEntry.ts
@@ -79,6 +79,10 @@ export class ChannelStoreEntry implements IChannelStoreEntry {
     return this.participants.findIndex(p => p.signingAddress === this.privateKey);
   }
 
+  get hasSupportedState(): boolean {
+    return this.states.some(supported);
+  }
+
   get latestSupportedState(): State {
     const signedState = this.states.find(supported);
     if (!signedState) {
@@ -100,7 +104,9 @@ export class ChannelStoreEntry implements IChannelStoreEntry {
     if (!this.latestSupportedState) {
       return [];
     } else {
-      return this.states.slice(this.states.map(s => s.state).indexOf(this.latestSupportedState) + 1);
+      return this.states.slice(
+        this.states.map(s => s.state).indexOf(this.latestSupportedState) + 1
+      );
     }
   }
 

--- a/packages/wallet-specs/src/protocols/advance-channel/protocol.ts
+++ b/packages/wallet-specs/src/protocols/advance-channel/protocol.ts
@@ -70,7 +70,7 @@ export const machine: MachineFactory<Init, any> = (store: Store, context?: Init)
       if (!latestEntry.hasSupportedState) {
         return false;
       }
-      return state.turnNum >= targetTurnNum;
+      return latestEntry.latestSupportedState.turnNum >= targetTurnNum;
     },
   };
 

--- a/packages/wallet-specs/src/protocols/advance-channel/protocol.ts
+++ b/packages/wallet-specs/src/protocols/advance-channel/protocol.ts
@@ -66,6 +66,10 @@ export const mockOptions = {
 export const machine: MachineFactory<Init, any> = (store: Store, context?: Init) => {
   const guards: Guards = {
     advanced: ({ channelId, targetTurnNum }: Init, event, { state: s }) => {
+      const latestEntry = store.getEntry(channelId);
+      if (!latestEntry.hasSupportedState) {
+        return false;
+      }
       const { latestSupportedState: state } = store.getEntry(channelId);
       return !!state && state.turnNum >= targetTurnNum;
     },

--- a/packages/wallet-specs/src/protocols/advance-channel/protocol.ts
+++ b/packages/wallet-specs/src/protocols/advance-channel/protocol.ts
@@ -70,7 +70,6 @@ export const machine: MachineFactory<Init, any> = (store: Store, context?: Init)
       if (!latestEntry.hasSupportedState) {
         return false;
       }
-      const { latestSupportedState: state } = store.getEntry(channelId);
       return state.turnNum >= targetTurnNum;
     },
   };

--- a/packages/wallet-specs/src/protocols/advance-channel/protocol.ts
+++ b/packages/wallet-specs/src/protocols/advance-channel/protocol.ts
@@ -71,7 +71,7 @@ export const machine: MachineFactory<Init, any> = (store: Store, context?: Init)
         return false;
       }
       const { latestSupportedState: state } = store.getEntry(channelId);
-      return !!state && state.turnNum >= targetTurnNum;
+      return state.turnNum >= targetTurnNum;
     },
   };
 

--- a/packages/wallet-specs/src/protocols/support-state/protocol.ts
+++ b/packages/wallet-specs/src/protocols/support-state/protocol.ts
@@ -72,12 +72,12 @@ export const machine: MachineFactory<Init, any> = (store, context: Init) => {
 
   const guards: Guards = {
     supported: ({ channelId, outcome }: Init) => {
-      const { latestSupportedState } = store.getEntry(channelId);
-      if (!latestSupportedState) {
+      const latestEntry = store.getEntry(channelId);
+      if (!latestEntry.hasSupportedState) {
         return false;
       }
 
-      return outcomesEqual(latestSupportedState.outcome, outcome);
+      return outcomesEqual(latestEntry.latestSupportedState.outcome, outcome);
     },
   };
 


### PR DESCRIPTION
Some protocols were still relying on `latestSupportState` to return `undefined` instead of throwing an error. I've added a `hasSupportedState` so protocols that aren't sure if a state is supported yet can check that before trying to access it.