### PR TITLE
Switch to single bracket syntax in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "postinstall": "patch-package",
     "build:netlify:ci": "lerna run --stream --parallel build:netlify",
     "release:netlify": "lerna run --stream --parallel release:netlify --",
-    "release:netlify:ci": "yarn release:netlify --auth $NETLIFY_ACCESS_TOKEN --message $(git rev-parse --short HEAD) $([[ $(git rev-parse --abbrev-ref HEAD) == master ]] && echo --prod)"
+    "release:netlify:ci": "yarn release:netlify --auth $NETLIFY_ACCESS_TOKEN --message $(git rev-parse --short HEAD) $([ $(git rev-parse --abbrev-ref HEAD) = master ] && echo --prod)"
   },
   "keywords": [
     "ethereum",


### PR DESCRIPTION
On Linux Alpine, `yarn` uses `sh` (as opposed to `bash`) to execute subshell commands. `[[ ]]` and `==` are not valid. 