### PR TITLE
[nitro] Fix and test forceMove transaction generator

### DIFF
--- a/packages/nitro-protocol/src/contract/transaction-creators/force-move.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/force-move.ts
@@ -28,8 +28,8 @@ export function createGetDataTransaction(channelId: string): TransactionRequest 
 }
 
 export function createForceMoveTransaction(
-  states: State[],
-  signatures: Signature[],
+  states: State[], // in turnNum order [..,state-with-largestTurnNum]
+  signatures: Signature[], // in participant order: [sig-from-p0, sig-from-p1, ...]
   whoSignedWhat: number[],
   challengerPrivateKey: string
 ): TransactionRequest {
@@ -50,8 +50,10 @@ export function createForceMoveTransaction(
   // Get the largest turn number from the states
   const largestTurnNum = Math.max(...states.map(s => s.turnNum));
   const isFinalCount = states.filter(s => s.isFinal === true).length;
-  // TODO: Is there a reason why createForceMoveTransaction accepts a State[] and a Signature[]
+  // Q: Is there a reason why createForceMoveTransaction accepts a State[] and a Signature[]
   // Argument rather than a SignedState[] argument?
+  // A: Yes, because the signatures must be passed in participant order: [sig-from-p0, sig-from-p1, ...]
+  // and SignedStates[] won't comply with that in general. This function accetps the re-ordered sigs.
   const signedStates = states.map(s => ({state: s, signature: {v: 0, r: '', s: ''}}));
   const challengerSignature = signChallengeMessage(signedStates, challengerPrivateKey);
 

--- a/packages/nitro-protocol/src/transactions.ts
+++ b/packages/nitro-protocol/src/transactions.ts
@@ -81,10 +81,13 @@ function createSignatureArguments(
   const {participants} = signedStates[0].state.channel;
 
   // Get a list of all unique states.
-  const states = signedStates.filter((s, i, a) => a.indexOf(s) === i).map(s => s.state);
-  const signatures = signedStates.map(s => s.signature);
+  const uniqueSignedStates = signedStates.filter((s, i, a) => a.indexOf(s) === i);
+  const states = uniqueSignedStates.map(s => s.state);
+
   // Generate whoSignedWhat based on the original list of states (which may contain the same state signed by multiple participants)
   const whoSignedWhat = signedStates.map(s => participants.indexOf(getStateSignerAddress(s)));
+  const signatures = [];
+  participants.forEach((p, i) => signatures.push(uniqueSignedStates[whoSignedWhat[i]].signature));
 
   return {states, signatures, whoSignedWhat};
 }

--- a/packages/nitro-protocol/test/contracts/ForceMove/forceMove.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/forceMove.test.ts
@@ -244,24 +244,20 @@ describe('forceMove with transaction generator', () => {
     description                  | appData   | turnNums  | challenger
     ${'forceMove(0,1) accepted'} | ${[0, 0]} | ${[0, 1]} | ${1}
     ${'forceMove(1,2) accepted'} | ${[0, 0]} | ${[1, 2]} | ${0}
-  `(
-    '$description', // For the purposes of this test, chainId and participants are fixed, making channelId 1-1 with channelNonce
-
-    async ({description, appData, turnNums, challenger}) => {
-      const transactionRequest: TransactionRequest = createForceMoveTransaction(
-        [
-          await createSignedCountingAppState(twoPartyChannel, appData[0], turnNums[0]),
-          await createSignedCountingAppState(twoPartyChannel, appData[1], turnNums[1]),
-        ],
-        wallets[challenger].privateKey
-      );
-      const signer = provider.getSigner();
-      const transaction = {data: transactionRequest.data, gasLimit: 3000000};
-      const response = await signer.sendTransaction({
-        to: ForceMove.address,
-        ...transaction,
-      });
-      expect(response).toBeDefined();
-    }
-  );
+  `('$description', async ({description, appData, turnNums, challenger}) => {
+    const transactionRequest: TransactionRequest = createForceMoveTransaction(
+      [
+        await createSignedCountingAppState(twoPartyChannel, appData[0], turnNums[0]),
+        await createSignedCountingAppState(twoPartyChannel, appData[1], turnNums[1]),
+      ],
+      wallets[challenger].privateKey
+    );
+    const signer = provider.getSigner();
+    const transaction = {data: transactionRequest.data, gasLimit: 3000000};
+    const response = await signer.sendTransaction({
+      to: ForceMove.address,
+      ...transaction,
+    });
+    expect(response).toBeDefined();
+  });
 });


### PR DESCRIPTION
It was previously using a broken `createSignatureArguments` helper -- this is now altered to rip the signatures out of an array of `SignedStates`, and re-order them by participant (as is required by the contract code). 

This PR also increases test coverage such that tests would fail without the above fix (namely, when the array of states submitted does not begin with one owned by participant 0). 

Some scope for DRYing out the new tests.
