### PR TITLE
[wallet-protocols] Add sort-imports rules to wallet-protocols

### DIFF
--- a/packages/wallet-protocols/.eslintrc.js
+++ b/packages/wallet-protocols/.eslintrc.js
@@ -23,7 +23,7 @@ module.exports = {
     'no-empty-pattern': 'off',
     'import/first': 2,
     "import/order": ["error", {
-      "groups": ["builtin", "external", "internal",  "parent", , "sibling", "index"],
+      "groups": ["builtin", "external", "internal",  "parent", "sibling", "index"],
       "newlines-between": "always-and-inside-groups"
     }],
     'no-restricted-imports': ['error', { patterns: ['**/lib/**', '**/src/**'] }],

--- a/packages/wallet-protocols/.eslintrc.js
+++ b/packages/wallet-protocols/.eslintrc.js
@@ -22,7 +22,10 @@ module.exports = {
     'no-useless-catch': 'off',
     'no-empty-pattern': 'off',
     'import/first': 2,
-    'import/order': [2, { 'newlines-between': 'always' }],
+    "import/order": ["error", {
+      "groups": ["builtin", "external", "internal",  "parent", , "sibling", "index"],
+      "newlines-between": "always-and-inside-groups"
+    }],
     'no-restricted-imports': ['error', { patterns: ['**/lib/**', '**/src/**'] }],
   },
 };

--- a/packages/wallet-protocols/src/ChannelStoreEntry.ts
+++ b/packages/wallet-protocols/src/ChannelStoreEntry.ts
@@ -1,4 +1,4 @@
-import { Channel, getChannelId, State, getStateSignerAddress } from '@statechannels/nitro-protocol';
+import { Channel, State, getChannelId, getStateSignerAddress } from '@statechannels/nitro-protocol';
 import { ethers } from 'ethers';
 import _ from 'lodash';
 

--- a/packages/wallet-protocols/src/__tests__/allocateToTarget.test.ts
+++ b/packages/wallet-protocols/src/__tests__/allocateToTarget.test.ts
@@ -1,7 +1,7 @@
 import { Allocation } from '@statechannels/nitro-protocol';
 import { AddressZero } from 'ethers/constants';
 
-import { allocateToTarget, Errors, ethAllocationOutcome } from '../calculations';
+import { Errors, allocateToTarget, ethAllocationOutcome } from '../calculations';
 
 const left = '0x01';
 const right = '0x02';

--- a/packages/wallet-protocols/src/__tests__/integration.test.ts
+++ b/packages/wallet-protocols/src/__tests__/integration.test.ts
@@ -5,10 +5,10 @@ import { AddressZero, HashZero } from 'ethers/constants';
 import { getChannelId } from '@statechannels/nitro-protocol';
 
 import {
+  ConcludeChannelEvent,
+  CreateChannelEvent,
   Init,
   machine,
-  CreateChannelEvent,
-  ConcludeChannelEvent,
 } from '../protocols/wallet/protocol';
 import { EphemeralStore, Store } from '../store';
 import { messageService } from '../messaging';
@@ -17,7 +17,7 @@ import { log } from '../utils';
 import { Chain } from '../chain';
 
 import { processStates } from './utils';
-import { first, second, wallet1, wallet2, participants, storeWithFundedChannel } from './data';
+import { first, participants, second, storeWithFundedChannel, wallet1, wallet2 } from './data';
 
 const EXPECTATION_TIMEOUT = process.env.CI ? 10000 : 500;
 jest.setTimeout(60000);

--- a/packages/wallet-protocols/src/calculations.ts
+++ b/packages/wallet-protocols/src/calculations.ts
@@ -1,16 +1,16 @@
 import {
-  Outcome,
   Allocation,
-  AssetOutcome,
-  isAllocationOutcome,
   AllocationAssetOutcome,
-  GuaranteeAssetOutcome,
+  AssetOutcome,
   Guarantee,
+  GuaranteeAssetOutcome,
+  Outcome,
+  isAllocationOutcome,
 } from '@statechannels/nitro-protocol';
 import { hexZeroPad } from 'ethers/utils';
 import { AddressZero } from 'ethers/constants';
 
