### PR TITLE
Add Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug :bug:**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots (if applicable)**
+If applicable, add screenshots to help explain your problem.
+
+**Environment:**
+ - Affected packages: [e.g., nitro-protocol]
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Problem description :confused:**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like :rocket:**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/need-help.md
+++ b/.github/ISSUE_TEMPLATE/need-help.md
@@ -1,4 +1,4 @@
-If you have a question about State Chanles that is not a bug report or feature
+If you have a question about State Channels that is not a bug report or feature
 request, please post it in the [forum](https://research.statechannels.org/)
 
 Questions posted to this repository will be closed.

--- a/.github/ISSUE_TEMPLATE/need-help.md
+++ b/.github/ISSUE_TEMPLATE/need-help.md
@@ -1,0 +1,4 @@
+If you have a question about State Chanles that is not a bug report or feature
+request, please post it in the [forum](https://research.statechannels.org/)
+
+Questions posted to this repository will be closed.


### PR DESCRIPTION
Add issue templates that help us structure the discussions, cut through the noise and push the project forward.

I added two templates. Feel free to add more if needed.