### PR TITLE
[hub, rps] Only initialize Sentry in production environment

### DIFF
--- a/packages/hub/src/hub/server.ts
+++ b/packages/hub/src/hub/server.ts
@@ -1,9 +1,11 @@
 import * as Sentry from '@sentry/node';
 
-Sentry.init({
-  dsn: 'https://5b818f025d1a4259a8cf086377b67025@sentry.io/2047255',
-  environment: process.env.RUNTIME_ENV || 'development'
-});
+if (process.env.RUNTIME_ENV) {
+  Sentry.init({
+    dsn: 'https://5b818f025d1a4259a8cf086377b67025@sentry.io/2047255',
+    environment: process.env.RUNTIME_ENV
+  });
+}
 
 import {RelayableAction} from '../communication';
 import '../wallet/db/connection';

--- a/packages/rps/src/index.tsx
+++ b/packages/rps/src/index.tsx
@@ -1,15 +1,16 @@
+import * as Sentry from '@sentry/browser';
+if (process.env.NODE_ENV === 'production') {
+  Sentry.init({dsn: 'https://db92051c360145b4b3537d33881c1bc3@sentry.io/1913622'});
+}
 import * as React from 'react';
 import {render} from 'react-dom';
 import {Provider} from 'react-redux';
-import * as Sentry from '@sentry/browser';
 
 // Not adding in currently because it breaks most of our existing components
 // import 'bootstrap/dist/css/bootstrap.min.css';
 import './index.scss';
 import store from './redux/store';
 import SiteContainer from './containers/SiteContainer';
-
-Sentry.init({dsn: 'https://db92051c360145b4b3537d33881c1bc3@sentry.io/1913622'});
 
 render(
   <Provider store={store}>


### PR DESCRIPTION
This prevents everyone from being alerted (emailed) when some developer gets an error locally.