### PR TITLE
[rps] Overwrite CHAIN_NETWORK_ID in production

### DIFF
--- a/packages/rps/.env.production
+++ b/packages/rps/.env.production
@@ -1,4 +1,5 @@
 TARGET_NETWORK='ropsten'
+CHAIN_NETWORK_ID=3
 FIREBASE_PROJECT = 'rock-paper-scissors-production' 
 FIREBASE_API_KEY = 'AIzaSyCGck4vYsR1CF6LEiOH2HtYnUNYgs_tYbk' 
 WALLET_URL = 'https://wallet.statechannels.org' 


### PR DESCRIPTION
This variable is needed for the UI to pickup the target network id. Previously, this was not being overwritten and so took on some default value for `ganache`.

There might be a more elegant fix that removes the redundancy with `TARGET_NETWORK` (which has the network namesting), but at least this change should un-break the deployed app. 