### PR TITLE
[hub] Use TypeScript references correctly in hub

### DIFF
--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -21,7 +21,7 @@
     "hub:test": "npx jest --runInBand -c ./jest/jest.config.js",
     "test:ci": "run-s chain:test hub:test",
     "start:shared-ganache": "NODE_ENV=development npx start-shared-ganache",
-    "build": "npx tsc",
+    "build": "tsc -b .",
     "build:typescript": "tsc -b .",
     "prestart": "yarn build && npm run db:rollback && npm run db:migrate && npm run db:seed",
     "lint:check": "eslint \"*/**/*.{js,ts,tsx}\" --cache",

--- a/packages/hub/tsconfig.json
+++ b/packages/hub/tsconfig.json
@@ -10,7 +10,7 @@
     "esModuleInterop": true,
     "strict": false
   },
-  "references": [{"path": "../devtools"}],
+  "references": [{"path": "../devtools"}, {"path": "../nitro-protocol"}],
   "include": ["src/**/*"],
   "exclude": ["**/*test_data.ts", "**/__mocks__/*"]
 }


### PR DESCRIPTION
`hub` was not using [build mode](https://www.typescriptlang.org/docs/handbook/project-references.html#build-mode-for-typescript), now it is. Also added the `nitro-protocol` reference.