### PR TITLE
[monorepo] Remove fmg-core and web3 dependencies

### DIFF
--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -35,7 +35,6 @@
     "@firebase/database": "^0.5.18",
     "@statechannels/nitro-protocol": "0.0.1",
     "async-lock": "1.2.2",
-    "fmg-core": "0.5.9",
     "knex": "0.20.3",
     "objection": "1.6.11",
     "pg": "7.12.1",

--- a/packages/hub/src/test/test-constants.ts
+++ b/packages/hub/src/test/test-constants.ts
@@ -6,7 +6,7 @@ import {
 } from '@statechannels/nitro-protocol';
 import {ethers} from 'ethers';
 import {bigNumberify} from 'ethers/utils';
-import {Address, Uint256} from 'fmg-core';
+import {Address, Uint256} from '../types';
 import {HUB_ADDRESS} from '../constants';
 
 export const PARTICIPANT_1_PRIVATE_KEY =

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -1,4 +1,34 @@
-import {Address, BaseCommitment, Bytes, Bytes32, CommitmentType, Uint32, Uint8} from 'fmg-core';
+// NOTE: These were copy and pasted from fmg-core to remove the fmg-core
+// dependency. It would be better if we imported these types from nitro-protocol
+export declare type Byte = string;
+export declare type Bytes32 = string;
+export declare type Bytes = string;
+export declare type Uint8 = number;
+export declare type Uint32 = number;
+export declare type Uint64 = string;
+export declare type Uint128 = string;
+export declare type Uint256 = string;
+export type Address = string;
+export interface Channel {
+  channelType: Address;
+  nonce: Uint32;
+  participants: Address[];
+  guaranteedChannel?: Address;
+}
+export interface BaseCommitment {
+  channel: Channel;
+  turnNum: Uint32;
+  allocation: Uint256[];
+  destination: Address[];
+  commitmentCount: Uint32;
+}
+export declare enum CommitmentType {
+  PreFundSetup = 0,
+  PostFundSetup = 1,
+  App = 2,
+  Conclude = 3
+}
+// END COMMENT
 
 export type CommitmentString = string;
 
@@ -20,5 +50,3 @@ export interface AppCommitment extends BaseCommitment {
   appAttributes: any;
   commitmentType: CommitmentType;
 }
-
-export {Address, Bytes32, Bytes, Uint8, Uint32};

--- a/packages/hub/src/wallet/db/queries/channels.ts
+++ b/packages/hub/src/wallet/db/queries/channels.ts
@@ -1,5 +1,5 @@
 import {getChannelId, State} from '@statechannels/nitro-protocol';
-import {Uint256} from 'fmg-core';
+import {Uint256} from '../../../types';
 import errors from '../../errors';
 import Channel from '../../models/channel';
 import {outcomeObjectToModel} from '../../utilities/outcome';

--- a/packages/hub/src/wallet/index.ts
+++ b/packages/hub/src/wallet/index.ts
@@ -1,4 +1,4 @@
-import {Bytes} from 'fmg-core';
+import {Bytes} from '../types';
 import {State} from '@statechannels/nitro-protocol';
 import {queries} from './db/queries/channels';
 import {formResponse, nextState, validSignature} from './services/channelManager';

--- a/packages/hub/src/wallet/models/allocation.ts
+++ b/packages/hub/src/wallet/models/allocation.ts
@@ -1,5 +1,5 @@
 import {Bytes32} from '@statechannels/nitro-protocol/lib/src/contract/types';
-import {Uint256, Uint32} from 'fmg-core';
+import {Uint256, Uint32} from '../../types';
 import {Model, snakeCaseMappers} from 'objection';
 import Outcome from './outcome';
 

--- a/packages/hub/src/wallet/models/channel.ts
+++ b/packages/hub/src/wallet/models/channel.ts
@@ -1,5 +1,5 @@
 import {Channel as ChannelObject} from '@statechannels/nitro-protocol';
-import {Uint256} from 'fmg-core';
+import {Uint256} from '../../types';
 import {Model, snakeCaseMappers} from 'objection';
 import ChannelHolding from './channelHoldings';
 import ChannelParticipant from './channelParticipants';

--- a/packages/hub/src/wallet/models/channelHoldings.ts
+++ b/packages/hub/src/wallet/models/channelHoldings.ts
@@ -1,6 +1,5 @@
-import {Uint256} from 'fmg-core';
+import {Uint256, Address} from '../../types';
 import {Model, snakeCaseMappers} from 'objection';
