### PR TITLE
[rps] Fix security bug and refactor for clarity

### DIFF
--- a/packages/rps/src/contract-tests/rock-paper-scissors.test.ts
+++ b/packages/rps/src/contract-tests/rock-paper-scissors.test.ts
@@ -1,12 +1,10 @@
 import {expectRevert} from '@statechannels/devtools';
 import RockPaperScissorsArtifact from '../../build/contracts/RockPaperScissors.json';
 import * as ethers from 'ethers';
-import {Contract} from 'ethers';
-import {defaultAbiCoder, bigNumberify, keccak256, Interface} from 'ethers/utils';
+import {defaultAbiCoder, bigNumberify, keccak256, Interface, BigNumberish} from 'ethers/utils';
 import dotEnvExtended from 'dotenv-extended';
 import path from 'path';
 import {AddressZero} from 'ethers/constants';
-import {TransactionRequest} from 'ethers/providers';
 import {
   Allocation,
   encodeOutcome,
@@ -21,6 +19,7 @@ import {Weapon} from '../core/weapons';
 import loadJsonFile from 'load-json-file';
 
 import {randomHex} from '../utils/randomHex';
+import fs from 'fs';
 
 dotEnvExtended.load();
 
@@ -43,7 +42,7 @@ const WeaponIndex = {
   Scissors: Weapon.Scissors,
 };
 
-let RockPaperScissors: Contract;
+let RockPaperScissors: ethers.Contract;
 
 const numParticipants = 3;
 const addresses = {
@@ -86,6 +85,7 @@ describe('validTransition', () => {
       BWeapon,
       fromBalances,
       toBalances,
+      description,
     }: {
       isValid: boolean;
       fromPositionType: string;
@@ -95,6 +95,7 @@ describe('validTransition', () => {
       BWeapon: string;
       fromBalances: AssetOutcomeShortHand;
       toBalances: AssetOutcomeShortHand;
+      description: string;
     }) => {
       fromBalances = replaceAddressesAndBigNumberify(fromBalances, addresses);
       toBalances = replaceAddressesAndBigNumberify(toBalances, addresses);
@@ -148,8 +149,19 @@ describe('validTransition', () => {
           1,
           numParticipants,
         ]);
+        const signer = testProvider.getSigner();
+        const transaction = {data, gasLimit: 3000000};
+        const response = await signer.sendTransaction({
+          to: RockPaperScissors.address,
+          ...transaction,
+        });
 
-        await sendTransaction(RockPaperScissors.address, {data, gasLimit: 3000000});
+        const receipt = await (await response).wait();
+        await writeGasConsumption(
+          './RockPaperScissors.gas.md',
+          `Returns $isValid on $fromPositionType -> $toPositionType; $description`,
+          receipt.gasUsed
+        );
 
         const isValidFromCall = await RockPaperScissors.validTransition(
           fromVariablePart,
@@ -199,9 +211,13 @@ export function hashPreCommit(weapon: Weapon, salt: string) {
   return keccak256(defaultAbiCoder.encode(['uint256', 'bytes32'], [weapon, salt]));
 }
 
-async function sendTransaction(contractAddress: string, transaction: TransactionRequest) {
-  // move to devtools
-  const signer = testProvider.getSigner();
-  const response = await signer.sendTransaction({to: contractAddress, ...transaction});
-  await response.wait();
+export async function writeGasConsumption(
+  filename: string,
+  description: string,
+  gas: BigNumberish
+): Promise<void> {
+  await fs.appendFile(filename, description + ':\n' + gas.toString() + ' gas\n\n', err => {
+    if (err) throw err;
+    console.log('Wrote gas info to ' + filename);
+  });
 }

--- a/packages/rps/src/contract-tests/rock-paper-scissors.test.ts
+++ b/packages/rps/src/contract-tests/rock-paper-scissors.test.ts
@@ -73,7 +73,8 @@ describe('validTransition', () => {
     ${false} | ${'Reveal'}        | ${'Start'}         | ${{from: 1, to: 2}} | ${'Rock'} | ${'Rock'}     | ${{A: 5, B: 5}} | ${{A: 5, B: 5}} | ${'Disallows stake change'}
     ${false} | ${'Start'}         | ${'RoundProposed'} | ${{from: 1, to: 1}} | ${'Rock'} | ${'Rock'}     | ${{A: 5, B: 5}} | ${{A: 6, B: 4}} | ${'Disallows allocations change '}
     ${false} | ${'RoundProposed'} | ${'RoundAccepted'} | ${{from: 1, to: 1}} | ${'Rock'} | ${'Rock'}     | ${{A: 6, B: 4}} | ${{B: 6, A: 4}} | ${'Disallows destination swap'}
-    ${false} | ${'Start'}         | ${'RoundProposed'} | ${{from: 1, to: 6}} | ${'Rock'} | ${'Rock'}     | ${{A: 5, B: 5}} | ${{A: 5, B: 5}} | ${'Disallows a stake that is too large'}
+    ${false} | ${'Start'}         | ${'RoundProposed'} | ${{from: 1, to: 6}} | ${'Rock'} | ${'Rock'}     | ${{A: 5, B: 5}} | ${{A: 5, B: 5}} | ${'Disallows a stake that changes'}
+    ${false} | ${'RoundAccepted'} | ${'Reveal'}        | ${{from: 1, to: 2}} | ${'Rock'} | ${'Scissors'} | ${{A: 4, B: 6}} | ${{A: 8, B: 4}} | ${'Disallows a stake that changes'}
   `(
     `Returns $isValid on $fromPositionType -> $toPositionType; $description`,
     async ({
@@ -156,12 +157,9 @@ describe('validTransition', () => {
           ...transaction,
         });
 
+        const descriptor = `Returns ${isValid} on ${fromPositionType} -> ${toPositionType}; ${description}`;
         const receipt = await (await response).wait();
-        await writeGasConsumption(
-          './RockPaperScissors.gas.md',
-          `Returns $isValid on $fromPositionType -> $toPositionType; $description`,
-          receipt.gasUsed
-        );
+        await writeGasConsumption('./RockPaperScissors.gas.md', descriptor, receipt.gasUsed);
 
         const isValidFromCall = await RockPaperScissors.validTransition(
           fromVariablePart,


### PR DESCRIPTION
This PR 

- upgrades test script to output gas information
- adds a test case specifying an attack where player A can increase their payout if they win (test fails on existing contract)
- refactors the contract to fix this case (test passes), and increase clarity around "stake" and "winnings" etc
- ^ negligible changes in gas cost (see below)

Gas before:
Returns true on RoundAccepted -> Reveal; B won:
66335 gas
Returns true on RoundAccepted -> Reveal; A won:
66282 gas
Returns true on RoundAccepted -> Reveal; Draw:
65960 gas

Gas after: 
Returns true on RoundAccepted -> Reveal; B won:
66431 gas (+96)
Returns true on RoundAccepted -> Reveal; A won:
66360 gas (+78)
Returns true on RoundAccepted -> Reveal; Draw:
65670 gas (-290)

