### PR TITLE
Add ethereum.selectedAddress to puppeteer environment

### DIFF
--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -14,7 +14,10 @@ export async function loadRPSApp(page: Page, ganacheAccountIndex: number) {
   // MetaMask has an .enable() API to unlock it / access it from the app
   await page.evaluateOnNewDocument(`window.ethereum.enable = () => new Promise(r => r())`);
   await page.evaluateOnNewDocument(
-    `web3.eth.getAccounts().then(lst => web3.eth.defaultAccount = lst[${ganacheAccountIndex}])`
+    `web3.eth.getAccounts().then(lst => {
+      web3.eth.defaultAccount = lst[${ganacheAccountIndex}];
+      window.ethereum.selectedAddress = web3.eth.defaultAccount;
+    });`
   );
   await page.evaluateOnNewDocument(`window.ethereum.networkVersion = 9001`);
   await page.evaluateOnNewDocument(`window.ethereum.on = () => {}`);

--- a/packages/rps/src/redux/game/saga.ts
+++ b/packages/rps/src/redux/game/saga.ts
@@ -64,7 +64,7 @@ function* gameSagaRun(client: RPSChannelClient) {
   switch (localState.type) {
     case 'Setup.NeedAddress':
       const address: string = yield call([client, 'getAddress']);
-      const outcomeAddress: string = address; // FIXME: Should be window.ethereum.selectedAddress
+      const outcomeAddress: string = window.ethereum.selectedAddress;
       yield put(a.gotAddressFromWallet(address, outcomeAddress));
       break;
     case 'A.GameChosen':

--- a/packages/rps/src/redux/game/saga.ts
+++ b/packages/rps/src/redux/game/saga.ts
@@ -64,7 +64,7 @@ function* gameSagaRun(client: RPSChannelClient) {
   switch (localState.type) {
     case 'Setup.NeedAddress':
       const address: string = yield call([client, 'getAddress']);
-      const outcomeAddress: string = window.ethereum.selectedAddress;
+      const outcomeAddress: string = address; // FIXME: Should be window.ethereum.selectedAddress
       yield put(a.gotAddressFromWallet(address, outcomeAddress));
       break;
     case 'A.GameChosen':

--- a/packages/wallet/src/redux/protocols/virtual-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/virtual-funding/reducer.ts
@@ -131,7 +131,11 @@ function waitForJointChannelReducer(
           const ourAddress = new Wallet(privateKey).address;
           const appDefinition = CONSENSUS_LIBRARY_ADDRESS;
 
-          const destinations = [targetChannelId, window.ethereum.selectedAddress, hubAddress];
+          const destinations = [
+            targetChannelId,
+            window.ethereum ? window.ethereum.selectedAddress : ourAddress,
+            hubAddress
+          ];
           const outcome = createGuaranteeOutcome(destinations, jointChannelId);
 
           const guarantorChannelResult = advanceChannel.initializeAdvanceChannel(
@@ -223,7 +227,7 @@ function waitForGuarantorChannelReducer(
         case StateType.PostFundSetup:
           const outcome = calculateLedgerOutcome(
             startingOutcome,
-            window.ethereum.selectedAddress,
+            window.ethereum ? window.ethereum.selectedAddress : participants[ourIndex],
             hubAddress
           );
 

--- a/packages/wallet/src/redux/protocols/virtual-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/virtual-funding/reducer.ts
@@ -131,7 +131,7 @@ function waitForJointChannelReducer(
           const ourAddress = new Wallet(privateKey).address;
           const appDefinition = CONSENSUS_LIBRARY_ADDRESS;
 
-          const destinations = [targetChannelId, ourAddress, hubAddress];
+          const destinations = [targetChannelId, window.ethereum.selectedAddress, hubAddress];
           const outcome = createGuaranteeOutcome(destinations, jointChannelId);
 
           const guarantorChannelResult = advanceChannel.initializeAdvanceChannel(
@@ -223,7 +223,7 @@ function waitForGuarantorChannelReducer(
         case StateType.PostFundSetup:
           const outcome = calculateLedgerOutcome(
             startingOutcome,
-            participants[ourIndex],
+            window.ethereum.selectedAddress,
             hubAddress
           );
 


### PR DESCRIPTION
It turns out #823 caused a regression that was undetected by the integration tests since `window.ethereum.selectedAddress` was `undefined`. This meant `address` and `outcomeAddress` were the same value.

However, in production they will be different.

This means we need to update the virtual funding protocols to be OK with this scenario, or revert that PR, or just change the default value to address of the ephemeral signing key temporarily.

This is where the virtual funding gets stuck now:

<img width="1276" alt="Screen Shot 2020-01-14 at 09 28 20" src="https://user-images.githubusercontent.com/1933029/72352777-dd1c8800-36b0-11ea-8ca3-1bd85adb0d25.png">
