### PR TITLE
Protocols connect to an IStore, not a Store

### DIFF
--- a/packages/wallet-specs/src/index.ts
+++ b/packages/wallet-specs/src/index.ts
@@ -10,7 +10,7 @@ import {
 } from '@statechannels/nitro-protocol/lib/src/contract/outcome';
 import { Signature, hexZeroPad } from 'ethers/utils';
 import { AddressZero } from 'ethers/constants';
-export { Store } from './store';
+export { Store, IStore } from './store';
 export interface Balance {
   address: string;
   wei: string;

--- a/packages/wallet-specs/src/protocols/advance-channel/protocol.ts
+++ b/packages/wallet-specs/src/protocols/advance-channel/protocol.ts
@@ -1,5 +1,5 @@
 import { AnyEventObject, ConditionPredicate, Machine, MachineConfig } from 'xstate';
-import { MachineFactory, Store } from '../..';
+import { MachineFactory, IStore } from '../..';
 
 const PROTOCOL = 'advance-channel';
 /*
@@ -63,7 +63,7 @@ export const mockOptions = {
   services: async () => true,
 };
 
-export const machine: MachineFactory<Init, any> = (store: Store, context?: Init) => {
+export const machine: MachineFactory<Init, any> = (store: IStore, context?: Init) => {
   const guards: Guards = {
     advanced: ({ channelId, targetTurnNum }: Init, event, { state: s }) => {
       const latestEntry = store.getEntry(channelId);

--- a/packages/wallet-specs/src/protocols/create-channel/protocol.ts
+++ b/packages/wallet-specs/src/protocols/create-channel/protocol.ts
@@ -4,7 +4,7 @@ import {
   Channel,
   forwardChannelUpdated,
   MachineFactory,
-  Store,
+  IStore,
   success,
   ethAllocationOutcome,
 } from '../..';
@@ -97,7 +97,7 @@ export const mockOptions = {
   // actions: { sendOpenChannelMessage },
 };
 
-export const machine: MachineFactory<Init, any> = (store: Store, init: Init) => {
+export const machine: MachineFactory<Init, any> = (store: IStore, init: Init) => {
   const setChannelId: InvokeCreator<any> = (ctx: Init): Promise<SetChannel> => {
     const participants = ctx.participants.map(p => p.destination);
     const channelNonce = store.getNextNonce(participants);

--- a/packages/wallet-specs/src/protocols/funding/protocol.ts
+++ b/packages/wallet-specs/src/protocols/funding/protocol.ts
@@ -1,6 +1,6 @@
 import { assign, DoneInvokeEvent, Machine } from 'xstate';
 import { LedgerFunding } from '..';
-import { failure, MachineFactory, pretty, Store, success } from '../..';
+import { failure, MachineFactory, pretty, IStore, success } from '../..';
 import { FundingStrategy, FundingStrategyProposed } from '../../wire-protocol';
 
 const PROTOCOL = 'funding';
@@ -184,7 +184,7 @@ export const mockOptions: Options = {
   actions: mockActions,
 };
 
-export const machine: MachineFactory<Init, any> = (store: Store, context: Init) => {
+export const machine: MachineFactory<Init, any> = (store: IStore, context: Init) => {
   function sendClientChoice(ctx: ClientChoiceKnown) {
     store.sendStrategyChoice(strategyChoice(ctx));
   }

--- a/packages/wallet-specs/src/protocols/join-channel/protocol.ts
+++ b/packages/wallet-specs/src/protocols/join-channel/protocol.ts
@@ -1,6 +1,6 @@
-import { Machine, MachineConfig, send, SendAction, sendParent } from 'xstate';
+import { Machine, MachineConfig, sendParent } from 'xstate';
 import { AdvanceChannel, Funding, JoinChannel } from '..';
-import { forwardChannelUpdated, MachineFactory, Store, success } from '../..';
+import { forwardChannelUpdated, MachineFactory, IStore } from '../..';
 import { JsonRpcJoinChannelParams } from '../../json-rpc';
 import { ChannelUpdated } from '../../store';
 import { CloseChannel, OpenChannel } from '../../wire-protocol';
@@ -114,7 +114,7 @@ export type Actions = {
 };
 
 export const machine: MachineFactory<Init, any> = (
-  store: Store,
+  store: IStore,
   { channelId }: JoinChannel.Init
 ) => {
   const guards: Guards = {

--- a/packages/wallet-specs/src/protocols/ledger-funding/protocol.ts
+++ b/packages/wallet-specs/src/protocols/ledger-funding/protocol.ts
@@ -1,7 +1,7 @@
 import { assign, DoneInvokeEvent, Machine } from 'xstate';
 import { CreateNullChannel, DirectFunding, SupportState } from '..';
 import { allocateToTarget } from '../../calculations';
-import { Channel, ensureExists, MachineFactory, Store, success, getEthAllocation } from '../..';
+import { Channel, ensureExists, MachineFactory, IStore, success, getEthAllocation } from '../..';
 import { Outcome } from '@statechannels/nitro-protocol';
 
 const PROTOCOL = 'ledger-funding';
@@ -129,7 +129,7 @@ export const guards = {
     data.type === 'FOUND',
 };
 
-export const machine: MachineFactory<Init, any> = (store: Store, context: Init) => {
+export const machine: MachineFactory<Init, any> = (store: IStore, context: Init) => {
   function directFundingArgs(ctx: LedgerExists): DirectFunding.Init {
     const minimalAllocation = getEthAllocation(
       store.getEntry(ctx.targetChannelId).latestState.outcome

--- a/packages/wallet-specs/src/store.ts
+++ b/packages/wallet-specs/src/store.ts
@@ -20,18 +20,19 @@ export interface IStore {
   /*
   Store modifiers
   */
-  initializeChannel: (entry: ChannelStoreEntry) => void;
+  initializeChannel: (entry: IChannelStoreEntry) => void;
   sendState: (state: State) => void;
   sendOpenChannel: (state: State) => void;
   receiveStates: (signedStates: SignedState[]) => void;
+  useNonce(participants: string[], nonce): void;
 
   // TODO: set funding
   // setFunding(channelId: string, funding: Funding): void;
 
   signState(state: State): SignedState;
+  sendStrategyChoice(message: FundingStrategyProposed): void;
 
   getNextNonce(participants: string[]): string;
-  useNonce(participants: string[], nonce): void;
   nonceOk(participants: string[], nonce: string): boolean;
 }
 
@@ -183,6 +184,7 @@ export class Store implements IStore {
     const { recipients } = this.getEntry(message.targetChannelId);
     this.sendMessage(message, recipients);
   }
+
   public signState(state: State): SignedState {
     const { privateKey } = this.getEntry(getChannelId(state.channel));
 


### PR DESCRIPTION
The `IStore` interface should specify all the methods are needed by the protocols. The `Store` implementation is still useful for trying things out, and contains some useful implementation details.