### PR TITLE
[monorepo] Run yarn install immediately after typesync

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "node": "^10.16.3"
   },
   "scripts": {
-    "prepare": "typesync && yarn install --ignore-scripts && lerna run --concurrency 8 --stream prepare",
+    "preinstall": "npx typesync",
+    "prepare": "lerna run --concurrency 8 --stream prepare",
     "build": "lerna run build",
     "build:ci:incremental": "yarn build:ci --since $(git merge-base $CIRCLE_BRANCH origin/master)",
     "build:ci": "lerna run build:ci",
@@ -46,8 +47,7 @@
     "npm-normalize-package-bin": "^1.0.1",
     "postinstall-postinstall": "2.0.0",
     "prettier": "1.19.1",
-    "typescript": "3.7.2",
-    "typesync": "^0.6.1"
+    "typescript": "3.7.2"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": "^10.16.3"
   },
   "scripts": {
-    "prepare": "typesync && lerna run --concurrency 8 --stream prepare",
+    "prepare": "typesync && yarn install --ignore-scripts && lerna run --concurrency 8 --stream prepare",
     "build": "lerna run build",
     "build:ci:incremental": "yarn build:ci --since $(git merge-base $CIRCLE_BRANCH origin/master)",
     "build:ci": "lerna run build:ci",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8019,14 +8019,6 @@ awesome-typescript-loader@5.2.1, awesome-typescript-loader@^5.2.1:
     source-map-support "^0.5.3"
     webpack-log "^1.2.0"
 
-awilix@^4.2.2:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/awilix/-/awilix-4.2.3.tgz#9cf20037311970842620793d369b4dcbba8d7dd9"
-  integrity sha512-5a17FdZMI/VK+VtTI7mrXgYYtyq1trv1k5m2kp8PCikgWWbFpVBlEtK+SXCqCBhC+m2FBhcFla37HEUkbyvN1w==
-  dependencies:
-    camel-case "^3.0.0"
-    glob "^7.1.6"
-
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -8037,7 +8029,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@0.19.0, axios@^0.19.0:
+axios@0.19.0:
   version "0.19.0"
   resolved "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
   integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
@@ -31026,19 +31018,6 @@ typescript@^3.7.3:
   version "3.7.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
   integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
-
-typesync@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.npmjs.org/typesync/-/typesync-0.6.1.tgz#faedb7c6fe58f932d414dbc360d87855f2002552"
-  integrity sha512-s0gz49waO75HHDe0dCrvkT2EMWj6GKXSQnliSytoxH7JY+JYTow5d+CeCmypO95EOTrLvQAVnwxx2t/VdiDGTw==
-  dependencies:
-    awilix "^4.2.2"
-    axios "^0.19.0"
-    chalk "^2.4.2"
-    detect-indent "^6.0.0"
-    glob "^7.1.4"
-    ora "^3.4.0"
-    semver "^6.3.0"
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Running typesync _only_ alters `package.json`, adding values such as `@types/foo` if it finds `foo` as a dependency. As such, any nontrivial change (that does not have `yarn` run afterwards) is just going to cause everyone who bases work from that commit to regenerate `yarn.lock`.

This fix isn't particularly nice, so open to alternative suggestions (such as not having tyepsync be  part of `prepare` at all...).