### PR TITLE
Properly update ledger outcome in ledger-funding

### DIFF
--- a/packages/wallet-specs/jest.config.js
+++ b/packages/wallet-specs/jest.config.js
@@ -1,10 +1,10 @@
 module.exports = {
   rootDir: '.',
-  testMatch: ['<rootDir>/src/**/test.ts'],
+  testMatch: ['<rootDir>/src/**/*.test.ts'],
   testEnvironment: 'node',
   testURL: 'http://localhost',
   transform: {
-    '^.+\\.tsx?$': 'ts-jest'
+    '^.+\\.tsx?$': 'ts-jest',
   },
   transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|ts|tsx)$'],
   moduleFileExtensions: [
@@ -18,6 +18,6 @@ module.exports = {
     'jsx',
     'json',
     'node',
-    'mjs'
-  ]
+    'mjs',
+  ],
 };

--- a/packages/wallet-specs/src/__tests__/allocateToTarget.test.ts
+++ b/packages/wallet-specs/src/__tests__/allocateToTarget.test.ts
@@ -1,0 +1,107 @@
+import { allocateToTarget, Errors } from '../calculations';
+import { Allocation } from '@statechannels/nitro-protocol';
+import { ethAllocationOutcome } from '..';
+
+const left = '0x01';
+const right = '0x02';
+const middle = '0x03';
+const targetChannelId = '0x04';
+
+describe('allocateToTarget with valid input', () => {
+  const target1: Allocation = [
+    { destination: left, amount: '1' },
+    { destination: right, amount: '1' },
+  ];
+  const ledger1: Allocation = [...target1];
+  const expected1 = [{ destination: targetChannelId, amount: '2' }];
+
+  const target2: Allocation = [
+    { destination: left, amount: '1' },
+    { destination: right, amount: '2' },
+  ];
+  const ledger2: Allocation = [
+    { destination: left, amount: '3' },
+    { destination: right, amount: '3' },
+  ];
+  const expected2: Allocation = [
+    { destination: left, amount: '2' },
+    { destination: right, amount: '1' },
+    { destination: targetChannelId, amount: '3' },
+  ];
+
+  const target3: Allocation = [
+    { destination: left, amount: '1' },
+    { destination: right, amount: '2' },
+  ];
+  const ledger3: Allocation = [
+    { destination: right, amount: '3' },
+    { destination: left, amount: '3' },
+  ];
+  const expected3: Allocation = [
+    { destination: right, amount: '1' },
+    { destination: left, amount: '2' },
+    { destination: targetChannelId, amount: '3' },
+  ];
+
+  const target4: Allocation = [
+    { destination: left, amount: '1' },
+    { destination: right, amount: '2' },
+  ];
+  const ledger4: Allocation = [
+    { destination: left, amount: '3' },
+    { destination: middle, amount: '3' },
+    { destination: right, amount: '3' },
+  ];
+  const expected4: Allocation = [
+    { destination: left, amount: '2' },
+    { destination: middle, amount: '3' },
+    { destination: right, amount: '1' },
+    { destination: targetChannelId, amount: '3' },
+  ];
+  it.each`
+    description | targetAllocation | ledgerAllocation | expectedAllocation
+    ${'one'}    | ${target1}       | ${ledger1}       | ${expected1}
+    ${'two'}    | ${target2}       | ${ledger2}       | ${expected2}
+    ${'three'}  | ${target3}       | ${ledger3}       | ${expected3}
+    ${'four'}   | ${target4}       | ${ledger4}       | ${expected4}
+  `(
+    'Test $description',
+    ({ description, targetAllocation, ledgerAllocation, expectedAllocation }) => {
+      expect(allocateToTarget(targetAllocation, ledgerAllocation, targetChannelId)).toMatchObject(
+        ethAllocationOutcome(expectedAllocation)
+      );
+    }
+  );
+});
+
+describe('allocateToTarget with invalid input', () => {
+  const target1: Allocation = [
+    { destination: left, amount: '1' },
+    { destination: middle, amount: '1' },
+  ];
+  const ledger1: Allocation = [
+    { destination: left, amount: '1' },
+    { destination: right, amount: '1' },
+  ];
+  const error1 = Errors.DestinationMissing;
+
+  const target2: Allocation = [
+    { destination: left, amount: '3' },
+    { destination: right, amount: '3' },
+  ];
+  const ledger2: Allocation = [
+    { destination: left, amount: '1' },
+    { destination: right, amount: '2' },
+  ];
+  const error2 = Errors.InsufficientFunds;
+
+  it.each`
+    description | targetAllocation | ledgerAllocation | error
+    ${'one'}    | ${target1}       | ${ledger1}       | ${error1}
+    ${'two'}    | ${target2}       | ${ledger2}       | ${error2}
+  `('Test $description', ({ targetAllocation, ledgerAllocation, error }) => {
+    expect(() => allocateToTarget(targetAllocation, ledgerAllocation, targetChannelId)).toThrow(
+      error
+    );
+  });
+});

