### PR TITLE
Fix Wallet Funding issues

### DIFF
--- a/packages/rps/src/utils/rps-channel-client.ts
+++ b/packages/rps/src/utils/rps-channel-client.ts
@@ -21,7 +21,7 @@ export class RPSChannelClient {
     aOutcomeAddress: string = aAddress,
     bOutcomeAddress: string = bAddress
   ): Promise<ChannelState> {
-    const participants = formatParticipants(aAddress, bAddress);
+    const participants = formatParticipants(aAddress, bAddress, aOutcomeAddress, bOutcomeAddress);
     const allocations = formatAllocations(aOutcomeAddress, bOutcomeAddress, aBal, bBal);
     const appDefinition = RPS_ADDRESS;
     const appData = encodeAppData(appAttrs);

--- a/packages/wallet/src/redux/protocols/virtual-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/virtual-funding/reducer.ts
@@ -48,13 +48,13 @@ export function initialize(
   const jointChannelInitialized = advanceChannel.initializeAdvanceChannel(sharedData, {
     privateKey,
     appDefinition,
-    ourIndex: TwoPartyPlayerIndex.A,
+    ourIndex,
     stateType: StateType.PreFundSetup,
     clearedToSend: true,
     processId,
     protocolLocator: makeLocator(protocolLocator, ADVANCE_CHANNEL_PROTOCOL_LOCATOR),
     outcome,
-    participants: [participants[ourIndex], hubAddress],
+    participants: participants.concat(hubAddress),
     appData: getInitialAppData()
   });
 
@@ -115,7 +115,7 @@ function waitForJointChannelReducer(
             processId,
             protocolLocator: makeLocator(protocolLocator, ADVANCE_CHANNEL_PROTOCOL_LOCATOR),
             channelId: jointChannelId,
-            ourIndex: TwoPartyPlayerIndex.A
+            ourIndex: protocolState.ourIndex
           });
 
           return {


### PR DESCRIPTION
Fixes two main issues:
- The joint channel was not being properly constructed with 3 participants. This would cause defunding to behave improperly later.
- The participants being passed into `createChannel` had their `destination` set to their `signingAddress`.