### PR TITLE
[hub] Fix hub:start:dev

### DIFF
--- a/packages/hub/.env.development
+++ b/packages/hub/.env.development
@@ -4,6 +4,7 @@ FIREBASE_API_KEY='AIzaSyAOvhDzJir_El3O6SJ2xQlrpOisnObq6zw'
 HUB_DB_HOST=localhost
 HUB_DB_PORT=5432
 HUB_DB_NAME=hub_wallet_development
+HUB_DB_USER=postgres
 
 GANACHE_HOST=0.0.0.0
 GANACHE_PORT=8547

--- a/packages/hub/src/db-config.ts
+++ b/packages/hub/src/db-config.ts
@@ -1,5 +1,7 @@
 import {Config} from 'knex';
 
+import '../env';
+
 export const dbCofig: Config = {
   client: 'pg',
   connection: process.env.DATABASE_URL || {

--- a/packages/hub/src/wallet/db/connection.ts
+++ b/packages/hub/src/wallet/db/connection.ts
@@ -1,5 +1,6 @@
 import Knex from 'knex';
 import {Model} from 'objection';
+
 import {dbCofig} from '../../db-config';
 
 const knex = Knex(dbCofig);


### PR DESCRIPTION
The environment variables were not being loaded for some reason when I ran `yarn hub:start:dev` unless I did this.