--- a/packages/wallet-specs/src/calculations.ts
+++ b/packages/wallet-specs/src/calculations.ts
@@ -1,0 +1,44 @@
+import { Outcome, Allocation } from '@statechannels/nitro-protocol';
+import { ethAllocationOutcome, add, subtract, gt } from '.';
+export enum Errors {
+  DestinationMissing = 'Destination missing from ledger channel',
+  InsufficientFunds = 'Insufficient funds in ledger channel',
+}
+
+export function allocateToTarget(
+  targetAllocation: Allocation,
+  ledgerAllocation: Allocation,
+  targetChannelId: string
+): Outcome {
+  let total = '0';
+
+  targetAllocation.forEach(targetItem => {
+    const ledgerIdx = ledgerAllocation.findIndex(
+      ledgerItem => ledgerItem.destination === targetItem.destination
+    );
+    if (ledgerIdx === -1) {
+      throw new Error(Errors.DestinationMissing);
+    }
+    let ledgerItem = ledgerAllocation[ledgerIdx];
+    try {
+      ledgerItem = {
+        destination: ledgerItem.destination,
+        amount: subtract(ledgerItem.amount, targetItem.amount),
+      };
+    } catch (e) {
+      if (e.message === 'Unsafe subtraction') {
+        throw new Error(Errors.InsufficientFunds);
+      } else {
+        throw e;
+      }
+    }
+    total = add(total, targetItem.amount);
+    if (gt(ledgerItem.amount, 0)) {
+      ledgerAllocation[ledgerIdx] = ledgerItem;
+    } else {
+      ledgerAllocation.splice(ledgerIdx, 1);
+    }
+  });
+  ledgerAllocation.push({ destination: targetChannelId, amount: total });
+  return ethAllocationOutcome(ledgerAllocation);
+}

--- a/packages/wallet-specs/src/index.ts
+++ b/packages/wallet-specs/src/index.ts
@@ -79,9 +79,21 @@ export { chain } from './chain';
 
 // This stuff should be replaced with some big number logic
 type numberish = string | number | undefined;
-export const add = (a: numberish, b: numberish) => (Number(a || 0) + Number(b || 0)).toString();
-export const subtract = (a: numberish, b: numberish) => (Number(a) - Number(b)).toString();
-export const max = (a: numberish, b: numberish) => Math.max(Number(a), Number(b)).toString();
+type MathOp = (a: numberish, b: numberish) => string;
+export const add: MathOp = (a: numberish, b: numberish) =>
+  (Number(a || 0) + Number(b || 0)).toString();
+export const subtract: MathOp = (a: numberish, b: numberish) => {
+  const numA = Number(a);
+  const numB = Number(b);
+
+  if (numB > numA) {
+    throw new Error('Unsafe subtraction');
+  }
+  return (numA - numB).toString();
+};
+
+export const max: MathOp = (a: numberish, b: numberish) =>
+  Math.max(Number(a), Number(b)).toString();
 export const gt = (a: numberish, b: numberish) => Number(a) > Number(b);
 
 export const success: { type: 'final' } = { type: 'final' };

--- a/packages/wallet-specs/src/index.ts
+++ b/packages/wallet-specs/src/index.ts
@@ -19,7 +19,9 @@ export interface Balance {
 }
 
 export function getEthAllocation(outcome: Outcome): Allocation {
-  const ethOutcome: AssetOutcome | undefined = outcome.find(o => o.assetHolderAddress === '0x');
+  const ethOutcome: AssetOutcome | undefined = outcome.find(
+    o => o.assetHolderAddress === AddressZero
+  );
   return checkThat(ethOutcome, isAllocationOutcome).allocation;
 }
 

--- a/packages/wallet-specs/src/protocols/funding/__tests__/funding.test.ts
+++ b/packages/wallet-specs/src/protocols/funding/__tests__/funding.test.ts
@@ -1,0 +1,30 @@
+import { interpret, Machine } from 'xstate';
+import { FundingStrategyProposed } from '../../../wire-protocol';
+import { config, Init, mockOptions } from '../protocol';
+const context: Init = {
+  targetChannelId: 'foo',
+  tries: 0,
+};
+
+it('gets to ledger funding', async () => {
+  const service = interpret(Machine(config).withConfig(mockOptions, context)).start();
+  expect(service.state.value).toMatchObject({
+    determineStrategy: 'getClientChoice',
+  });
+
+  await service;
+  expect(service.state.value).toMatchObject({
+    determineStrategy: 'wait',
+  });
+  const strategyChoice: FundingStrategyProposed = {
+    type: 'FUNDING_STRATEGY_PROPOSED',
+    choice: 'Indirect',
+    targetChannelId: context.targetChannelId,
+  };
+
+  service.send(strategyChoice);
+  expect(service.state.value).toEqual('fundIndirectly');
+
+  await service;
+  expect(service.state.value).toEqual('success');
+});


### PR DESCRIPTION
In addition to the main event, this PR introduces a unit test for a complicated bit of logic around ledger-funding. I think that these kinds of tests are more useful than copying over the "if we receive this action in this state we move to that state" tests from the redux wallet.