### PR TITLE
💸 💸  Set resource_class to "large" in test and prepare 💸 💸

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,7 @@ commands:
 jobs:
   prepare:
     <<: *defaults
+    resource_class: large
     steps:
       - checkout
       - log_stats:
@@ -140,8 +141,8 @@ jobs:
       - notify_slack
 
   test:
-    resource_class: large
     <<: *defaults
+    resource_class: large
     steps:
       - checkout
       - log_stats:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,7 @@ jobs:
       - notify_slack
 
   test:
+    resource_class: large
     <<: *defaults
     steps:
       - checkout
@@ -298,4 +299,3 @@ workflows:
           filters:
             branches:
               only: master
-


### PR DESCRIPTION
These are the rate-limiting steps in most builds. In my very unscientific comparison:
- `"large"` saves ~30 seconds on `yarn install`
- `"large"` saves ~20 seconds on `yarn test:ci` with concurrent tests
  - `lerna run test:ci --parallel` is slower than `lerna run test:ci --concurrency 4 --no-sort`

So, we might save 30-60s by spending a bit more money on circle credits.

Other things, like restoring the cache or persisting/restoring a workspace, seem to take a pretty variable amount of time.