-import {Address} from '../../types';
 
 export default class ChannelHolding extends Model {
   static tableName = 'channel_holdings';

--- a/packages/hub/src/wallet/models/channelState.ts
+++ b/packages/hub/src/wallet/models/channelState.ts
@@ -1,5 +1,5 @@
 import {State} from '@statechannels/nitro-protocol';
-import {Uint32} from 'fmg-core';
+import {Uint32} from '../../types';
 import {Model, snakeCaseMappers} from 'objection';
 import Channel from './channel';
 import Outcome from './outcome';

--- a/packages/hub/src/wallet/models/outcome.ts
+++ b/packages/hub/src/wallet/models/outcome.ts
@@ -1,6 +1,6 @@
 import {AllocationAssetOutcome} from '@statechannels/nitro-protocol/lib/src/contract/outcome';
 import {AssetOutcome, GuaranteeAssetOutcome} from '@statechannels/nitro-protocol';
-import {Address} from 'fmg-core';
+import {Address} from '../../types';
 import {Model, snakeCaseMappers} from 'objection';
 import Allocation from './allocation';
 import ChannelState from './channelState';

--- a/packages/hub/src/wallet/models/rule.ts
+++ b/packages/hub/src/wallet/models/rule.ts
@@ -1,4 +1,4 @@
-import {Address} from 'fmg-core';
+import {Address} from '../../types';
 import {Model} from 'objection';
 import Channel from './channel';
 

--- a/packages/hub/src/wallet/services/__test__/depositManager.test.ts
+++ b/packages/hub/src/wallet/services/__test__/depositManager.test.ts
@@ -1,5 +1,5 @@
 import {bigNumberify} from 'ethers/utils';
-import {Uint256} from 'fmg-core';
+import {Uint256} from '../../../types';
 import {DUMMY_ASSET_HOLDER_ADDRESS} from '../../../test/test-constants';
 import {FUNDED_CHANNEL_ID, UNFUNDED_CHANNEL_ID} from '../../../test/test-data';
 import Channel from '../../models/channel';

--- a/packages/hub/src/wallet/services/applicationManager.ts
+++ b/packages/hub/src/wallet/services/applicationManager.ts
@@ -1,4 +1,4 @@
-import {Address} from 'fmg-core';
+import {Address} from '../../types';
 import Rule from '../models/rule';
 
 interface Application {

--- a/packages/hub/src/wallet/services/asset-holder-watcher.ts
+++ b/packages/hub/src/wallet/services/asset-holder-watcher.ts
@@ -1,5 +1,5 @@
 import {ethers} from 'ethers';
-import {Address, Uint256} from 'fmg-core';
+import {Address, Uint256} from '../../types';
 import {ethAssetHolder as ethAssetHolderConstrutor} from '../utilities/blockchain';
 import {logger} from '../../logger';
 

--- a/packages/hub/src/wallet/services/blockchain.ts
+++ b/packages/hub/src/wallet/services/blockchain.ts
@@ -1,5 +1,5 @@
 import AsyncLock from 'async-lock';
-import {Address, Uint256} from 'fmg-core';
+import {Address, Uint256} from '../../types';
 import {ethAssetHolder} from '../utilities/blockchain';
 
 const lock = new AsyncLock();

--- a/packages/hub/src/wallet/services/index.ts
+++ b/packages/hub/src/wallet/services/index.ts
@@ -1,5 +1,5 @@
 import {SignedState, State} from '@statechannels/nitro-protocol';
-import {Address, Uint256} from 'fmg-core';
+import {Address, Uint256} from '../../types';
 import {Blockchain} from './blockchain';
 import * as LedgerChannelManager from './ledgerChannelManager';
 

--- a/packages/rps/package.json
+++ b/packages/rps/package.json
@@ -65,7 +65,6 @@
     "enum": "^2.5.0",
     "ethers": "^4.0.39",
     "firebase": "^7.6.2",
-    "fmg-core": "0.5.9",
     "fs-extra": "3.0.1",
     "key-mirror": "^1.0.1",
     "lodash": "^4.17.10",

--- a/packages/rps/src/components/NavigationBar.tsx
+++ b/packages/rps/src/components/NavigationBar.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import {Button, Navbar} from 'reactstrap';
-import {Commitment} from 'fmg-core';
 import {RulesModal} from './RulesModal';
 import NetworkIndicator from '@rimble/network-indicator';
 import {MetamaskState} from 'src/redux/metamask/state';
@@ -19,7 +18,7 @@ function getInitials(loginDisplayName: string): string {
   return userDisplayName.map(name => name.charAt(0)).join('');
 }
 
-export default class NavigationBar extends React.PureComponent<Props, Commitment> {
+export default class NavigationBar extends React.PureComponent<Props> {
   render() {
     const currentNetwork = Number(this.props.metamaskState.network);
     const targetNetwork = Number(process.env.CHAIN_NETWORK_ID);

--- a/packages/rps/src/components/OpenGameCard.tsx
+++ b/packages/rps/src/components/OpenGameCard.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {Commitment} from 'fmg-core';
 import {Button} from 'reactstrap';
 import {OpenGame} from '../redux/open-games/state';
 import {bigNumberify, formatUnits} from 'ethers/utils';
@@ -15,7 +14,7 @@ interface Props {
   ) => void;
 }
 
-export class OpenGameEntry extends React.PureComponent<Props, Commitment> {
+export class OpenGameEntry extends React.PureComponent<Props> {
   render() {
     // Generate a random number from 0 to MaxInt
     const {openGame, joinOpenGame} = this.props;

--- a/packages/tic-tac-toe/package.json
+++ b/packages/tic-tac-toe/package.json
@@ -54,7 +54,6 @@
     "enum": "^2.5.0",
     "ethers": "^4.0.39",
     "firebase": "^7.5.2",
-    "fmg-core": "0.5.9",
     "fs-extra": "3.0.1",
     "key-mirror": "^1.0.1",
     "lodash": "^4.17.10",

--- a/packages/tic-tac-toe/package.json
+++ b/packages/tic-tac-toe/package.json
@@ -57,7 +57,6 @@
     "fs-extra": "3.0.1",
     "key-mirror": "^1.0.1",
     "lodash": "^4.17.10",
-    "magmo-wallet-client": "0.0.3",
     "nanoid": "^1.0.3",
     "npm-run-all": "4.1.5",
     "object-assign": "4.1.1",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -81,7 +81,6 @@
     "redux-storage-decorator-filter": "1.1.8",
     "redux-storage-engine-indexed-db": "1.0.0",
     "resolve": "1.6.0",
-    "web3-utils": "1.2.2",
     "webpack": "4.29.5",
     "webpack-dev-server": "3.1.14",
     "webpack-manifest-plugin": "2.0.4",
@@ -185,7 +184,6 @@
     "uglifyjs-webpack-plugin": "2.2.0",
     "url-loader": "2.2.0",
     "wait-on": "3.3.0",
-    "web3": "1.2.4",
     "workbox-webpack-plugin": "4.3.1"
   },
   "lint-staged": {

--- a/packages/wallet/src/redux/protocols/withdrawing/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/withdrawing/__tests__/scenarios.ts
@@ -6,8 +6,8 @@ import {ChannelState, ChannelStore} from "../../../channel-store";
 
 import {Wallet} from "ethers";
 import {EMPTY_SHARED_DATA, SharedData} from "../../../state";
-import * as web3Utils from "web3-utils";
 import * as testScenarios from "../../../__tests__/state-helpers";
+import {parseEther} from "ethers/utils";
 
 // ---------
 // Test data
@@ -63,7 +63,7 @@ const transaction = {};
 const withdrawalAddress = Wallet.createRandom().address;
 const processId = "process-id.123";
 const sharedData: SharedData = {...EMPTY_SHARED_DATA, channelStore, bytecodeStorage};
-const withdrawalAmount = web3Utils.toWei("5");
+const withdrawalAmount = parseEther("5").toString();
 const transactionSubmissionState = transactionScenarios.preSuccessState;
 const props = {
   transaction,

--- a/packages/xstate-wallet/package.json
+++ b/packages/xstate-wallet/package.json
@@ -28,6 +28,7 @@
     "@types/react": "16.9.19",
     "@types/react-dom": "16.9.5",
     "@types/webpack": "4.41.0",
+    "@types/webpack-merge": "4.1.5",
     "source-map-loader": "0.2.4",
     "typescript": "3.7.4",
     "webpack": "4.41.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13491,7 +13491,7 @@ ethers@4.0.0-beta.3:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@4.0.39, ethers@^4.0.26, ethers@^4.0.27, ethers@^4.0.39, ethers@~4.0.4:
+ethers@4.0.39, ethers@^4.0.27, ethers@^4.0.39, ethers@~4.0.4:
   version "4.0.39"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.39.tgz#5ce9dfffedb03936415743f63b37d96280886a47"
   integrity sha512-QVtC8TTUgTrnlQjQvdFJ7fkSWKwp8HVTbKRmrdbVryrPzJHMTf3WSeRNvLF2enGyAFtyHJyFNnjN0fSshcEr9w==
@@ -14493,20 +14493,6 @@ flush-write-stream@^2.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
-
-fmg-core@0.5.6:
-  version "0.5.6"
-  resolved "https://registry.npmjs.org/fmg-core/-/fmg-core-0.5.6.tgz#2a895b10f8fc6fe75bdd6ab320e1c97e483a92d2"
-  integrity sha512-aHWDk73c23X5n2T5LzCCDDX1ker2JVlR3wmdqN/nAgCLeNEeGUPH8fYYFAQv3wxXDXEBk8boeS5KWiVBjlgjpA==
-  dependencies:
-    bn.js "^4.11.8"
-    ethers "^4.0.26"
-    sha3 "^1.2.2"
-    web3 "1.0.0-beta.37"
-    web3-eth-abi "1.0.0-beta.37"
-    web3-eth-accounts "1.0.0-beta.37"
-    web3-utils "1.0.0-beta.37"
-    websocket "^1.0.28"
 
 focus-lock@^0.6.3:
   version "0.6.5"
@@ -19340,15 +19326,6 @@ magic-string@^0.22.4:
   integrity sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==
   dependencies:
     vlq "^0.2.2"
-
-magmo-wallet-client@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/magmo-wallet-client/-/magmo-wallet-client-0.0.3.tgz#4ebc0de83fbceb11dae37f7275717c4f3d7acb15"
-  integrity sha512-tCxj/diU5++y1ICEJk3PkAHErsm1Q0SLWPELkzXpoIZaziszpvMvyhUEEHeewmnadEVsJY2vDFDwFvGvsg1YFw==
-  dependencies:
-    bn.js "4.11.8"
-    eventemitter2 "5.0.1"
-    fmg-core "0.5.6"
 
 magnet-uri@^5.1.3:
   version "5.2.4"
@@ -30464,16 +30441,6 @@ websocket@1.0.29, "websocket@github:web3-js/WebSocket-Node#polyfill/globalThis":
   dependencies:
     debug "^2.2.0"
     es5-ext "^0.10.50"
-    nan "^2.14.0"
-    typedarray-to-buffer "^3.1.5"
-    yaeti "^0.0.6"
-
-websocket@^1.0.28:
-  version "1.0.30"
-  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.30.tgz#91d3bd00c3d43e916f0cf962f8f8c451bb0b2373"
-  integrity sha512-aO6klgaTdSMkhfl5VVJzD5fm+Srhh5jLYbS15+OiI1sN6h/RU/XW6WN9J1uVIpUKNmsTvT3Hs35XAFjn9NMfOw==
-  dependencies:
-    debug "^2.2.0"
     nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4482,13 +4482,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/bignumber.js@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-5.0.0.tgz#d9f1a378509f3010a3255e9cc822ad0eeb4ab969"
-  integrity sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==
-  dependencies:
-    bignumber.js "*"
-
 "@types/bittorrent-protocol@*":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@types/bittorrent-protocol/-/bittorrent-protocol-2.2.3.tgz#522f30db08695e14df4ca3fc6495431f27c72f70"
@@ -5088,11 +5081,6 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-12.12.24.tgz#d4606afd8cf6c609036b854360367d1b2c78931f"
   integrity sha512-1Ciqv9pqwVtW6FsIUKSZNB82E5Cu1I2bBTj1xuIHXLe/1zYLl3956Nbhg2MzSYHVfl9/rmanjbQIb7LibfCnug==
 
-"@types/node@^12.6.1":
-  version "12.12.11"
-  resolved "https://registry.npmjs.org/@types/node/-/node-12.12.11.tgz#bec2961975888d964196bf0016a2f984d793d3ce"
-  integrity sha512-O+x6uIpa6oMNTkPuHDa9MhMMehlxLAd5QcOvKRjAFsBVpeFWTOPnXbDvILvFgFFZfQ1xh1EZi1FbXxUix+zpsQ==
-
 "@types/node@^13.1.6":
   version "13.1.6"
   resolved "https://registry.npmjs.org/@types/node/-/node-13.1.6.tgz#076028d0b0400be8105b89a0a55550c86684ffec"
@@ -5585,6 +5573,13 @@
   dependencies:
     "@types/webpack" "*"
 
+"@types/webpack-merge@4.1.5":
+  version "4.1.5"
+  resolved "https://registry.npmjs.org/@types/webpack-merge/-/webpack-merge-4.1.5.tgz#265fbee4810474860d0f4c17e0107032881eed47"
+  integrity sha512-cbDo592ljSHeaVe5Q39JKN6Z4vMhmo4+C3JbksOIg+kjhKQYN2keGN7dvr/i18+dughij98Qrsfn1mU9NgVoCA==
+  dependencies:
+    "@types/webpack" "*"
+
 "@types/webpack-sources@*":
   version "0.1.5"
   resolved "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-0.1.5.tgz#be47c10f783d3d6efe1471ff7f042611bd464a92"
@@ -5841,25 +5836,6 @@
     lodash "^4.17.15"
     semver "^6.3.0"
     tsutils "^3.17.1"
-
-"@web3-js/scrypt-shim@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/@web3-js/scrypt-shim/-/scrypt-shim-0.1.0.tgz#0bf7529ab6788311d3e07586f7d89107c3bea2cc"
-  integrity sha512-ZtZeWCc/s0nMcdx/+rZwY1EcuRdemOK9ag21ty9UsHkFxsNb/AaoucUz0iPuyGe0Ku+PFuRmWZG7Z7462p9xPw==
-  dependencies:
-    scryptsy "^2.1.0"
-    semver "^6.3.0"
-
-"@web3-js/websocket@^1.0.29":
-  version "1.0.30"
-  resolved "https://registry.npmjs.org/@web3-js/websocket/-/websocket-1.0.30.tgz#9ea15b7b582cf3bf3e8bc1f4d3d54c0731a87f87"
-  integrity sha512-fDwrD47MiDrzcJdSeTLF75aCcxVVt8B1N74rA+vh2XCAvFy4tEWJjtnUtj2QG7/zlQ6g9cQ88bZFBxwd9/FmtA==
-  dependencies:
-    debug "^2.2.0"
-    es5-ext "^0.10.50"
-    nan "^2.14.0"
-    typedarray-to-buffer "^3.1.5"
-    yaeti "^0.0.6"
 
 "@webassemblyjs/ast@1.8.3":
   version "1.8.3"
@@ -8154,11 +8130,6 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
-
-bignumber.js@*:
-  version "9.0.0"
-  resolved "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
-  integrity sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==
 
 bignumber.js@7.2.1:
   version "7.2.1"
@@ -13195,13 +13166,6 @@ ethereum-blockies@^0.1.1:
   resolved "https://registry.npmjs.org/ethereum-blockies/-/ethereum-blockies-0.1.1.tgz#879fe959deef492a7a92b43dc34ae8dc2ee591fc"
   integrity sha1-h5/pWd7vSSp6krQ9w0ro3C7lkfw=
 
-ethereum-bloom-filters@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.6.tgz#9cdebb3ec20de96ec4a434c6bad6ea5a513037aa"
-  integrity sha512-dE9CGNzgOOsdh7msZirvv8qjHtnHpvBlKe2647kM8v+yeF71IRso55jpojemvHV+jMjr48irPWxMRaHuOWzAFA==
-  dependencies:
-    js-sha3 "^0.8.0"
-
 ethereum-common@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/ethereum-common/-/ethereum-common-0.2.0.tgz#13bf966131cce1eeade62a1b434249bb4cb120ca"
@@ -13327,11 +13291,6 @@ ethereumjs-common@^1.1.0:
   resolved "https://registry.yarnpkg.com/ethereumjs-common/-/ethereumjs-common-1.3.2.tgz#5a20831e52199a31ff4b68ef361e34c05c976ed0"
   integrity sha512-GkltYRIqBLzaZLmF/K3E+g9lZ4O4FL+TtpisAlD3N+UVlR+mrtoG+TvxavqVa6PwOY4nKIEMe5pl6MrTio3Lww==
 
-ethereumjs-common@^1.3.1, ethereumjs-common@^1.3.2:
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.4.0.tgz#a940685f88f3c2587e4061630fe720b089c965b8"
-  integrity sha512-ser2SAplX/YI5W2AnzU8wmSjKRy4KQd4uxInJ36BzjS3m18E/B9QedPUIresZN1CSEQb/RgNQ2gN7C/XbpTafA==
-
 ethereumjs-tx@1.3.7, ethereumjs-tx@^1.1.1, ethereumjs-tx@^1.2.0, ethereumjs-tx@^1.2.2, ethereumjs-tx@^1.3.3, ethereumjs-tx@^1.3.5:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz#88323a2d875b10549b8347e09f4862b546f3d89a"
@@ -13339,14 +13298,6 @@ ethereumjs-tx@1.3.7, ethereumjs-tx@^1.1.1, ethereumjs-tx@^1.2.0, ethereumjs-tx@^
   dependencies:
     ethereum-common "^0.0.18"
     ethereumjs-util "^5.0.0"
-
-ethereumjs-tx@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.1.tgz#7d204e2b319156c9bc6cec67e9529424a26e8ccc"
-  integrity sha512-QtVriNqowCFA19X9BCRPMgdVNJ0/gMBS91TQb1DfrhsbR748g4STwxZptFAwfqehMyrF8rDwB23w87PQwru0wA==
-  dependencies:
-    ethereumjs-common "^1.3.1"
-    ethereumjs-util "^6.0.0"
 
 ethereumjs-util@6.1.0, ethereumjs-util@^6.0.0:
   version "6.1.0"
@@ -14547,20 +14498,6 @@ fmg-core@0.5.6:
   version "0.5.6"
   resolved "https://registry.npmjs.org/fmg-core/-/fmg-core-0.5.6.tgz#2a895b10f8fc6fe75bdd6ab320e1c97e483a92d2"
   integrity sha512-aHWDk73c23X5n2T5LzCCDDX1ker2JVlR3wmdqN/nAgCLeNEeGUPH8fYYFAQv3wxXDXEBk8boeS5KWiVBjlgjpA==
-  dependencies:
-    bn.js "^4.11.8"
-    ethers "^4.0.26"
-    sha3 "^1.2.2"
-    web3 "1.0.0-beta.37"
-    web3-eth-abi "1.0.0-beta.37"
-    web3-eth-accounts "1.0.0-beta.37"
-    web3-utils "1.0.0-beta.37"
-    websocket "^1.0.28"
-
-fmg-core@0.5.9:
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/fmg-core/-/fmg-core-0.5.9.tgz#9feee0ce880d2cb6d59985116d01acc9eab90a95"
-  integrity sha512-YpEPex8mqzRZFMFXl4HdBxQIWY+gOePROQ1OwBMBZKSECOv+OfKAiVYay6CRJKHBK47e1GExCV5kDch0VMzkHw==
   dependencies:
     bn.js "^4.11.8"
     ethers "^4.0.26"
@@ -17924,7 +17861,7 @@ js-sha3@0.5.7, js-sha3@^0.5.7:
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
   integrity sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=
 
-js-sha3@0.8.0, js-sha3@^0.8.0:
+js-sha3@0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
   integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
@@ -24281,7 +24218,7 @@ random-iterate@^1.0.1:
   resolved "https://registry.yarnpkg.com/random-iterate/-/random-iterate-1.0.1.tgz#f7d97d92dee6665ec5f6da08c7f963cad4b2ac99"
   integrity sha1-99l9kt7mZl7F9toIx/ljytSyrJk=
 
-randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.3, randombytes@^2.0.5, randombytes@^2.0.6, randombytes@^2.1.0:
+randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.3, randombytes@^2.0.5, randombytes@^2.0.6:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
@@ -26270,7 +26207,7 @@ scrypt@^6.0.2:
   dependencies:
     nan "^2.0.8"
 
-scryptsy@2.1.0, scryptsy@^2.1.0:
+scryptsy@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/scryptsy/-/scryptsy-2.1.0.tgz#8d1e8d0c025b58fdd25b6fa9a0dc905ee8faa790"
   integrity sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==
@@ -29678,16 +29615,6 @@ web3-bzz@1.2.1:
     swarm-js "0.1.39"
     underscore "1.9.1"
 
-web3-bzz@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.4.tgz#a4adb7a8cba3d260de649bdb1f14ed359bfb3821"
-  integrity sha512-MqhAo/+0iQSMBtt3/QI1rU83uvF08sYq8r25+OUZ+4VtihnYsmkkca+rdU0QbRyrXY2/yGIpI46PFdh0khD53A==
-  dependencies:
-    "@types/node" "^10.12.18"
-    got "9.6.0"
-    swarm-js "0.1.39"
-    underscore "1.9.1"
-
 web3-core-helpers@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.37.tgz#04ec354b7f5c57234c309eea2bda9bf1f2fe68ba"
@@ -29705,15 +29632,6 @@ web3-core-helpers@1.2.1:
     underscore "1.9.1"
     web3-eth-iban "1.2.1"
     web3-utils "1.2.1"
-
-web3-core-helpers@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.4.tgz#ffd425861f4d66b3f38df032afdb39ea0971fc0f"
-  integrity sha512-U7wbsK8IbZvF3B7S+QMSNP0tni/6VipnJkB0tZVEpHEIV2WWeBHYmZDnULWcsS/x/jn9yKhJlXIxWGsEAMkjiw==
-  dependencies:
-    underscore "1.9.1"
-    web3-eth-iban "1.2.4"
-    web3-utils "1.2.4"
 
 web3-core-method@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -29737,17 +29655,6 @@ web3-core-method@1.2.1:
     web3-core-subscriptions "1.2.1"
     web3-utils "1.2.1"
 
-web3-core-method@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.4.tgz#a0fbc50b8ff5fd214021435cc2c6d1e115807aed"
-  integrity sha512-8p9kpL7di2qOVPWgcM08kb+yKom0rxRCMv6m/K+H+yLSxev9TgMbCgMSbPWAHlyiF3SJHw7APFKahK5Z+8XT5A==
-  dependencies:
-    underscore "1.9.1"
-    web3-core-helpers "1.2.4"
-    web3-core-promievent "1.2.4"
-    web3-core-subscriptions "1.2.4"
-    web3-utils "1.2.4"
-
 web3-core-promievent@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.37.tgz#4e51c469d0a7ac0a969885a4dbcde8504abe5b02"
@@ -29760,14 +29667,6 @@ web3-core-promievent@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.2.1.tgz#003e8a3eb82fb27b6164a6d5b9cad04acf733838"
   integrity sha512-IVUqgpIKoeOYblwpex4Hye6npM0aMR+kU49VP06secPeN0rHMyhGF0ZGveWBrGvf8WDPI7jhqPBFIC6Jf3Q3zw==
-  dependencies:
-    any-promise "1.3.0"
-    eventemitter3 "3.1.2"
-
-web3-core-promievent@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz#75e5c0f2940028722cdd21ba503ebd65272df6cb"
-  integrity sha512-gEUlm27DewUsfUgC3T8AxkKi8Ecx+e+ZCaunB7X4Qk3i9F4C+5PSMGguolrShZ7Zb6717k79Y86f3A00O0VAZw==
   dependencies:
     any-promise "1.3.0"
     eventemitter3 "3.1.2"
@@ -29794,17 +29693,6 @@ web3-core-requestmanager@1.2.1:
     web3-providers-ipc "1.2.1"
     web3-providers-ws "1.2.1"
 
-web3-core-requestmanager@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.4.tgz#0a7020a23fb91c6913c611dfd3d8c398d1e4b4a8"
-  integrity sha512-eZJDjyNTDtmSmzd3S488nR/SMJtNnn/GuwxnMh3AzYCqG3ZMfOylqTad2eYJPvc2PM5/Gj1wAMQcRpwOjjLuPg==
-  dependencies:
-    underscore "1.9.1"
-    web3-core-helpers "1.2.4"
-    web3-providers-http "1.2.4"
-    web3-providers-ipc "1.2.4"
-    web3-providers-ws "1.2.4"
-
 web3-core-subscriptions@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.37.tgz#40de5e2490cc05b15faa8f935c97fd48d670cd9a"
@@ -29822,15 +29710,6 @@ web3-core-subscriptions@1.2.1:
     eventemitter3 "3.1.2"
     underscore "1.9.1"
     web3-core-helpers "1.2.1"
-
-web3-core-subscriptions@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.4.tgz#0dc095b5cfd82baa527a39796e3515a846b21b99"
-  integrity sha512-3D607J2M8ymY9V+/WZq4MLlBulwCkwEjjC2U+cXqgVO1rCyVqbxZNCmHyNYHjDDCxSEbks9Ju5xqJxDSxnyXEw==
-  dependencies:
-    eventemitter3 "3.1.2"
-    underscore "1.9.1"
-    web3-core-helpers "1.2.4"
 
 web3-core@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -29851,19 +29730,6 @@ web3-core@1.2.1:
     web3-core-method "1.2.1"
     web3-core-requestmanager "1.2.1"
     web3-utils "1.2.1"
-
-web3-core@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-core/-/web3-core-1.2.4.tgz#2df13b978dcfc59c2abaa887d27f88f21ad9a9d6"
-  integrity sha512-CHc27sMuET2cs1IKrkz7xzmTdMfZpYswe7f0HcuyneTwS1yTlTnHyqjAaTy0ZygAb/x4iaVox+Gvr4oSAqSI+A==
-  dependencies:
-    "@types/bignumber.js" "^5.0.0"
-    "@types/bn.js" "^4.11.4"
-    "@types/node" "^12.6.1"
-    web3-core-helpers "1.2.4"
-    web3-core-method "1.2.4"
-    web3-core-requestmanager "1.2.4"
-    web3-utils "1.2.4"
 
 web3-eth-abi@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -29892,15 +29758,6 @@ web3-eth-abi@1.2.1, web3-eth-abi@^1.0.0-beta.24:
     ethers "4.0.0-beta.3"
     underscore "1.9.1"
     web3-utils "1.2.1"
-
-web3-eth-abi@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.4.tgz#5b73e5ef70b03999227066d5d1310b168845e2b8"
-  integrity sha512-8eLIY4xZKoU3DSVu1pORluAw9Ru0/v4CGdw5so31nn+7fR8zgHMgwbFe0aOqWQ5VU42PzMMXeIJwt4AEi2buFg==
-  dependencies:
-    ethers "4.0.0-beta.3"
-    underscore "1.9.1"
-    web3-utils "1.2.4"
 
 web3-eth-accounts@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -29935,24 +29792,6 @@ web3-eth-accounts@1.2.1:
     web3-core-method "1.2.1"
     web3-utils "1.2.1"
 
-web3-eth-accounts@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.4.tgz#ada6edc49542354328a85cafab067acd7f88c288"
-  integrity sha512-04LzT/UtWmRFmi4hHRewP5Zz43fWhuHiK5XimP86sUQodk/ByOkXQ3RoXyGXFMNoRxdcAeRNxSfA2DpIBc9xUw==
-  dependencies:
-    "@web3-js/scrypt-shim" "^0.1.0"
-    any-promise "1.3.0"
-    crypto-browserify "3.12.0"
-    eth-lib "0.2.7"
-    ethereumjs-common "^1.3.2"
-    ethereumjs-tx "^2.1.1"
-    underscore "1.9.1"
-    uuid "3.3.2"
-    web3-core "1.2.4"
-    web3-core-helpers "1.2.4"
-    web3-core-method "1.2.4"
-    web3-utils "1.2.4"
-
 web3-eth-contract@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.37.tgz#87f93c95ed16f320ba54943b7886890de6766013"
@@ -29980,21 +29819,6 @@ web3-eth-contract@1.2.1:
     web3-core-subscriptions "1.2.1"
     web3-eth-abi "1.2.1"
     web3-utils "1.2.1"
-
-web3-eth-contract@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.4.tgz#68ef7cc633232779b0a2c506a810fbe903575886"
-  integrity sha512-b/9zC0qjVetEYnzRA1oZ8gF1OSSUkwSYi5LGr4GeckLkzXP7osEnp9lkO/AQcE4GpG+l+STnKPnASXJGZPgBRQ==
-  dependencies:
-    "@types/bn.js" "^4.11.4"
-    underscore "1.9.1"
-    web3-core "1.2.4"
-    web3-core-helpers "1.2.4"
-    web3-core-method "1.2.4"
-    web3-core-promievent "1.2.4"
-    web3-core-subscriptions "1.2.4"
-    web3-eth-abi "1.2.4"
-    web3-utils "1.2.4"
 
 web3-eth-ens@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -30024,20 +29848,6 @@ web3-eth-ens@1.2.1:
     web3-eth-contract "1.2.1"
     web3-utils "1.2.1"
 
-web3-eth-ens@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.4.tgz#b95b3aa99fb1e35c802b9e02a44c3046a3fa065e"
-  integrity sha512-g8+JxnZlhdsCzCS38Zm6R/ngXhXzvc3h7bXlxgKU4coTzLLoMpgOAEz71GxyIJinWTFbLXk/WjNY0dazi9NwVw==
-  dependencies:
-    eth-ens-namehash "2.0.8"
-    underscore "1.9.1"
-    web3-core "1.2.4"
-    web3-core-helpers "1.2.4"
-    web3-core-promievent "1.2.4"
-    web3-eth-abi "1.2.4"
-    web3-eth-contract "1.2.4"
-    web3-utils "1.2.4"
-
 web3-eth-iban@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.37.tgz#313a3f18ae2ab00ba98678ea1156b09ef32a3655"
@@ -30053,14 +29863,6 @@ web3-eth-iban@1.2.1:
   dependencies:
     bn.js "4.11.8"
     web3-utils "1.2.1"
-
-web3-eth-iban@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.4.tgz#8e0550fd3fd8e47a39357d87fe27dee9483ee476"
-  integrity sha512-D9HIyctru/FLRpXakRwmwdjb5bWU2O6UE/3AXvRm6DCOf2e+7Ve11qQrPtaubHfpdW3KWjDKvlxV9iaFv/oTMQ==
-  dependencies:
-    bn.js "4.11.8"
-    web3-utils "1.2.4"
 
 web3-eth-personal@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -30083,18 +29885,6 @@ web3-eth-personal@1.2.1:
     web3-core-method "1.2.1"
     web3-net "1.2.1"
     web3-utils "1.2.1"
-
-web3-eth-personal@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.4.tgz#3224cca6851c96347d9799b12c1b67b2a6eb232b"
-  integrity sha512-5Russ7ZECwHaZXcN3DLuLS7390Vzgrzepl4D87SD6Sn1DHsCZtvfdPIYwoTmKNp69LG3mORl7U23Ga5YxqkICw==
-  dependencies:
-    "@types/node" "^12.6.1"
-    web3-core "1.2.4"
-    web3-core-helpers "1.2.4"
-    web3-core-method "1.2.4"
-    web3-net "1.2.4"
-    web3-utils "1.2.4"
 
 web3-eth@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -30134,25 +29924,6 @@ web3-eth@1.2.1:
     web3-net "1.2.1"
     web3-utils "1.2.1"
 
-web3-eth@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.4.tgz#24c3b1f1ac79351bbfb808b2ab5c585fa57cdd00"
-  integrity sha512-+j+kbfmZsbc3+KJpvHM16j1xRFHe2jBAniMo1BHKc3lho6A8Sn9Buyut6odubguX2AxoRArCdIDCkT9hjUERpA==
-  dependencies:
-    underscore "1.9.1"
-    web3-core "1.2.4"
-    web3-core-helpers "1.2.4"
-    web3-core-method "1.2.4"
-    web3-core-subscriptions "1.2.4"
-    web3-eth-abi "1.2.4"
-    web3-eth-accounts "1.2.4"
-    web3-eth-contract "1.2.4"
-    web3-eth-ens "1.2.4"
-    web3-eth-iban "1.2.4"
-    web3-eth-personal "1.2.4"
-    web3-net "1.2.4"
-    web3-utils "1.2.4"
-
 web3-net@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.0.0-beta.37.tgz#b494136043f3c6ba84fe4a47d4c028c2a63c9a8e"
@@ -30170,15 +29941,6 @@ web3-net@1.2.1:
     web3-core "1.2.1"
     web3-core-method "1.2.1"
     web3-utils "1.2.1"
-
-web3-net@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-net/-/web3-net-1.2.4.tgz#1d246406d3aaffbf39c030e4e98bce0ca5f25458"
-  integrity sha512-wKOsqhyXWPSYTGbp7ofVvni17yfRptpqoUdp3SC8RAhDmGkX6irsiT9pON79m6b3HUHfLoBilFQyt/fTUZOf7A==
-  dependencies:
-    web3-core "1.2.4"
-    web3-core-method "1.2.4"
-    web3-utils "1.2.4"
 
 web3-provider-engine@14.0.6:
   version "14.0.6"
@@ -30247,14 +30009,6 @@ web3-providers-http@1.2.1:
     web3-core-helpers "1.2.1"
     xhr2-cookies "1.1.0"
 
-web3-providers-http@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.4.tgz#514fcad71ae77832c2c15574296282fbbc5f4a67"
-  integrity sha512-dzVCkRrR/cqlIrcrWNiPt9gyt0AZTE0J+MfAu9rR6CyIgtnm1wFUVVGaxYRxuTGQRO4Dlo49gtoGwaGcyxqiTw==
-  dependencies:
-    web3-core-helpers "1.2.4"
-    xhr2-cookies "1.1.0"
-
 web3-providers-ipc@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.37.tgz#55d247e7197257ca0c3e4f4b0fe1561311b9d5b9"
@@ -30273,15 +30027,6 @@ web3-providers-ipc@1.2.1:
     underscore "1.9.1"
     web3-core-helpers "1.2.1"
 
-web3-providers-ipc@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.4.tgz#9d6659f8d44943fb369b739f48df09092be459bd"
-  integrity sha512-8J3Dguffin51gckTaNrO3oMBo7g+j0UNk6hXmdmQMMNEtrYqw4ctT6t06YOf9GgtOMjSAc1YEh3LPrvgIsR7og==
-  dependencies:
-    oboe "2.1.4"
-    underscore "1.9.1"
-    web3-core-helpers "1.2.4"
-
 web3-providers-ws@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.37.tgz#77c15aebc00b75d760d22d063ac2e415bdbef72f"
@@ -30299,15 +30044,6 @@ web3-providers-ws@1.2.1:
     underscore "1.9.1"
     web3-core-helpers "1.2.1"
     websocket "github:web3-js/WebSocket-Node#polyfill/globalThis"
-
-web3-providers-ws@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.4.tgz#099ee271ee03f6ea4f5df9cfe969e83f4ce0e36f"
-  integrity sha512-F/vQpDzeK+++oeeNROl1IVTufFCwCR2hpWe5yRXN0ApLwHqXrMI7UwQNdJ9iyibcWjJf/ECbauEEQ8CHgE+MYQ==
-  dependencies:
-    "@web3-js/websocket" "^1.0.29"
-    underscore "1.9.1"
-    web3-core-helpers "1.2.4"
 
 web3-shh@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -30328,16 +30064,6 @@ web3-shh@1.2.1:
     web3-core-method "1.2.1"
     web3-core-subscriptions "1.2.1"
     web3-net "1.2.1"
-
-web3-shh@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.4.tgz#5c8ff5ab624a3b14f08af0d24d2b16c10e9f70dd"
-  integrity sha512-z+9SCw0dE+69Z/Hv8809XDbLj7lTfEv9Sgu8eKEIdGntZf4v7ewj5rzN5bZZSz8aCvfK7Y6ovz1PBAu4QzS4IQ==
-  dependencies:
-    web3-core "1.2.4"
-    web3-core-method "1.2.4"
-    web3-core-subscriptions "1.2.4"
-    web3-net "1.2.4"
 
 web3-utils@1.0.0-beta.37:
   version "1.0.0-beta.37"
@@ -30381,34 +30107,6 @@ web3-utils@1.2.1:
     underscore "1.9.1"
     utf8 "3.0.0"
 
-web3-utils@1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.2.2.tgz#b53a08c40d2c3f31d3c4a28e7d749405df99c8c0"
-  integrity sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==
-  dependencies:
-    bn.js "4.11.8"
-    eth-lib "0.2.7"
-    ethereum-bloom-filters "^1.0.6"
-    ethjs-unit "0.1.6"
-    number-to-bn "1.7.0"
-    randombytes "^2.1.0"
-    underscore "1.9.1"
-    utf8 "3.0.0"
-
-web3-utils@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.4.tgz#96832a39a66b05bf8862a5b0bdad2799d709d951"
-  integrity sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==
-  dependencies:
-    bn.js "4.11.8"
-    eth-lib "0.2.7"
-    ethereum-bloom-filters "^1.0.6"
-    ethjs-unit "0.1.6"
-    number-to-bn "1.7.0"
-    randombytes "^2.1.0"
-    underscore "1.9.1"
-    utf8 "3.0.0"
-
 web3@1.0.0-beta.37:
   version "1.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/web3/-/web3-1.0.0-beta.37.tgz#b42c30e67195f816cd19d048fda872f70eca7083"
@@ -30434,20 +30132,6 @@ web3@1.2.1:
     web3-net "1.2.1"
     web3-shh "1.2.1"
     web3-utils "1.2.1"
-
-web3@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/web3/-/web3-1.2.4.tgz#6e7ab799eefc9b4648c2dab63003f704a1d5e7d9"
-  integrity sha512-xPXGe+w0x0t88Wj+s/dmAdASr3O9wmA9mpZRtixGZxmBexAF0MjfqYM+MS4tVl5s11hMTN3AZb8cDD4VLfC57A==
-  dependencies:
-    "@types/node" "^12.6.1"
-    web3-bzz "1.2.4"
-    web3-core "1.2.4"
-    web3-eth "1.2.4"
-    web3-eth-personal "1.2.4"
-    web3-net "1.2.4"
-    web3-shh "1.2.4"
-    web3-utils "1.2.4"
 
 web3@^0.18.4:
   version "0.18.4"


### PR DESCRIPTION
I tried upgrading to Node 12.7.0 and hit an issue related [to this Github issue](https://github.com/ethereum/web3.js/issues/2913). I don't think we even need `scrypt` since we don't need `web3`... so removing these.