### PR TITLE
Direct funding

### DIFF
--- a/packages/wallet-specs/src/index.ts
+++ b/packages/wallet-specs/src/index.ts
@@ -27,7 +27,9 @@ export function ethAllocationOutcome(allocation: Allocation): AllocationAssetOut
   return [
     {
       assetHolderAddress: AddressZero,
-      allocation: allocation.map(a => ({ ...a, destination: hexZeroPad(a.destination, 32) })),
+      allocation: allocation
+        .map(a => ({ ...a, destination: hexZeroPad(a.destination, 32) }))
+        .filter(({ amount }) => gt(amount, 0)),
     },
   ];
 }

--- a/packages/wallet-specs/src/protocols/depositing/protocol.ts
+++ b/packages/wallet-specs/src/protocols/depositing/protocol.ts
@@ -1,0 +1,27 @@
+import { FINAL } from '../..';
+
+type Guards = {
+  safeToDeposit: (x) => boolean;
+  funded: (x) => boolean;
+};
+
+export const config = {
+  initial: 'waiting',
+  states: {
+    waiting: {
+      on: {
+        '*': [
+          { target: 'deposit', cond: 'safeToDeposit', actions: 'deposit' },
+          { target: 'done', cond: 'funded' },
+        ],
+      },
+    },
+    deposit: {
+      invoke: { src: 'depositService' },
+      onDone: 'waiting',
+      onError: 'failure',
+    },
+    done: { type: FINAL },
+  },
+  onDone: 'updatePostFundOutcome',
+};

