### PR TITLE
Build and release to Netlify on every CI run

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "lint:write": "lerna run lint:write --parallel --no-bail",
     "publish": "lerna publish --yes from-package patch",
     "postinstall": "patch-package",
-    "build:netlify:ci": "lerna run --stream --parallel --since $(git merge-base $(git rev-parse --abbrev-ref HEAD) origin/master) build:netlify",
-    "release:netlify": "lerna run --stream --parallel --since $(git merge-base $(git rev-parse --abbrev-ref HEAD) origin/master) release:netlify --",
+    "build:netlify:ci": "lerna run --stream --parallel build:netlify",
+    "release:netlify": "lerna run --stream --parallel release:netlify --",
     "release:netlify:ci": "yarn release:netlify --auth $NETLIFY_ACCESS_TOKEN --message $(git rev-parse --short HEAD) $([[ $(git rev-parse --abbrev-ref HEAD) == master ]] && echo --prod)"
   },
   "keywords": [


### PR DESCRIPTION
In order to address [@geoknee comment](https://github.com/statechannels/monorepo/pull/856#discussion_r367328106), `--since` flag was added to Netlify build and release commands. The issue is that when a PR is merged into master, Netlify build and release are skipped. On PR merge into `master`, the correct action is to release static sites to production.

For now, turning on Netlify build and release for every CI run. This will generate lots of Deploy Previews. But I am not aware that this will cause any issues. 