-import { add, subtract, gt } from './mathOps';
+import { add, gt, subtract } from './mathOps';
 
 import { checkThat } from '.';
 

--- a/packages/wallet-protocols/src/machine-utils.ts
+++ b/packages/wallet-protocols/src/machine-utils.ts
@@ -1,4 +1,4 @@
-import { DoneInvokeEvent, EventObject, StateMachine, MachineConfig, Machine } from 'xstate';
+import { DoneInvokeEvent, EventObject, Machine, MachineConfig, StateMachine } from 'xstate';
 
 import { FINAL, Store } from '.';
 

--- a/packages/wallet-protocols/src/protocols/advance-channel/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/advance-channel/protocol.ts
@@ -1,5 +1,5 @@
-import { assign, MachineConfig, AnyEventObject, spawn } from 'xstate';
-import { map, filter } from 'rxjs/operators';
+import { AnyEventObject, MachineConfig, assign, spawn } from 'xstate';
+import { filter, map } from 'rxjs/operators';
 
 import { Store, observeChannel } from '../../store';
 import { connectToStore } from '../../machine-utils';

--- a/packages/wallet-protocols/src/protocols/conclude-channel/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/conclude-channel/protocol.ts
@@ -2,12 +2,12 @@ import { Machine } from 'xstate';
 
 import * as VirtualDefundingAsHub from '../virtual-defunding-as-hub/protocol';
 import * as VirtualDefundingAsLeaf from '../virtual-defunding-as-leaf/protocol';
-import { outcomesEqual, FINAL, checkThat } from '../..';
+import { FINAL, checkThat, outcomesEqual } from '../..';
 import { MachineFactory, getDataAndInvoke } from '../../machine-utils';
 import { add } from '../../mathOps';
 import { Store } from '../../store';
 import { isIndirectFunding } from '../../ChannelStoreEntry';
-import { getEthAllocation, ethAllocationOutcome } from '../../calculations';
+import { ethAllocationOutcome, getEthAllocation } from '../../calculations';
 
 import { SupportState } from '..';
 

--- a/packages/wallet-protocols/src/protocols/create-channel/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/create-channel/protocol.ts
@@ -1,7 +1,7 @@
-import { assign, DoneInvokeEvent, Machine, MachineConfig, sendParent } from 'xstate';
-import { State, Channel } from '@statechannels/nitro-protocol';
+import { DoneInvokeEvent, Machine, MachineConfig, assign, sendParent } from 'xstate';
+import { Channel, State } from '@statechannels/nitro-protocol';
 
-import { success, Store } from '../..';
+import { Store, success } from '../..';
 import { MachineFactory } from '../../machine-utils';
 import { ethAllocationOutcome } from '../../calculations';
 import { ChannelStoreEntry } from '../../ChannelStoreEntry';

--- a/packages/wallet-protocols/src/protocols/create-null-channel/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/create-null-channel/protocol.ts
@@ -1,5 +1,5 @@
-import { assign, Machine } from 'xstate';
-import { HashZero, AddressZero } from 'ethers/constants';
+import { Machine, assign } from 'xstate';
+import { AddressZero, HashZero } from 'ethers/constants';
 import { Outcome } from '@statechannels/nitro-protocol';
 
 import { Channel, FINAL, getChannelId } from '../../';

--- a/packages/wallet-protocols/src/protocols/depositing/protocol.test.ts
+++ b/packages/wallet-protocols/src/protocols/depositing/protocol.test.ts
@@ -6,7 +6,7 @@ import { Chain } from '../../chain';
 import { EphemeralStore } from '../..';
 import { log } from '../../utils';
 
-import { machine, Init } from './protocol';
+import { Init, machine } from './protocol';
 
 jest.setTimeout(50000);
 

--- a/packages/wallet-protocols/src/protocols/depositing/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/depositing/protocol.ts
@@ -1,5 +1,5 @@
 import { bigNumberify } from 'ethers/utils';
