### PR TITLE
[rps] Allow multiple serial games

### DIFF
--- a/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
@@ -11,8 +11,8 @@ describe('Playing a game of RPS', () => {
   let rpsTabB: Page;
 
   beforeAll(async () => {
-    browserA = await setUpBrowser(false);
-    browserB = await setUpBrowser(false);
+    browserA = await setUpBrowser(false, 10);
+    browserB = await setUpBrowser(false, 10);
 
     rpsTabA = (await browserA.pages())[0];
     rpsTabB = (await browserB.pages())[0];

--- a/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
@@ -1,4 +1,4 @@
-import {setUpBrowser, loadRPSApp} from '../helpers';
+import {setUpBrowser, loadRPSApp, waitForHeading} from '../helpers';
 import {clickThroughRPSUI, clickThroughResignationUI, setupRPS} from '../scripts/rps';
 import {Page, Browser} from 'puppeteer';
 
@@ -33,12 +33,8 @@ describe('Playing a game of RPS', () => {
 
   it('can play a game end to end, and start a second game', async () => {
     await clickThroughRPSUI(rpsTabA, rpsTabB);
-    expect(await (await rpsTabA.waitFor('h1.mb-5')).evaluate(el => el.textContent)).toMatch(
-      'You lost'
-    );
-    expect(await (await rpsTabB.waitFor('h1.mb-5')).evaluate(el => el.textContent)).toMatch(
-      'You won!'
-    );
+    expect(await waitForHeading(rpsTabA)).toMatch('You lost');
+    expect(await waitForHeading(rpsTabB)).toMatch('You won!');
 
     await clickThroughResignationUI(rpsTabA, rpsTabB);
 
@@ -47,11 +43,7 @@ describe('Playing a game of RPS', () => {
     expect(await rpsTabA.waitForXPath('//button[contains(., "Create a game")]')).toBeDefined();
 
     await clickThroughRPSUI(rpsTabA, rpsTabB);
-    expect(await (await rpsTabA.waitFor('h1.mb-5')).evaluate(el => el.textContent)).toMatch(
-      'You lost'
-    );
-    expect(await (await rpsTabB.waitFor('h1.mb-5')).evaluate(el => el.textContent)).toMatch(
-      'You won!'
-    );
+    expect(await waitForHeading(rpsTabA)).toMatch('You lost');
+    expect(await waitForHeading(rpsTabB)).toMatch('You won!');
   });
 });

--- a/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
@@ -11,8 +11,8 @@ describe('Playing a game of RPS', () => {
   let rpsTabB: Page;
 
   beforeAll(async () => {
-    browserA = await setUpBrowser(false, 10);
-    browserB = await setUpBrowser(false, 10);
+    browserA = await setUpBrowser(true, 10);
+    browserB = await setUpBrowser(true, 10);
 
     rpsTabA = (await browserA.pages())[0];
     rpsTabB = (await browserB.pages())[0];

--- a/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
@@ -1,5 +1,5 @@
 import {setUpBrowser, loadRPSApp} from '../helpers';
-import {clickThroughRPSUI, clickThroughResignationUI, setupRPS} from '../scripts/rps;
+import {clickThroughRPSUI, clickThroughResignationUI, setupRPS} from '../scripts/rps';
 import {Page, Browser} from 'puppeteer';
 
 jest.setTimeout(60000);

--- a/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
@@ -1,5 +1,5 @@
 import {setUpBrowser, loadRPSApp} from '../helpers';
-import {clickThroughRPSUI, clickThroughResignationUI, setupRPS} from '../scripts/rps';
+import {clickThroughRPSUI, clickThroughResignationUI, setupRPS} from '../scripts/rps;
 import {Page, Browser} from 'puppeteer';
 
 jest.setTimeout(60000);

--- a/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
@@ -1,5 +1,5 @@
 import {setUpBrowser, loadRPSApp} from '../helpers';
-import {clickThroughRPSUI, clickThroughResignationUI} from '../scripts/rps';
+import {clickThroughRPSUI, clickThroughResignationUI, setupRPS} from '../scripts/rps';
 import {Page, Browser} from 'puppeteer';
 
 jest.setTimeout(60000);
@@ -14,11 +14,12 @@ describe('Playing a game of RPS', () => {
     browserA = await setUpBrowser(true);
     browserB = await setUpBrowser(true);
 
-    rpsTabA = await browserA.newPage();
-    rpsTabB = await browserB.newPage();
+    rpsTabA = (await browserA.pages())[0];
+    rpsTabB = (await browserB.pages())[0];
 
     await loadRPSApp(rpsTabA, 0);
     await loadRPSApp(rpsTabB, 1);
+    await setupRPS(rpsTabA, rpsTabB);
   });
 
   afterAll(async () => {
@@ -43,7 +44,18 @@ describe('Playing a game of RPS', () => {
   it('can then withdraw funds', async () => {
     await clickThroughResignationUI(rpsTabA, rpsTabB);
 
-    // Should be on the homepage
+    // Should be in the lobby
     expect(await rpsTabB.waitForXPath('//button[contains(., "Create a game")]')).toBeDefined();
+    expect(await rpsTabA.waitForXPath('//button[contains(., "Create a game")]')).toBeDefined();
+  });
+
+  it('can play a second game', async () => {
+    await clickThroughRPSUI(rpsTabA, rpsTabB);
+    expect(await (await rpsTabA.waitFor('h1.mb-5')).evaluate(el => el.textContent)).toMatch(
+      'You lost'
+    );
+    expect(await (await rpsTabB.waitFor('h1.mb-5')).evaluate(el => el.textContent)).toMatch(
+      'You won!'
+    );
   });
 });

--- a/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
@@ -11,8 +11,8 @@ describe('Playing a game of RPS', () => {
   let rpsTabB: Page;
 
   beforeAll(async () => {
-    browserA = await setUpBrowser(true);
-    browserB = await setUpBrowser(true);
+    browserA = await setUpBrowser(false);
+    browserB = await setUpBrowser(false);
 
     rpsTabA = (await browserA.pages())[0];
     rpsTabB = (await browserB.pages())[0];
@@ -31,7 +31,7 @@ describe('Playing a game of RPS', () => {
     }
   });
 
-  it('can play a game end to end', async () => {
+  it('can play a game end to end, and start a second game', async () => {
     await clickThroughRPSUI(rpsTabA, rpsTabB);
     expect(await (await rpsTabA.waitFor('h1.mb-5')).evaluate(el => el.textContent)).toMatch(
       'You lost'
@@ -39,17 +39,13 @@ describe('Playing a game of RPS', () => {
     expect(await (await rpsTabB.waitFor('h1.mb-5')).evaluate(el => el.textContent)).toMatch(
       'You won!'
     );
-  });
 
-  it('can then withdraw funds', async () => {
     await clickThroughResignationUI(rpsTabA, rpsTabB);
 
     // Should be in the lobby
     expect(await rpsTabB.waitForXPath('//button[contains(., "Create a game")]')).toBeDefined();
     expect(await rpsTabA.waitForXPath('//button[contains(., "Create a game")]')).toBeDefined();
-  });
 
-  it('can play a second game', async () => {
     await clickThroughRPSUI(rpsTabA, rpsTabB);
     expect(await (await rpsTabA.waitFor('h1.mb-5')).evaluate(el => el.textContent)).toMatch(
       'You lost'

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -33,9 +33,10 @@ export async function loadRPSApp(page: Page, ganacheAccountIndex: number): Promi
 }
 //
 
-export async function setUpBrowser(headless: boolean): Promise<Browser> {
+export async function setUpBrowser(headless: boolean, slowMo?: number): Promise<Browser> {
   const browser = await launch({
     headless,
+    slowMo,
     devtools: !headless,
     // Needed to allow both windows to execute JS at the same time
     ignoreDefaultArgs: [

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -36,6 +36,9 @@ export async function waitForAndClickButton(page: Page | Frame, button: string):
   return (await page.waitForXPath('//button[contains(., "' + button + '")]')).click();
 }
 
+export async function waitForHeading(page: Page | Frame): Promise<string | null> {
+  return (await page.waitFor('h1.mb-5')).evaluate(el => el.textContent);
+}
 export async function setUpBrowser(headless: boolean, slowMo?: number): Promise<Browser> {
   const browser = await launch({
     headless,

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -1,4 +1,4 @@
-import {Browser, Page, launch} from 'puppeteer';
+import {Browser, Page, Frame, launch} from 'puppeteer';
 
 import * as fs from 'fs';
 import * as path from 'path';
@@ -31,7 +31,10 @@ export async function loadRPSApp(page: Page, ganacheAccountIndex: number): Promi
     }
   });
 }
-//
+
+export async function waitForAndClickButton(page: Page | Frame, button: string): Promise<void> {
+  return (await page.waitForXPath('//button[contains(., "' + button + '")]')).click();
+}
 
 export async function setUpBrowser(headless: boolean, slowMo?: number): Promise<Browser> {
   const browser = await launch({

--- a/packages/e2e-tests/puppeteer/scripts/rps.ts
+++ b/packages/e2e-tests/puppeteer/scripts/rps.ts
@@ -1,15 +1,15 @@
-import {setUpBrowser, loadRPSApp} from '../helpers';
+import {setUpBrowser, loadRPSApp, waitForAndClickButton} from '../helpers';
 import {Page} from 'puppeteer';
 
 export async function setupRPS(rpsTabA: Page, rpsTabB: Page): Promise<void> {
-  await (await rpsTabA.waitForXPath('//button[contains(., "Start Playing!")]')).click();
-  await (await rpsTabB.waitForXPath('//button[contains(., "Start Playing!")]')).click();
+  await waitForAndClickButton(rpsTabA, 'Start Playing!');
+  await waitForAndClickButton(rpsTabB, 'Start Playing!');
 
   await (await rpsTabA.waitFor('#name')).type('playerA');
-  (await rpsTabA.waitForXPath('//button[contains(., "Connect with MetaMask")]')).click();
+  await waitForAndClickButton(rpsTabA, 'Connect with MetaMask');
 
   await (await rpsTabB.waitFor('#name')).type('playerB');
-  (await rpsTabB.waitForXPath('//button[contains(., "Connect with MetaMask")]')).click();
+  await waitForAndClickButton(rpsTabB, 'Connect with MetaMask');
 }
 
 export async function clickThroughRPSUI(rpsTabA: Page, rpsTabB: Page): Promise<void> {
@@ -20,16 +20,17 @@ export async function clickThroughRPSUI(rpsTabA: Page, rpsTabB: Page): Promise<v
     'document.querySelector("button.lobby-new-game").click()'
   ); // TODO this is actually Player B. Consider permuting A and B throughout this script.
 
-  await (await rpsTabA.waitForXPath('//button[contains(., "Create Game")]')).click();
-  await (await rpsTabB.waitForXPath('//button[contains(., "Join")]')).click();
+  await waitForAndClickButton(rpsTabA, 'Create Game');
+  await waitForAndClickButton(rpsTabB, 'Join');
 
   const walletIFrameA = rpsTabA.frames()[1];
   const walletIFrameB = rpsTabB.frames()[1];
 
-  await (await walletIFrameB.waitForXPath('//button[contains(., "Fund Channel")]')).click();
-  await (await walletIFrameA.waitForXPath('//button[contains(., "Fund Channel")]')).click();
-  await (await walletIFrameB.waitForXPath('//button[contains(., "Ok!")]')).click();
-  await (await walletIFrameA.waitForXPath('//button[contains(., "Ok!")]')).click();
+  await waitForAndClickButton(walletIFrameB, 'Fund Channel');
+  await waitForAndClickButton(walletIFrameA, 'Fund Channel');
+  await waitForAndClickButton(walletIFrameB, 'Ok!');
+  await waitForAndClickButton(walletIFrameA, 'Ok!');
+
   await (await rpsTabA.waitFor('img[src*="rock"]')).click();
   await (await rpsTabB.waitFor('img[src*="paper"]')).click();
 }
@@ -37,28 +38,26 @@ export async function clickThroughRPSUI(rpsTabA: Page, rpsTabB: Page): Promise<v
 export async function clickThroughResignationUI(rpsTabA: Page, rpsTabB: Page): Promise<void> {
   async function tabA(): Promise<void> {
     const walletIFrameA = rpsTabA.frames()[1];
+    await waitForAndClickButton(rpsTabA, 'Resign');
+    await waitForAndClickButton(walletIFrameA, 'Close Channel');
 
-    await (await rpsTabA.waitForXPath('//button[contains(., "Resign")]')).click();
-    await (await walletIFrameA.waitForXPath('//button[contains(., "Close Channel")]')).click();
     const button = await Promise.race([
       walletIFrameA.waitForXPath('//button[contains(., "Approve")]'), // virtual funding
       walletIFrameA.waitForXPath('//button[contains(., "Ok")]') // ledger funding NOTE CASE SENSITIVE Ok not OK
     ]);
+
     await button.click();
-    await (await rpsTabA.waitForXPath('//button[contains(., "OK")]')).click();
-    await (await rpsTabA.waitForXPath('//button[contains(., "Exit")]')).click();
-    return;
+    await waitForAndClickButton(rpsTabA, 'OK');
+    await waitForAndClickButton(rpsTabA, 'Exit');
   }
 
   async function tabB(): Promise<void> {
     const walletIFrameB = rpsTabB.frames()[1];
-
-    await (await walletIFrameB.waitForXPath('//button[contains(., "Close Channel")]')).click();
-    await (await walletIFrameB.waitForXPath('//button[contains(., "Approve")]')).click();
-    await (await walletIFrameB.waitForXPath('//button[contains(., "Ok")]')).click();
-    await (await rpsTabB.waitForXPath('//button[contains(., "OK")]')).click();
-    await (await rpsTabB.waitForXPath('//button[contains(., "Exit")]')).click();
-    return;
+    await waitForAndClickButton(walletIFrameB, 'Close Channel');
+    await waitForAndClickButton(walletIFrameB, 'Approve');
+    await waitForAndClickButton(walletIFrameB, 'Ok');
+    await waitForAndClickButton(rpsTabB, 'OK');
+    await waitForAndClickButton(rpsTabB, 'Exit');
   }
 
   const tabAcomplete = tabA();

--- a/packages/e2e-tests/puppeteer/scripts/rps.ts
+++ b/packages/e2e-tests/puppeteer/scripts/rps.ts
@@ -1,7 +1,7 @@
 import {setUpBrowser, loadRPSApp} from '../helpers';
 import {Page} from 'puppeteer';
 
-export async function clickThroughRPSUI(rpsTabA: Page, rpsTabB: Page): Promise<void> {
+export async function setupRPS(rpsTabA: Page, rpsTabB: Page): Promise<void> {
   await (await rpsTabA.waitForXPath('//button[contains(., "Start Playing!")]')).click();
   await (await rpsTabB.waitForXPath('//button[contains(., "Start Playing!")]')).click();
 
@@ -10,53 +10,60 @@ export async function clickThroughRPSUI(rpsTabA: Page, rpsTabB: Page): Promise<v
 
   await (await rpsTabB.waitFor('#name')).type('playerB');
   (await rpsTabB.waitForXPath('//button[contains(., "Connect with MetaMask")]')).click();
+}
 
+export async function clickThroughRPSUI(rpsTabA: Page, rpsTabB: Page): Promise<void> {
   // NOTE: There is some weird scrolling issue. .click() scrolls and somehow React re-renders this
   // button and so we get a "Node is detached from document error". Using .evaluate() fixes it.
   // https://github.com/puppeteer/puppeteer/issues/3496
   await (await rpsTabA.waitForXPath('//button[contains(., "Create a game")]')).evaluate(
     'document.querySelector("button.lobby-new-game").click()'
-  );
-  await (await rpsTabA.waitForXPath('//button[contains(., "Create Game")]')).click();
+  ); // TODO this is actually Player B. Consider permuting A and B throughout this script.
 
+  await (await rpsTabA.waitForXPath('//button[contains(., "Create Game")]')).click();
   await (await rpsTabB.waitForXPath('//button[contains(., "Join")]')).click();
 
   const walletIFrameA = rpsTabA.frames()[1];
   const walletIFrameB = rpsTabB.frames()[1];
 
   await (await walletIFrameB.waitForXPath('//button[contains(., "Fund Channel")]')).click();
-
   await (await walletIFrameA.waitForXPath('//button[contains(., "Fund Channel")]')).click();
-
   await (await walletIFrameB.waitForXPath('//button[contains(., "Ok!")]')).click();
-
   await (await walletIFrameA.waitForXPath('//button[contains(., "Ok!")]')).click();
-
   await (await rpsTabA.waitFor('img[src*="rock"]')).click();
-
   await (await rpsTabB.waitFor('img[src*="paper"]')).click();
 }
 
 export async function clickThroughResignationUI(rpsTabA: Page, rpsTabB: Page): Promise<void> {
-  (await rpsTabA.waitForXPath('//button[contains(., "Resign")]')).click();
+  async function tabA(): Promise<void> {
+    const walletIFrameA = rpsTabA.frames()[1];
 
-  const walletIFrameA = rpsTabA.frames()[1];
-  const walletIFrameB = rpsTabB.frames()[1];
+    await (await rpsTabA.waitForXPath('//button[contains(., "Resign")]')).click();
+    await (await walletIFrameA.waitForXPath('//button[contains(., "Close Channel")]')).click();
+    const button = await Promise.race([
+      walletIFrameA.waitForXPath('//button[contains(., "Approve")]'), // virtual funding
+      walletIFrameA.waitForXPath('//button[contains(., "Ok")]') // ledger funding NOTE CASE SENSITIVE Ok not OK
+    ]);
+    await button.click();
+    await (await rpsTabA.waitForXPath('//button[contains(., "OK")]')).click();
+    await (await rpsTabA.waitForXPath('//button[contains(., "Exit")]')).click();
+    return;
+  }
 
-  await (await walletIFrameB.waitForXPath('//button[contains(., "Close Channel")]')).click();
+  async function tabB(): Promise<void> {
+    const walletIFrameB = rpsTabB.frames()[1];
 
-  await (await walletIFrameA.waitForXPath('//button[contains(., "Close Channel")]')).click();
+    await (await walletIFrameB.waitForXPath('//button[contains(., "Close Channel")]')).click();
+    await (await walletIFrameB.waitForXPath('//button[contains(., "Approve")]')).click();
+    await (await walletIFrameB.waitForXPath('//button[contains(., "Ok")]')).click();
+    await (await rpsTabB.waitForXPath('//button[contains(., "OK")]')).click();
+    await (await rpsTabB.waitForXPath('//button[contains(., "Exit")]')).click();
+    return;
+  }
 
-  await (await walletIFrameB.waitForXPath('//button[contains(., "Approve")]')).click();
-
-  await (await walletIFrameB.waitForXPath('//button[contains(., "Ok")]')).click();
-
-  (await rpsTabB.waitForXPath('//button[contains(., "OK")]')).click();
-
-  (await rpsTabB.waitForXPath('//button[contains(., "Exit")]')).click();
-
-  // TODO: Implement some logic so this can be called in both the ledger or virtual channel case
-  //       (in the virtual case, both UIs show "Approve" but in the ledger case, only one does)
+  const tabAcomplete = tabA();
+  const tabBcomplete = tabB();
+  await Promise.all([tabAcomplete, tabBcomplete]);
 }
 
 if (require.main === module) {

--- a/packages/e2e-tests/puppeteer/scripts/rps.ts
+++ b/packages/e2e-tests/puppeteer/scripts/rps.ts
@@ -47,14 +47,19 @@ export async function clickThroughResignationUI(rpsTabA: Page, rpsTabB: Page): P
     await waitForAndClickButton(rpsTabA, 'Resign');
     await waitForAndClickButton(walletIFrameA, 'Close Channel');
 
-    const button = await Promise.race([
-      walletIFrameA.waitForXPath('//button[contains(., "Approve")]'), // virtual funding
-      walletIFrameA.waitForXPath('//button[contains(., "Ok")]') // ledger funding NOTE CASE SENSITIVE Ok not OK
-    ]);
+    async function virtualFunding(): Promise<void> {
+      await waitForAndClickButton(walletIFrameA, 'Approve');
+      await waitForAndClickButton(walletIFrameA, 'Ok');
+      await waitForAndClickButton(rpsTabA, 'OK');
+      await waitForAndClickButton(rpsTabA, 'Exit');
+    }
 
-    await button.click();
-    await waitForAndClickButton(rpsTabA, 'OK');
-    await waitForAndClickButton(rpsTabA, 'Exit');
+    async function ledgerFunding(): Promise<void> {
+      await waitForAndClickButton(walletIFrameA, 'Ok');
+      await waitForAndClickButton(rpsTabA, 'OK');
+      await waitForAndClickButton(rpsTabA, 'Exit');
+    }
+    await Promise.race([virtualFunding(), ledgerFunding()]);
   }
 
   async function tabB(): Promise<void> {

--- a/packages/rps/src/redux/auto-opponent/__tests__/auto-opponent.test.ts
+++ b/packages/rps/src/redux/auto-opponent/__tests__/auto-opponent.test.ts
@@ -38,7 +38,6 @@ it(
       .withReducer(reducer, initialState)
       .silentRun(SUFFICIENT_TIME_TO_GET_TO_TURNUM_16); // Kill the saga after (hopefully) enough time. Brittle.
     expect(storeState.game.localState.type).toEqual('EndGame.GameOver');
-    expect(storeState.game.channelState.turnNum).toEqual('16');
   },
   SUFFICIENT_TIME_TO_GET_TO_TURNUM_16 + 1000
 ); // We don't want jest to timeout

--- a/packages/rps/src/redux/game/__tests__/player-a.test.ts
+++ b/packages/rps/src/redux/game/__tests__/player-a.test.ts
@@ -219,8 +219,6 @@ describe('when in Resigned and user clicks on button', () => {
       .dispatch(action)
       .run({silenceTimeout: true});
 
-    expect(storeState).toEqual(
-      gameState(localStatesA.gameOver, channelStates.concludeFromProposed)
-    );
+    expect(storeState).toEqual(gameState(localStatesA.gameOver, null));
   });
 });

--- a/packages/rps/src/redux/game/__tests__/player-b.test.ts
+++ b/packages/rps/src/redux/game/__tests__/player-b.test.ts
@@ -283,8 +283,6 @@ describe('when in Resigned and user clicks on button', () => {
       .dispatch(action)
       .run({silenceTimeout: true});
 
-    expect(storeState).toEqual(
-      gameState(localStatesB.gameOver, channelStates.concludeFromAccepted)
-    );
+    expect(storeState).toEqual(gameState(localStatesB.gameOver, null));
   });
 });

--- a/packages/rps/src/redux/game/saga.ts
+++ b/packages/rps/src/redux/game/saga.ts
@@ -135,7 +135,9 @@ function* gameSagaRun(client: RPSChannelClient) {
       }
       break;
     case 'EndGame.GameOver':
-      yield* clearChannelState();
+      if (channelState) {
+        yield put(a.updateChannelState(null));
+      }
       break;
   }
 }
@@ -338,9 +340,6 @@ function* sendStartAndStartRound(channelState: ChannelState<Reveal>, client: RPS
 function* closeChannel(channelState: ChannelState, client: RPSChannelClient) {
   const closingChannelState = yield call([client, 'closeChannel'], channelState.channelId);
   yield put(a.updateChannelState(closingChannelState));
-}
-function* clearChannelState() {
-  yield put(a.updateChannelState(null));
 }
 
 const calculateFundingSituation = (

--- a/packages/rps/src/redux/game/saga.ts
+++ b/packages/rps/src/redux/game/saga.ts
@@ -65,7 +65,9 @@ function* gameSagaRun(client: RPSChannelClient) {
     case 'Setup.NeedAddress':
       const address: string = yield call([client, 'getAddress']);
       const outcomeAddress: string = window.ethereum.selectedAddress;
-      yield put(a.gotAddressFromWallet(address, outcomeAddress));
+      if (outcomeAddress) {
+        yield put(a.gotAddressFromWallet(address, outcomeAddress));
+      }
       break;
     case 'A.GameChosen':
       if (cs.isEmpty(channelState)) {
@@ -131,6 +133,9 @@ function* gameSagaRun(client: RPSChannelClient) {
       ) {
         yield* closeChannel(channelState, client);
       }
+      break;
+    case 'EndGame.GameOver':
+      yield* clearChannelState();
       break;
   }
 }
@@ -333,6 +338,9 @@ function* sendStartAndStartRound(channelState: ChannelState<Reveal>, client: RPS
 function* closeChannel(channelState: ChannelState, client: RPSChannelClient) {
   const closingChannelState = yield call([client, 'closeChannel'], channelState.channelId);
   yield put(a.updateChannelState(closingChannelState));
+}
+function* clearChannelState() {
+  yield put(a.updateChannelState(null));
 }
 
 const calculateFundingSituation = (

--- a/packages/rps/src/redux/open-games/saga.ts
+++ b/packages/rps/src/redux/open-games/saga.ts
@@ -18,10 +18,9 @@ export default function* openGameSaga() {
   // this is more robust though, so stick to watching all actions for the time being
   let openGameSyncerProcess: any = null;
   let myGameIsOnFirebase = false;
-  let joinedAGame = false;
 
   while (true) {
-    yield take('*');
+    const action = yield take('*');
 
     const localState: LocalState = yield select(getLocalState);
 
@@ -37,7 +36,7 @@ export default function* openGameSaga() {
       }
     }
 
-    if (localState.type === 'A.GameChosen' && !joinedAGame) {
+    if (action.type === 'JoinOpenGame' && localState.type === 'A.GameChosen') {
       const openGameKey = `/challenges/${localState.opponentAddress}`;
       const taggedOpenGame = {
         isPublic: false,
@@ -45,7 +44,6 @@ export default function* openGameSaga() {
         playerAOutcomeAddress: localState.outcomeAddress,
       };
       yield call(reduxSagaFirebase.database.patch, openGameKey, taggedOpenGame);
-      joinedAGame = true;
     }
 
     if (localState.type === 'B.WaitingRoom') {


### PR DESCRIPTION
Three fixes: 

- Because most of the `rps` sagas `take` every action, there were hacks in place to prevent performing some tasks multiple times: in this case a mutex to track if Player A had joined a game. This mutex was never getting reset. The new approach is to do away with the mutex, and only join a game when a "join game" action was dispatched. 

- Some tasks (e.g. opening a channel) were only executed when the `channelState` was "empty". The new approach is to clear out the `channelState` when the game is over. 


Closes #778 .


(and, unrelated to this issue)

- In some scenarios the metamask address never gets injected, leading to runtime errors down the line. The new approach is to wait for the metamask address to exist before progressing with the game. 
