### PR TITLE
Confirm-Create-Channel workflow

### DIFF
--- a/packages/xstate-wallet/src/workflows/confirm-create-channel.ts
+++ b/packages/xstate-wallet/src/workflows/confirm-create-channel.ts
@@ -1,0 +1,94 @@
+import {
+  MachineConfig,
+  Action,
+  DefaultGuardType,
+  GuardPredicate,
+  ConditionPredicate,
+  StateSchema
+} from 'xstate';
+import {Allocations, Participant} from '@statechannels/client-api-schema';
+
+interface WorkflowActions {
+  hideUi: Action<WorkflowContext, any>;
+  displayUi: Action<WorkflowContext, any>;
+}
+interface WorkflowGuards {
+  noBudget:
+    | GuardPredicate<WorkflowContext, WorkflowEvent>
+    | ConditionPredicate<WorkflowContext, WorkflowEvent>;
+}
+
+// While this context info may not be used by the workflow
+// it may be used when displaying a UI
+interface WorkflowContext {
+  participants: Participant[];
+  allocations: Allocations;
+  appDefinition: string;
+  appData: string;
+  chainId: string;
+  challengeDuration: number;
+}
+
+interface WorkflowStateSchema extends StateSchema<WorkflowContext> {
+  states: {
+    needUserConfirmation: {};
+    waitForUserConfirmation: {};
+    // TODO: Is it possible to type these as type:'final' ?
+    done: {};
+    failure: {};
+  };
+}
+interface UserApproves {
+  type: 'USER_APPROVES';
+}
+interface UserRejects {
+  type: 'USER_REJECTS';
+}
+type WorkflowEvent = UserApproves | UserRejects;
+const generateConfig = (
+  actions: WorkflowActions,
+  guards: WorkflowGuards
+): MachineConfig<WorkflowContext, WorkflowStateSchema, WorkflowEvent> => ({
+  initial: 'needUserConfirmation',
+  states: {
+    needUserConfirmation: {
+      on: {
+        '': [
+          {
+            target: 'waitForUserConfirmation',
+            cond: guards.noBudget,
+            actions: [actions.displayUi]
+          },
+          {
+            target: 'done'
+          }
+        ]
+      }
+    },
+    waitForUserConfirmation: {
+      on: {
+        USER_APPROVES: {target: 'done', actions: [actions.hideUi]},
+        USER_REJECTS: {target: 'failure', actions: [actions.hideUi]}
+      }
+    },
+    done: {type: 'final'},
+    failure: {type: 'final'}
+  }
+});
+
+const mockActions: WorkflowActions = {
+  hideUi: 'hideUi',
+  displayUi: 'displayUi'
+};
+const mockGuards = {
+  noBudget: {
+    // TODO: Using a guard predicate type allows for the name to be displayed
+    // on the visualizer for the condition
+    // We should probably find a better way of doing this or not bother typing guards
+    type: 'xstate.guard' as DefaultGuardType,
+    name: 'noBudget',
+    predicate: (context, event) => true
+  }
+};
+export const mockOptions = {actions: mockActions, guards: mockGuards};
+export const config = generateConfig(mockActions, mockGuards);

--- a/packages/xstate-wallet/src/workflows/confirm-create-channel.ts
+++ b/packages/xstate-wallet/src/workflows/confirm-create-channel.ts
@@ -8,7 +8,7 @@ import {
   Machine
 } from 'xstate';
 import {Allocations, Participant} from '@statechannels/client-api-schema';
-import {MachineFactory, Store} from '@statechannels/wallet-protocols/src';
+import {MachineFactory, Store} from '@statechannels/wallet-protocols';
 import {sendDisplayMessage} from '../messaging';
 
 interface WorkflowActions {

--- a/packages/xstate-wallet/src/workflows/confirm-create-channel.ts
+++ b/packages/xstate-wallet/src/workflows/confirm-create-channel.ts
@@ -112,7 +112,6 @@ export const confirmChannelCreationWorkflow: MachineFactory<WorkflowContext, Wor
     }
   };
 
-  const options = {guards, actions};
   const config = generateConfig(actions, guards);
-  return Machine(config).withConfig(options, context);
+  return Machine(config).withConfig({}, context);
 };


### PR DESCRIPTION
Creates the workflow that handles confirming creating and joining a channel based on https://www.notion.so/0ee12a01ea684be095ca3b38909c9399?v=282f6c575af544e88924e7a1864a7a57&p=6ba5a9b3d85d467da9bb160986f8478d.

Visualizer here: https://xstate.js.org/viz/?gist=197d65fbc5f4dfa35865da66e8a156de

It seems that the actual `confirm-create-channel` workflow actually doesn't do much and can be re-used between either joining or creating a channel.

Marking as draft so we can discuss exactly what will be handled by the workflow versus handled outside of workflows.

I also experimented with some stricter typing.

Fixes #964 