-import { Machine, MachineConfig, InvokeCallback } from 'xstate';
+import { InvokeCallback, Machine, MachineConfig } from 'xstate';
 
 import { FINAL } from '../..';
 import { MachineFactory } from '../../machine-utils';

--- a/packages/wallet-protocols/src/protocols/direct-funding/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/direct-funding/protocol.ts
@@ -2,15 +2,15 @@ import { Allocation, Outcome } from '@statechannels/nitro-protocol';
 import { Machine, MachineConfig } from 'xstate';
 import _ from 'lodash';
 import { bigNumberify } from 'ethers/utils';
-import { HashZero, AddressZero } from 'ethers/constants';
+import { AddressZero, HashZero } from 'ethers/constants';
 
-import { getDataAndInvoke, MachineFactory } from '../../machine-utils';
+import { MachineFactory, getDataAndInvoke } from '../../machine-utils';
 import { FINAL } from '../../';
-import { add, subtract, gt } from '../../mathOps';
+import { add, gt, subtract } from '../../mathOps';
 import { Store } from '../../store';
-import { getEthAllocation, ethAllocationOutcome } from '../../calculations';
+import { ethAllocationOutcome, getEthAllocation } from '../../calculations';
 
-import { SupportState, Depositing } from '..';
+import { Depositing, SupportState } from '..';
 
 const PROTOCOL = 'direct-funding';
 const success = { type: FINAL };

--- a/packages/wallet-protocols/src/protocols/funding/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/funding/protocol.ts
@@ -1,6 +1,6 @@
-import { assign, DoneInvokeEvent, Machine } from 'xstate';
+import { DoneInvokeEvent, Machine, assign } from 'xstate';
 
-import { failure, pretty, Store, success } from '../..';
+import { Store, failure, pretty, success } from '../..';
 import { MachineFactory } from '../../machine-utils';
 import { FundingStrategy, FundingStrategyProposed } from '../../wire-protocol';
 import { log } from '../../utils';

--- a/packages/wallet-protocols/src/protocols/funding/test.ts
+++ b/packages/wallet-protocols/src/protocols/funding/test.ts
@@ -1,8 +1,8 @@
-import { interpret, Machine } from 'xstate';
+import { Machine, interpret } from 'xstate';
 
 import { FundingStrategyProposed } from '../../wire-protocol';
 
