### PR TITLE
Improve reliability of rps challenging scenario

### DIFF
--- a/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
@@ -44,7 +44,7 @@ describe('Playing a game of RPS', () => {
     }
   });
 
-  it('can play two games end to end in one tab session', async () => {
+  it('can play four games end to end in one tab session, two with challenges', async () => {
     await startAndFundRPSGame(rpsTabA, rpsTabB);
 
     await playMove(rpsTabA, 'rock');

--- a/packages/rps/src/redux/game/saga.ts
+++ b/packages/rps/src/redux/game/saga.ts
@@ -1,4 +1,4 @@
-import {select, call, put, take, actionChannel} from 'redux-saga/effects';
+import {select, call, put, putResolve, take, actionChannel} from 'redux-saga/effects';
 import {RPSChannelClient} from '../../utils/rps-channel-client';
 import {
   AppData,
@@ -302,7 +302,7 @@ function* calculateResultAndSendReveal(
     aOutcomeAddress,
     bOutcomeAddress
   );
-  yield put(a.updateChannelState(updatedChannelState));
+  yield putResolve(a.updateChannelState(updatedChannelState));
   yield put(a.resultArrived(theirWeapon, result, fundingSituation));
 }
 
@@ -355,7 +355,8 @@ function* closeChannel(channelState: ChannelState, client: RPSChannelClient) {
 }
 
 function* challengeChannel(channelId: string, client: RPSChannelClient) {
-  yield call([client, 'challengeChannel'], channelId);
+  const challengeState = yield call([client, 'challengeChannel'], channelId);
+  yield put(a.updateChannelState(challengeState));
 }
 
 const calculateFundingSituation = (

--- a/packages/wallet/src/redux/sagas/messaging/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-handler.ts
@@ -282,7 +282,7 @@ function* handleUpdateChannelMessage(payload: RequestObject) {
     if (
       protocolState &&
       protocolState.type === "Application.WaitForDispute" &&
-      typeof protocolState.disputeState! !== "undefined"
+      typeof protocolState.disputeState !== "undefined"
     ) {
       if (isResponderState(protocolState.disputeState)) {
         yield put(


### PR DESCRIPTION
I had been trying to make it the case that when you finish a challenge, the state can be updated despite the wallet process being in an `Application.WaitForDispute` state. This ended up causing race conditions not visible when testing against a fast local ganache network, but noticeable on Ropsten.

This PR gets rid of that feature, so if you want to continue a channel after a challenge, you need to click "Ok" on both prompts.