### PR TITLE
Avoid using const in json schemas

### DIFF
--- a/packages/client-api-schema/schema/notification.json
+++ b/packages/client-api-schema/schema/notification.json
@@ -32,7 +32,7 @@
           "if": {
             "properties": {
               "method": {
-                "const": "UIUpdate"
+                "enum": ["UIUpdate"]
               }
             }
           },
@@ -48,7 +48,7 @@
         },
         {
           "if": {
-            "properties": {"method": {"const": "MessageQueued"}}
+            "properties": {"method": {"enum": ["MessageQueued"]}}
           },
           "then": {
             "properties": {
@@ -58,7 +58,7 @@
         },
         {
           "if": {
-            "properties": {"method": {"const": "ChannelProposed"}}
+            "properties": {"method": {"enum": ["ChannelProposed"]}}
           },
           "then": {
             "params": {"$ref": "create-channel.json#/definitions/CreateChannelResult"}
@@ -66,7 +66,7 @@
         },
         {
           "if": {
-            "properties": {"method": {"const": "ChannelUpdated"}}
+            "properties": {"method": {"enum": ["ChannelUpdated"]}}
           },
           "then": {
             "params": {"$ref": "update-channel.json#/definitions/UpdateChannelParams"}

--- a/packages/client-api-schema/schema/push-message.json
+++ b/packages/client-api-schema/schema/push-message.json
@@ -4,7 +4,7 @@
   "definitions": {
     "PushMessageResult": {
       "properties": {
-        "success": {"const": true}
+        "success": {"enum": [true]}
       },
       "required": ["success"]
     },

--- a/packages/client-api-schema/schema/request.json
+++ b/packages/client-api-schema/schema/request.json
@@ -38,7 +38,7 @@
       "allOf": [
         {
           "if": {
-            "properties": {"method": {"const": "CreateChannel"}}
+            "properties": {"method": {"enum": ["CreateChannel"]}}
           },
           "then": {
             "properties": {
@@ -48,7 +48,7 @@
         },
         {
           "if": {
-            "properties": {"method": {"const": "JoinChannel"}}
+            "properties": {"method": {"enum": ["JoinChannel"]}}
           },
           "then": {
             "params": {"$ref": "join-channel.json#/definitions/JoinChannelParams"}
@@ -56,7 +56,7 @@
         },
         {
           "if": {
-            "properties": {"method": {"const": "GetAddress"}}
+            "properties": {"method": {"enum": ["GetAddress"]}}
           },
           "then": {
             "params": {"$ref": "get-address.json#/definitions/GetAddressParams"}
@@ -64,7 +64,7 @@
         },
         {
           "if": {
-            "properties": {"method": {"const": "PushMessage"}}
+            "properties": {"method": {"enum": ["PushMessage"]}}
           },
           "then": {
             "params": {"$ref": "push-message.json#/definitions/PushMessageParams"}
@@ -72,7 +72,7 @@
         },
         {
           "if": {
-            "properties": {"method": {"const": "UpdateChannel"}}
+            "properties": {"method": {"enum": ["UpdateChannel"]}}
           },
           "then": {
             "params": {"$ref": "update-channel.json#/definitions/UpdateChannelParams"}
@@ -80,7 +80,7 @@
         },
         {
           "if": {
-            "properties": {"method": {"const": "CloseChannel"}}
+            "properties": {"method": {"enum": ["CloseChannel"]}}
           },
           "then": {
             "params": {"$ref": "close-channel.json#/definitions/CloseChannelParams"}
@@ -88,7 +88,7 @@
         },
         {
           "if": {
-            "properties": {"method": {"const": "ChallengeChannel"}}
+            "properties": {"method": {"enum": ["ChallengeChannel"]}}
           },
           "then": {
             "params": {"$ref": "challenge-channel.json#/definitions/ChallengeChannelParams"}


### PR DESCRIPTION
Currently json-schema-to-typescript doesn't support `const` in json schemas, so some interfaces being generated were invalid. I've just switched to `enum:["bla"]` which is functionally the same as `const`.

There is a PR to fix this but it hasn't been touched in a while unfortunately: https://github.com/bcherny/json-schema-to-typescript/pull/264

It looks like some of the interfaces we're generating are still not valid (like `Notification`) but I haven't investigated the cause.

