### PR TITLE
[rps] 'Withdraw' button simply 'OK' button

### DIFF
--- a/packages/rps/src/components/InsufficientFunds.tsx
+++ b/packages/rps/src/components/InsufficientFunds.tsx
@@ -56,7 +56,7 @@ export default class InsufficientFunds extends React.PureComponent<Props> {
             </div>
           </div>
           <Button className="cog-button" onClick={action}>
-            {'Withdraw'}
+            {'Ok'}
           </Button>
         </div>
         )

--- a/packages/rps/src/components/Resigned.tsx
+++ b/packages/rps/src/components/Resigned.tsx
@@ -22,7 +22,7 @@ export default class Resigned extends React.PureComponent<Props> {
             onClick={this.props.action}
             disabled={!this.props.channelClosed}
           >
-            {'Withdraw'}
+            {'OK'}
           </Button>
           <br />
           {!this.props.channelClosed && 'Waiting for your opponent...'}


### PR DESCRIPTION
Minimal change that removes confusion for the user (since they already withdrew by this point). 

There is still arguably one more state / screen than there should be -- the user 

- has no warning from the *app* when opponent resigns or funds are depleted
- has to click *twice* to get back to the lobby after the wallet has wrapped up the channel.

I have kept that the way it is here, because I anticipate a future PR moving the `client.closeChannel()` call one state down, so that the app *does* give a warning, and there is one confirmatory click *before* the wallet takes over, and one afterwards.