-import { config, Init, mockOptions } from './protocol';
+import { Init, config, mockOptions } from './protocol';
 const context: Init = {
   targetChannelId: 'foo',
   tries: 0,

--- a/packages/wallet-protocols/src/protocols/join-channel/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/join-channel/protocol.ts
@@ -1,4 +1,4 @@
-import { Machine, MachineConfig, sendParent, assign, DoneInvokeEvent } from 'xstate';
+import { DoneInvokeEvent, Machine, MachineConfig, assign, sendParent } from 'xstate';
 import { getChannelId } from '@statechannels/nitro-protocol';
 
 import { MachineFactory } from '../../machine-utils';

--- a/packages/wallet-protocols/src/protocols/ledger-funding/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/ledger-funding/protocol.ts
@@ -1,7 +1,7 @@
-import { assign, DoneInvokeEvent, Machine, MachineConfig } from 'xstate';
+import { DoneInvokeEvent, Machine, MachineConfig, assign } from 'xstate';
 
 import { allocateToTarget, getEthAllocation } from '../../calculations';
-import { Store, Channel, success } from '../..';
+import { Channel, Store, success } from '../..';
 import { MachineFactory, getDataAndInvoke } from '../../machine-utils';
 import { Funding } from '../../ChannelStoreEntry';
 

--- a/packages/wallet-protocols/src/protocols/partial-withdrawal/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/partial-withdrawal/protocol.ts
@@ -6,7 +6,7 @@ import * as ConcludeChannel from '../conclude-channel/protocol';
 import * as CreateNullChannel from '../create-null-channel/protocol';
 import * as LedgerUpdate from '../ledger-update/protocol';
 import { store } from '../../temp-store';
-import { getEthAllocation, ethAllocationOutcome } from '../../calculations';
+import { ethAllocationOutcome, getEthAllocation } from '../../calculations';
 const PROTOCOL = 'partial-withdrawal';
 const success = { type: 'final' };
 

--- a/packages/wallet-protocols/src/protocols/support-state/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/support-state/protocol.ts
@@ -1,10 +1,10 @@
-import { MachineConfig, AnyEventObject, AssignAction, assign, spawn } from 'xstate';
+import { AnyEventObject, AssignAction, MachineConfig, assign, spawn } from 'xstate';
 import { State, getChannelId } from '@statechannels/nitro-protocol';
-import { map, filter } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
 
 import { outcomesEqual, statesEqual } from '../..';
 import { Store, observeChannel } from '../../store';
-import { connectToStore, MachineFactory } from '../../machine-utils';
+import { MachineFactory, connectToStore } from '../../machine-utils';
 
 const PROTOCOL = 'support-state';
 

--- a/packages/wallet-protocols/src/protocols/virtual-defunding-as-leaf/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/virtual-defunding-as-leaf/protocol.ts
@@ -6,7 +6,7 @@ import { Without, checkThat } from '../../';
 import { isIndirectFunding, isVirtualFunding } from '../../ChannelStoreEntry';
 import { store } from '../../temp-store';
 import * as LedgerUpdate from '../ledger-update/protocol';
-import { getEthAllocation, ethAllocationOutcome } from '../../calculations';
+import { ethAllocationOutcome, getEthAllocation } from '../../calculations';
 const PROTOCOL = 'virtual-defunding-as-leaf';
 
 export interface Init {

--- a/packages/wallet-protocols/src/protocols/wallet/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/wallet/protocol.ts
@@ -1,10 +1,10 @@
-import { assign, AssignAction, Interpreter, Machine, spawn, MachineConfig } from 'xstate';
+import { AssignAction, Interpreter, Machine, MachineConfig, assign, spawn } from 'xstate';
 
 import { getChannelId } from '../..';
 import { Store } from '../../store';
 import { FundingStrategyProposed, OpenChannel, SendStates } from '../../wire-protocol';
 
-import { CreateChannel, JoinChannel, ConcludeChannel } from '..';
+import { ConcludeChannel, CreateChannel, JoinChannel } from '..';
 
 const PROTOCOL = 'wallet';
 export type Events =

--- a/packages/wallet-protocols/src/store.ts
+++ b/packages/wallet-protocols/src/store.ts
@@ -1,18 +1,19 @@
 import { EventEmitter } from 'events';
 
-import * as rxjs from 'rxjs';
-import { State, getStateSignerAddress, signState, hashState } from '@statechannels/nitro-protocol';
-import _ from 'lodash';
 import { AddressZero } from 'ethers/constants';
-import { map, filter } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
+import { State, getStateSignerAddress, hashState, signState } from '@statechannels/nitro-protocol';
+import * as rxjs from 'rxjs';
+import _ from 'lodash';
 
-import { ChannelStoreEntry, IChannelStoreEntry, Funding, supported } from './ChannelStoreEntry';
-import { messageService, IMessageService } from './messaging';
 import { AddressableMessage, FundingStrategyProposed } from './wire-protocol';
-import { Chain, IChain, ChainEventType, ChainEvent } from './chain';
+import { Chain, ChainEvent, ChainEventType, IChain } from './chain';
+import { ChannelStoreEntry, Funding, IChannelStoreEntry, supported } from './ChannelStoreEntry';
+import { IMessageService, messageService } from './messaging';
+
 import { add, gt } from './mathOps';
 
-import { getChannelId, SignedState, unreachable, statesEqual } from '.';
+import { SignedState, getChannelId, statesEqual, unreachable } from '.';
 
 export interface ChannelUpdated {
   type: 'CHANNEL_UPDATED';


### PR DESCRIPTION
I find this sorting style to look clean and be easy to understand what a file depends on relative to external modules and local files more easily than the previous unsorted way.