### PR TITLE
[monorepo] Set concurrency for lerna to 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean:dry": "git clean -Xdn --exclude=\"!.env\"",
     "start:shared-ganache": "cd packages/devtools && NODE_ENV=development yarn start:shared-ganache",
     "test": "lerna run --stream --parallel test",
-    "test:ci:incremental": "yarn test:ci --since $(git merge-base $CIRCLE_BRANCH origin/master)",
+    "test:ci:incremental": "yarn test:ci",
     "test:ci": "lerna run  test:ci --stream --concurrency 2 --no-sort --include-dependents",
     "test:w3t": "lerna run test --concurrency 1 --scope=**/web3torrent ",
     "lint:check": "lerna run lint:check --parallel --no-bail -- --max-warnings=0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start:shared-ganache": "cd packages/devtools && NODE_ENV=development yarn start:shared-ganache",
     "test": "lerna run --stream --parallel test",
     "test:ci:incremental": "yarn test:ci",
-    "test:ci": "lerna run  test:ci --stream --concurrency 2 --no-sort --include-dependents",
+    "test:ci": "lerna run  test:ci --stream --concurrency 4 --no-sort --include-dependents",
     "test:w3t": "lerna run test --concurrency 1 --scope=**/web3torrent ",
     "lint:check": "lerna run lint:check --parallel --no-bail -- --max-warnings=0",
     "lint:write": "lerna run lint:write --parallel --no-bail",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean:dry": "git clean -Xdn --exclude=\"!.env\"",
     "start:shared-ganache": "cd packages/devtools && NODE_ENV=development yarn start:shared-ganache",
     "test": "lerna run --stream --parallel test",
-    "test:ci:incremental": "yarn test:ci",
+    "test:ci:incremental": "yarn test:ci --since $(git merge-base $CIRCLE_BRANCH origin/master)",
     "test:ci": "lerna run  test:ci --stream --concurrency 4 --no-sort --include-dependents",
     "test:w3t": "lerna run test --concurrency 1 --scope=**/web3torrent ",
     "lint:check": "lerna run lint:check --parallel --no-bail -- --max-warnings=0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start:shared-ganache": "cd packages/devtools && NODE_ENV=development yarn start:shared-ganache",
     "test": "lerna run --stream --parallel test",
     "test:ci:incremental": "yarn test:ci --since $(git merge-base $CIRCLE_BRANCH origin/master)",
-    "test:ci": "lerna run  test:ci --stream --parallel --include-dependents",
+    "test:ci": "lerna run  test:ci --stream --concurrency 2 --no-sort --include-dependents",
     "test:w3t": "lerna run test --concurrency 1 --scope=**/web3torrent ",
     "lint:check": "lerna run lint:check --parallel --no-bail -- --max-warnings=0",
     "lint:write": "lerna run lint:write --parallel --no-bail",


### PR DESCRIPTION
We get an out of memory error on circle under current config. 

On this branch I will try a few different configs that avoid the error while keeping the duration as short as possble.

Tests in the `wallet` package take the most time (typically 6mins).

For all tests:

Concurrency = 2: 9mins
Concurrency = 4: 6 mins