--- a/packages/wallet-specs/src/protocols/ledger-funding/protocol.ts
+++ b/packages/wallet-specs/src/protocols/ledger-funding/protocol.ts
@@ -80,7 +80,7 @@ type LedgerExists = Init & { ledgerChannelId: string };
 const fundLedger = {
   initial: 'getTargetAllocation',
   states: {
-    getTargetAllocation: { invoke: { src: 'getTargetAllocation' }, onDone: 'directFunding' },
+    getTargetAllocation: { invoke: { src: 'getTargetAllocation', onDone: 'directFunding' } },
     directFunding: {
       invoke: {
         src: 'directFunding',

--- a/packages/wallet-specs/src/protocols/ledger-funding/protocol.ts
+++ b/packages/wallet-specs/src/protocols/ledger-funding/protocol.ts
@@ -1,8 +1,16 @@
 import { assign, DoneInvokeEvent, Machine } from 'xstate';
 import { CreateNullChannel, DirectFunding, SupportState } from '..';
 import { allocateToTarget } from '../../calculations';
-import { Channel, ensureExists, MachineFactory, Store, success, getEthAllocation } from '../..';
-import { Outcome } from '@statechannels/nitro-protocol';
+import {
+  Channel,
+  ensureExists,
+  MachineFactory,
+  Store,
+  success,
+  getEthAllocation,
+  FINAL,
+} from '../..';
+import { Outcome, Allocation } from '@statechannels/nitro-protocol';
 
 const PROTOCOL = 'ledger-funding';
 
@@ -70,11 +78,23 @@ const waitForChannel = {
 
 type LedgerExists = Init & { ledgerChannelId: string };
 const fundLedger = {
-  invoke: {
-    src: 'directFunding',
-    onDone: 'fundTarget',
-    autoForward: true,
+  initial: 'getTargetAllocation',
+  states: {
+    getTargetAllocation: { invoke: { src: 'getTargetAllocation' }, onDone: 'directFunding' },
+    directFunding: {
+      invoke: {
+        src: 'directFunding',
+        data: (
+          { ledgerChannelId }: LedgerExists,
+          event: DoneInvokeEvent<Allocation>
+        ): DirectFunding.Init => ({ channelId: ledgerChannelId, minimalAllocation: event.data }),
+        onDone: 'done',
+        autoForward: true,
+      },
+    },
+    done: { type: FINAL },
   },
+  onDone: 'fundTarget',
 };
 
 const fundTarget = {
@@ -113,24 +133,23 @@ export const config = {
   },
 };
 
+type LedgerLookup = { type: 'FOUND'; channelId: string } | { type: 'NOT_FOUND' };
 export type Services = {
-  findLedgerChannelId(
-    ctx: Init
-  ): Promise<{ type: 'FOUND'; channelId: string } | { type: 'NOT_FOUND' }>;
+  findLedgerChannelId(ctx: Init): Promise<LedgerLookup>;
   getNullChannelArgs(ctx: Init): Promise<CreateNullChannel.Init>;
   createNullChannel: any;
+  getTargetAllocation(ctx: LedgerExists): Promise<DirectFunding.Init>;
   directFunding: any;
   getTargetOutcome(ctx: LedgerExists): Promise<SupportState.Init>;
   supportState: any;
 };
 
 export const guards = {
-  channelFound: (_, { data }: DoneInvokeEvent<{ type: 'FOUND' | 'NOT_FOUND' }>) =>
-    data.type === 'FOUND',
+  channelFound: (_, { data }: DoneInvokeEvent<LedgerLookup>) => data.type === 'FOUND',
 };
 
 export const machine: MachineFactory<Init, any> = (store: Store, context: Init) => {
-  function directFundingArgs(ctx: LedgerExists): DirectFunding.Init {
+  async function getTargetAllocation(ctx: LedgerExists): Promise<DirectFunding.Init> {
     const minimalAllocation = getEthAllocation(
       store.getEntry(ctx.targetChannelId).latestState.outcome
     );
@@ -178,7 +197,8 @@ export const machine: MachineFactory<Init, any> = (store: Store, context: Init) 
     findLedgerChannelId: async () => ({ type: 'NOT_FOUND' }), // TODO
     getNullChannelArgs,
     createNullChannel: CreateNullChannel.machine(store),
-    directFunding: async () => true,
+    getTargetAllocation,
+    directFunding: DirectFunding.machine(store),
     getTargetOutcome,
     supportState: SupportState.machine(store),
   };

--- a/packages/wallet-specs/src/runtime.ts
+++ b/packages/wallet-specs/src/runtime.ts
@@ -47,7 +47,8 @@ function logState(actor: Actor, level = 0) {
     });
   }
 }
-const logProcessStates = process.env.ADD_LOGS
+
+export const logProcessStates = process.env.ADD_LOGS
   ? state => {
       console.log(`WALLET: ${state.context.id}`);
       state.context.processes.forEach((p: Process) => {
@@ -67,14 +68,21 @@ const wallet = (wallet): any => {
     .start();
 };
 
-const wallets = {
-  [first.address]: wallet(first),
-  [second.address]: wallet(second),
-};
+export async function runtime() {
+  const wallets = {
+    [first.address]: wallet(first),
+    [second.address]: wallet(second),
+  };
 
-// This is sort of the "dispatcher"
-messageService.on('message', ({ to, ...event }: AddressableMessage) => {
-  wallets[to].send(event);
-});
+  // This is sort of the "dispatcher"
+  messageService.on('message', ({ to, ...event }: AddressableMessage) => {
+    wallets[to].send(event);
+  });
 
-wallets[first.address].send(createChannel);
+  await wallets[first.address].send(createChannel);
+
+  return wallets;
+}
+
+// If you want to debug, uncomment the following
+// runtime().then(wallets => { debugger; });

--- a/packages/wallet-specs/src/runtime.ts
+++ b/packages/wallet-specs/src/runtime.ts
@@ -1,4 +1,4 @@
-import { interpret } from 'xstate';
+import { interpret, Interpreter, Actor } from 'xstate';
 import { pretty } from '.';
 import { messageService } from './messaging';
 import { createChannel } from './mock-messages';
@@ -6,6 +6,8 @@ import { Wallet } from './protocols';
 import { Store } from './store';
 import { AddressableMessage } from './wire-protocol';
 import { ethers } from 'ethers';
+import { Process } from './protocols/wallet/protocol';
+import { assign } from 'xstate/lib/actionTypes';
 
 const store = (wallet: ethers.Wallet) => {
   const privateKeys = { [wallet.address]: wallet.privateKey };
@@ -36,14 +38,33 @@ const logEvents = name =>
         )
     : () => {};
 const logStore = name =>
-  process.env.ADD_LOGS
-    ? state => console.log(`${name}'s store: ${pretty(stores[name])}`)
-    : () => {};
+  process.env.ADD_LOGS ? state => console.log(`${pretty(stores[name])}`) : () => {};
+
+function logState(actor: Actor, level = 0) {
+  if (actor.state) {
+    console.log(`${' '.repeat(level)}${JSON.stringify(actor.state.value)}`);
+    Object.values(actor.state.children).map((child: Actor) => {
+      logState(child, level + 2);
+    });
+  }
+}
+const logProcessStates = process.env.ADD_LOGS
+  ? state => {
+      console.log(`WALLET: ${state.context.id}`);
+      state.context.processes.forEach((p: Process) => {
+        console.log(`  PROCESS: ${p.id}`);
+        Object.values(p.ref.state.children).map(child => {
+          logState(child, 4);
+        });
+      });
+    }
+  : () => {};
+
 const wallet = (wallet): any => {
   const machine = Wallet.machine(stores[wallet.address], { processes: [], id: wallet.address });
   return interpret<Wallet.Init, any, Wallet.Events>(machine)
     .onEvent(logEvents(wallet.address))
-    .onTransition(logStore(wallet.address))
+    .onTransition(logProcessStates)
     .start();
 };
 

--- a/packages/wallet-specs/src/runtime.ts
+++ b/packages/wallet-specs/src/runtime.ts
@@ -1,4 +1,4 @@
-import { interpret, Interpreter, Actor } from 'xstate';
+import { interpret, Actor } from 'xstate';
 import { pretty } from '.';
 import { messageService } from './messaging';
 import { createChannel } from './mock-messages';
@@ -7,7 +7,6 @@ import { Store } from './store';
 import { AddressableMessage } from './wire-protocol';
 import { ethers } from 'ethers';
 import { Process } from './protocols/wallet/protocol';
-import { assign } from 'xstate/lib/actionTypes';
 
 const store = (wallet: ethers.Wallet) => {
   const privateKeys = { [wallet.address]: wallet.privateKey };


### PR DESCRIPTION
I believe this PR gets direct funding working with the exception that it gets the holdings from an object called `chain` imported from `index.ts`. This should be updated based on the store's `getHoldings` method from `ag/xstate-deposit`. Since that branch has merged `ags/xstate-direct-funding` into it, the cleanest thing is to merge `ags/xstate-direct-funding` into master as is, and fix the state of affairs by branching off of `ag/xstate-deposit`.