### PR TITLE
[nitro] Fix error in definition of setup phase

### DIFF
--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -505,7 +505,7 @@ contract ForceMove is IForceMove {
                 !isFinalAB[0],
                 'InvalidTransitionError: Cannot move from a final state to a non final state'
             );
-            if (turnNumB <= 2 * nParticipants) {
+            if (turnNumB < 2 * nParticipants) {
                 require(
                     _bytesEqual(ab[1].outcome, ab[0].outcome),
                     'InvalidTransitionError: Cannot change the default outcome during setup phase'

--- a/packages/nitro-protocol/docs/forcemove-and-nitro/force-move.md
+++ b/packages/nitro-protocol/docs/forcemove-and-nitro/force-move.md
@@ -122,7 +122,7 @@ function validTransition(a, b) <=>
   b.signer == b.mover
   if b.isFinal
      b.defaultOutcome == a.defaultOutcome
-  else if b.turnNum <= 2n
+  else if b.turnNum < 2n
      a.isFinal == False
      b.defaultOutcome == a.defaultOutcome
      b.appData == a.appData

--- a/packages/nitro-protocol/test/contracts/ForceMove/respond.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/respond.test.ts
@@ -58,23 +58,29 @@ const description5 =
   'It reverts a respond tx if the response state is not a validTransition from the challenge state';
 
 describe('respond', () => {
-  const turnNumRecord = 8;
   let channelNonce = 1000;
   const future = 1e12;
   const past = 1;
   beforeEach(() => (channelNonce += 1));
   it.each`
-    description     | finalizesAt | slotEmpty | isFinalAB         | appDatas  | challenger    | responder         | reasonString
-    ${description1} | ${future}   | ${false}  | ${[false, false]} | ${[0, 1]} | ${wallets[2]} | ${wallets[0]}     | ${undefined}
-    ${description2} | ${past}     | ${false}  | ${[false, false]} | ${[0, 1]} | ${wallets[2]} | ${wallets[0]}     | ${NO_ONGOING_CHALLENGE}
-    ${description3} | ${future}   | ${true}   | ${[false, false]} | ${[0, 1]} | ${wallets[2]} | ${wallets[0]}     | ${WRONG_CHANNEL_STORAGE}
-    ${description4} | ${future}   | ${false}  | ${[false, false]} | ${[0, 1]} | ${wallets[2]} | ${nonParticipant} | ${RESPONSE_UNAUTHORIZED}
-    ${description5} | ${future}   | ${false}  | ${[false, false]} | ${[0, 0]} | ${wallets[2]} | ${wallets[0]}     | ${'CountingApp: Counter must be incremented'}
+    description     | finalizesAt | slotEmpty | isFinalAB         | turnNumRecord | appDatas  | challenger    | responder         | reasonString
+    ${description1} | ${future}   | ${false}  | ${[false, false]} | ${0}          | ${[0, 0]} | ${wallets[0]} | ${wallets[1]}     | ${undefined}
+    ${description1} | ${future}   | ${false}  | ${[false, false]} | ${1}          | ${[0, 0]} | ${wallets[1]} | ${wallets[2]}     | ${undefined}
+    ${description1} | ${future}   | ${false}  | ${[false, false]} | ${2}          | ${[0, 0]} | ${wallets[2]} | ${wallets[0]}     | ${undefined}
+    ${description1} | ${future}   | ${false}  | ${[false, false]} | ${3}          | ${[0, 0]} | ${wallets[0]} | ${wallets[1]}     | ${undefined}
+    ${description1} | ${future}   | ${false}  | ${[false, false]} | ${4}          | ${[0, 0]} | ${wallets[1]} | ${wallets[2]}     | ${undefined}
+    ${description1} | ${future}   | ${false}  | ${[false, false]} | ${5}          | ${[0, 1]} | ${wallets[2]} | ${wallets[0]}     | ${undefined}
+    ${description1} | ${future}   | ${false}  | ${[false, false]} | ${6}          | ${[1, 2]} | ${wallets[0]} | ${wallets[1]}     | ${undefined}
+    ${description2} | ${past}     | ${false}  | ${[false, false]} | ${8}          | ${[0, 1]} | ${wallets[2]} | ${wallets[0]}     | ${NO_ONGOING_CHALLENGE}
+    ${description3} | ${future}   | ${true}   | ${[false, false]} | ${8}          | ${[0, 1]} | ${wallets[2]} | ${wallets[0]}     | ${WRONG_CHANNEL_STORAGE}
+    ${description4} | ${future}   | ${false}  | ${[false, false]} | ${8}          | ${[0, 1]} | ${wallets[2]} | ${nonParticipant} | ${RESPONSE_UNAUTHORIZED}
+    ${description5} | ${future}   | ${false}  | ${[false, false]} | ${8}          | ${[0, 0]} | ${wallets[2]} | ${wallets[0]}     | ${'CountingApp: Counter must be incremented'}
   `(
     '$description', // For the purposes of this test, chainId and participants are fixed, making channelId 1-1 with channelNonce
     async ({
       description,
       isFinalAB,
+      turnNumRecord,
       appDatas,
       challenger,
       responder,


### PR DESCRIPTION
The bug disallowed `respond`ing to a challenge when the challenge state was the final post fund setup in the round, since the core protocol `validTransition` would erroneously judge the response state to be a setup state, and then require the `appData` to not change.

Hint: the test is for a 3 participant channel, so the example is when `turnNumRecord=5`.