### PR TITLE
Get XState Wallet working

### DIFF
--- a/packages/wallet-protocols/src/store.ts
+++ b/packages/wallet-protocols/src/store.ts
@@ -271,16 +271,17 @@ export class Store implements IStore {
 
   protected updateEntry(channelId: string, states: SignedState[]): ChannelStoreEntry {
     const entry = this.getEntry(channelId);
-    this._store[channelId] = { ...entry, states: merge(states, entry.states) };
-    if (!Store.equals(states, entry.states)) {
+    const newEntry = { ...entry, states: merge(states, entry.states) };
+    this._store[channelId] = newEntry;
+    if (!Store.equals(entry.states, newEntry.states)) {
       const channelUpdated: ChannelUpdated = {
         type: 'CHANNEL_UPDATED',
         channelId,
-        entry,
+        entry: newEntry, // Send the updated entry
       };
       this._eventEmitter.emit(channelUpdated.type, channelUpdated);
     }
-    return new ChannelStoreEntry(this._store[channelId]);
+    return new ChannelStoreEntry(newEntry);
   }
 }
 


### PR DESCRIPTION
After changes to `ChannelUpdated` in  #907  the xstate wallet wasn't functioning correctly and `rps` would get stuck on funding. 

This PR gets the `xstate-wallet` back to the point that `rps` can be funded/played. 