### PR TITLE
[rps, wallet] Handle challenging in various variations of rps state changes

### DIFF
--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -58,6 +58,13 @@ export async function setUpBrowser(headless: boolean, slowMo?: number): Promise<
     headless,
     slowMo,
     devtools: !headless,
+    // Keep code here for convenience... if you want to use redux-dev-tools
+    // then download and unzip the release from Github and specify the location.
+    // Github URL: https://github.com/zalmoxisus/redux-devtools-extension/releases
+    // args: [
+    //   '--disable-extensions-except=/Users/liam/Downloads/redux-dev-tools',
+    //   '--load-extension=/Users/liam/Downloads/redux-dev-tools'
+    // ],
     //, Needed to allow both windows to execute JS at the same time
     ignoreDefaultArgs: [
       '--disable-background-timer-throttling',

--- a/packages/nitro-protocol/src/contract/challenge.ts
+++ b/packages/nitro-protocol/src/contract/challenge.ts
@@ -131,7 +131,7 @@ export function getChallengeClearedEvent(tx: Transaction, eventResult): Challeng
       kind: 'respond',
       newStates: [signedState],
     };
-  } else if (decodedTransaction === 'checkpoint') {
+  } else if (decodedTransaction.name === 'checkpoint') {
     throw new Error('UnimplementedError');
   } else {
     throw new Error(

--- a/packages/rps/src/core/channel-state.ts
+++ b/packages/rps/src/core/channel-state.ts
@@ -34,6 +34,9 @@ export const isChallenging = (state: MaybeChannelState): state is ChannelState =
 export const isResponding = (state: MaybeChannelState): state is ChannelState =>
   (state && state.status === 'responding') || false;
 
+export const isChallengingOrResponding = (state: MaybeChannelState): state is ChannelState =>
+  isChallenging(state) || isResponding(state);
+
 export const isClosing = (state: MaybeChannelState): state is ChannelState =>
   (state && state.status === 'closing') || false;
 

--- a/packages/rps/src/redux/game/saga.ts
+++ b/packages/rps/src/redux/game/saga.ts
@@ -106,7 +106,7 @@ function* gameSagaRun(client: RPSChannelClient) {
       }
       break;
     case 'A.WeaponAndSaltChosen':
-      if (cs.inRoundAccepted(channelState)) {
+      if (cs.inRoundAccepted(channelState) && !cs.isChallengingOrResponding(channelState)) {
         yield* calculateResultAndSendReveal(localState, channelState, client);
       }
       break;

--- a/packages/wallet/src/redux/protocols/application/reducer.ts
+++ b/packages/wallet/src/redux/protocols/application/reducer.ts
@@ -84,7 +84,10 @@ function ownStateReceivedReducer(
     const updatedSharedData = {...sharedData, channelStore: signResult.store};
     return {
       sharedData: updatedSharedData,
-      protocolState: states.ongoing(protocolState)
+      protocolState:
+        protocolState.type === "Application.WaitForDispute"
+          ? protocolState
+          : states.ongoing(protocolState)
     };
   }
 }
@@ -107,7 +110,10 @@ function opponentStateReceivedReducer(
     const updatedSharedData = {...sharedData, channelStore: validateResult.store};
     return {
       sharedData: updatedSharedData,
-      protocolState: states.ongoing(protocolState)
+      protocolState:
+        protocolState.type === "Application.WaitForDispute"
+          ? protocolState
+          : states.ongoing(protocolState)
     };
   }
 }
@@ -197,7 +203,10 @@ const validateAndUpdate = (
       protocolState.participants,
       getAppDefinitionBytecode(sharedData, signedState.state.appDefinition)
     );
-  } else if (protocolState.type === "Application.Ongoing") {
+  } else if (
+    protocolState.type === "Application.Ongoing" ||
+    protocolState.type === "Application.WaitForDispute"
+  ) {
     return checkAndStore(
       sharedData.channelStore,
       signedState,

--- a/packages/wallet/src/redux/protocols/dispute/challenger/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/dispute/challenger/__tests__/reducer.test.ts
@@ -12,7 +12,10 @@ import {
   describeScenarioStep,
   itStoresThisState
 } from "../../../../__tests__/helpers";
-import {apiNotImplemented} from "../../../../sagas/messaging/outgoing-api-actions";
+import {
+  apiNotImplemented,
+  channelUpdatedEvent
+} from "../../../../sagas/messaging/outgoing-api-actions";
 
 describe("OPPONENT RESPONDS", () => {
   const scenario = scenarios.opponentResponds;
@@ -56,6 +59,7 @@ describe("OPPONENT RESPONDS", () => {
       expect((result.state as WaitForResponseOrTimeout).expiryTime).toEqual(action1.expiryTime);
     });
   });
+
   describeScenarioStep(scenario.waitForResponseOrTimeoutReceiveResponse, () => {
     const {state, action, signedState} = scenario.waitForResponseOrTimeoutReceiveResponse;
     const result = challengerReducer(state, sharedData, action);
@@ -71,7 +75,7 @@ describe("OPPONENT RESPONDS", () => {
     const result = challengerReducer(state, sharedData, action);
 
     itTransitionsTo(result, "Challenging.SuccessOpen");
-    itSendsThisMessage(result.sharedData, apiNotImplemented({apiMethod: "ChallengeComplete"}));
+    itSendsThisMessage(result.sharedData, channelUpdatedEvent({channelId}));
     itSendsThisDisplayEventType(result.sharedData, "Hide");
   });
 });

--- a/packages/wallet/src/redux/protocols/dispute/challenger/reducer.ts
+++ b/packages/wallet/src/redux/protocols/dispute/challenger/reducer.ts
@@ -74,7 +74,7 @@ export function challengerReducer(
     case "WALLET.DISPUTE.CHALLENGER.ACKNOWLEDGED":
       switch (state.type) {
         case "Challenging.AcknowledgeResponse":
-          return challengeResponseAcknowledged(state, sharedData);
+          return challengeResponseAcknowledged(state, sharedData, state.channelId);
         case "Challenging.AcknowledgeFailure":
           return challengeFailureAcknowledged(state, sharedData);
         case "Challenging.AcknowledgeTimeout":
@@ -264,12 +264,13 @@ function challengeTimedOut(state: NonTerminalCState, sharedData: SharedData): Re
 
 function challengeResponseAcknowledged(
   state: NonTerminalCState,
-  sharedData: SharedData
+  sharedData: SharedData,
+  channelId: string
 ): ReturnVal {
   if (state.type !== "Challenging.AcknowledgeResponse") {
     return {state, sharedData};
   }
-  sharedData = sendChallengeComplete(hideWallet(sharedData));
+  sharedData = sendChallengeComplete(hideWallet(sharedData), channelId);
   return {state: successOpen({}), sharedData};
 }
 

--- a/packages/wallet/src/redux/protocols/dispute/responder/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/dispute/responder/__tests__/reducer.test.ts
@@ -6,7 +6,10 @@ import * as TransactionGenerator from "../../../../../utils/transaction-generato
 import {itSendsThisDisplayEventType, itSendsThisMessage} from "../../../../__tests__/helpers";
 import {describeScenarioStep} from "../../../../__tests__/helpers";
 import {State} from "@statechannels/nitro-protocol";
-import {apiNotImplemented} from "../../../../sagas/messaging/outgoing-api-actions";
+import {
+  apiNotImplemented,
+  channelUpdatedEvent
+} from "../../../../sagas/messaging/outgoing-api-actions";
 
 // Mocks
 const mockTransaction = {to: "0xabc"};
@@ -168,7 +171,7 @@ describe("REQUIRE RESPONSE HAPPY-PATH ", () => {
     const {state, action} = scenario.waitForAcknowledgement;
     const result = responderReducer(state, sharedData, action);
     itSendsThisDisplayEventType(result.sharedData, "Hide");
-    itSendsThisMessage(result.sharedData, apiNotImplemented({apiMethod: "ChallengeComplete"}));
+    itSendsThisMessage(result.sharedData, channelUpdatedEvent({channelId}));
     itTransitionsTo(result, "Responding.Success");
   });
 });

--- a/packages/wallet/src/redux/protocols/dispute/responder/reducer.ts
+++ b/packages/wallet/src/redux/protocols/dispute/responder/reducer.ts
@@ -156,7 +156,7 @@ const waitForAcknowledgementReducer = (
     case "WALLET.DISPUTE.RESPONDER.ACKNOWLEDGED":
       return {
         protocolState: states.success({}),
-        sharedData: sendChallengeComplete(hideWallet(sharedData))
+        sharedData: sendChallengeComplete(hideWallet(sharedData), protocolState.channelId)
       };
     default:
       return {protocolState, sharedData};

--- a/packages/wallet/src/redux/protocols/reducer-helpers.ts
+++ b/packages/wallet/src/redux/protocols/reducer-helpers.ts
@@ -134,10 +134,10 @@ export function sendChallengeStateReceived(sharedData: SharedData) {
 }
 
 // TODO 'Complete' here means the challenge was successfully responded to
-export function sendChallengeComplete(sharedData: SharedData) {
+export function sendChallengeComplete(sharedData: SharedData, channelId: string) {
   const newSharedData = {...sharedData};
   newSharedData.outboxState = accumulateSideEffects(newSharedData.outboxState, {
-    messageOutbox: apiNotImplemented({apiMethod: "ChallengeComplete"})
+    messageOutbox: channelUpdatedEvent({channelId})
   });
   return newSharedData;
 }

--- a/packages/wallet/src/redux/sagas/messaging/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-handler.ts
@@ -1,4 +1,4 @@
-import {select, fork, put, call} from "redux-saga/effects";
+import {select, fork, put, putResolve, call} from "redux-saga/effects";
 import {getChannelId, State} from "@statechannels/nitro-protocol";
 import {
   JoinChannelParams,
@@ -282,21 +282,20 @@ function* handleUpdateChannelMessage(payload: RequestObject) {
     if (
       protocolState &&
       protocolState.type === "Application.WaitForDispute" &&
-      typeof protocolState.disputeState !== "undefined"
+      typeof protocolState.disputeState !== "undefined" &&
+      isResponderState(protocolState.disputeState)
     ) {
-      if (isResponderState(protocolState.disputeState)) {
-        yield put(
-          responseProvided({
-            processId: "Application",
-            state: newState
-          })
-        );
-      }
+      yield putResolve(
+        responseProvided({
+          processId: "Application",
+          state: newState
+        })
+      );
     } else {
       // NOTE: We only call ownStateReceived if _not_ in dispute because this action
       // has a reducer which returns the protocol state to Application.Ongoing, but we
       // want it to stay as Application.WaitForDispute
-      yield put(
+      yield putResolve(
         actions.application.ownStateReceived({
           state: newState,
           processId: APPLICATION_PROCESS_ID


### PR DESCRIPTION
Variations include:

- A challenges B, B responds and B clicks OK first
- A challenges B, B responds and A clicks OK first
- B challenges A, A responds and A clicks OK first
- B challenges A, A responds and B clicks OK first

And for each one of the above:

- A challenges and B responds before noticing the on-chain challenge 
- B challenges and A responds before noticing the on-chain challenge 
