### PR TITLE
[xsate-wallet] Add screen for confirm-create-channel workflow

### DIFF
--- a/packages/xstate-wallet/.storybook/main.js
+++ b/packages/xstate-wallet/.storybook/main.js
@@ -1,6 +1,6 @@
 const path = require('path');
 module.exports = {
-  stories: ['../stories/**/*.stories.tsx'],
+  stories: ['../src/ui/stories/**/*.stories.tsx'],
   addons: ['@storybook/addon-actions', '@storybook/addon-links'],
 
   webpackFinal: async config => {

--- a/packages/xstate-wallet/package.json
+++ b/packages/xstate-wallet/package.json
@@ -60,7 +60,6 @@
   "private": true,
   "scripts": {
     "build": "npx webpack --config ./webpack-build.config.js",
-    "build-storybook": "build-storybook",
     "build:ci": "yarn build",
     "generateConfigs": "yarn run ts-node bin/generateConfigs.ts ",
     "lint:check": "eslint . --ext .ts --cache",

--- a/packages/xstate-wallet/src/ui/application-workflow.tsx
+++ b/packages/xstate-wallet/src/ui/application-workflow.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import {State} from 'xstate';
+import './wallet.scss';
+import {Flex, Progress} from 'rimble-ui';
+import {ChannelId} from './channel-id';
+
+interface Props {
+  current: State<any, any, any, any>;
+}
+
+export const ApplicationWorkflow = (props: Props) => {
+  const current = props.current;
+  const messages = {
+    // TODO this lookup could be typed using Record<StateSchema,string> if/when we use StateSchema to type the underlying machine config
+    initializing: 'Initializing...',
+    join: 'Joining channel...',
+    opening: 'Opening channel...',
+    create: 'Creating channel...',
+    running: 'Running channel...',
+    closing: 'Closing channel...',
+    done: 'Channel closed'
+  };
+  return (
+    <div
+      style={{
+        paddingTop: '50px',
+        textAlign: 'center'
+      }}
+    >
+      <h1>{messages[current.value.toString()]}</h1>
+      <Flex px={3} height={3} mt={'0.8'} mx={'0.4'}>
+        <ChannelId channelId={current.context.channelId} />
+      </Flex>
+      {current.children &&
+        current.children.createMachine &&
+        current.children.createMachine.state && (
+          <Progress
+            value={progressThroughCreateMachine[current.children.createMachine.state.value]}
+          />
+        )}
+      {current.children && current.children.joinMachine && current.children.joinMachine.state && (
+        <Progress value={progressThroughJoinMachine[current.children.joinMachine.state.value]} />
+      )}
+    </div>
+  );
+};
+
+export default ApplicationWorkflow;
+
+const progressThroughCreateMachine = {
+  initializeChannel: 0.15,
+  sendOpenChannelMessage: 0.3,
+  preFundSetup: 0.45,
+  funding: 0.6,
+  postFundSetup: 0.75,
+  success: 0.9
+};
+
+const progressThroughJoinMachine = {
+  checkNonce: 0.15,
+  askClient: 0.3,
+  preFundSetup: 0.45,
+  funding: 0.6,
+  postFundSetup: 0.75,
+  success: 0.9
+};

--- a/packages/xstate-wallet/src/ui/confirm-create-channel-workflow.tsx
+++ b/packages/xstate-wallet/src/ui/confirm-create-channel-workflow.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {State, EventData} from 'xstate';
+import './wallet.scss';
+import {Button} from 'rimble-ui';
+
+interface Props {
+  current: State<any, any, any, any>;
+  send: (event: any, payload?: EventData | undefined) => State<any, any, any, any>;
+}
+
+export const ConfirmCreateChannel = (props: Props) => {
+  const current = props.current;
+  const prompt = (
+    <div
+      style={{
+        paddingTop: '50px',
+        textAlign: 'center'
+      }}
+    >
+      <h1>Do you wish to create a channel?</h1>
+      <Button onClick={() => props.send('USER_APPROVED')}>Yes</Button>
+      <Button.Text onClick={() => props.send('USER_REJECTS')}>No</Button.Text>
+    </div>
+  );
+  if (current.value.toString() === 'waitForUserConfirmation') {
+    return prompt;
+  } else {
+    return <div></div>;
+  }
+};
+
+export default ConfirmCreateChannel;

--- a/packages/xstate-wallet/src/ui/stories/application-workflow.stories.tsx
+++ b/packages/xstate-wallet/src/ui/stories/application-workflow.stories.tsx
@@ -1,15 +1,12 @@
-import React from 'react';
-import {Wallet} from '../wallet';
 import {
   applicationWorkflow,
   config as applicationWorkflowConfig
 } from '../../workflows/application';
 export default {title: 'X-state wallet'};
 import {storiesOf} from '@storybook/react';
-import {Image} from 'rimble-ui';
-import fakeApp from '../../images/fake-app.png';
 import {interpret} from 'xstate';
 import {EphemeralStore} from '@statechannels/wallet-protocols';
+import {renderWalletInFrontOfApp} from './helpers';
 
 const store = new EphemeralStore({
   privateKeys: {
@@ -28,24 +25,12 @@ if (applicationWorkflowConfig.states) {
       devTools: true
     }); // start a new interpreted machine for each story
     machine.start(state);
-    storiesOf('Application Workflow', module).add(
+    storiesOf('Workflows / Application', module).add(
       state.toString(),
       renderWalletInFrontOfApp(machine)
     );
     machine.stop();
   });
-}
-
-function renderWalletInFrontOfApp(machine) {
-  function renderFunction() {
-    return (
-      <div>
-        <Image src={fakeApp} />
-        <Wallet workflow={machine} />
-      </div>
-    );
-  }
-  return renderFunction;
 }
 
 if (applicationWorkflowConfig.states) {
@@ -54,7 +39,7 @@ if (applicationWorkflowConfig.states) {
       applicationWorkflow(store).withContext(testContext)
     ).start(); // start a new interpreted machine for each story
     machineWithChildren.send(event);
-    storiesOf('Application Workflow', module).add(
+    storiesOf('Workflows / Application', module).add(
       'Initialising + ' + event,
       renderWalletInFrontOfApp(machineWithChildren)
     );

--- a/packages/xstate-wallet/src/ui/stories/application-workflow.stories.tsx
+++ b/packages/xstate-wallet/src/ui/stories/application-workflow.stories.tsx
@@ -4,7 +4,6 @@ import {
   applicationWorkflow,
   config as applicationWorkflowConfig
 } from '../../workflows/application';
-import {ChannelId} from '../channel-id';
 export default {title: 'X-state wallet'};
 import {storiesOf} from '@storybook/react';
 import {Image} from 'rimble-ui';
@@ -49,19 +48,14 @@ function renderWalletInFrontOfApp(machine) {
   return renderFunction;
 }
 
-storiesOf('ChannelId', module).add('empty', () => <ChannelId channelId={undefined} />);
-storiesOf('ChannelId', module).add('not empty', () => (
-  <ChannelId channelId={testContext.channelId} />
-));
-
 if (applicationWorkflowConfig.states) {
   ['CREATE_CHANNEL', 'OPEN_CHANNEL'].forEach(event => {
     const machineWithChildren = interpret<any, any, any>(
       applicationWorkflow(store).withContext(testContext)
     ).start(); // start a new interpreted machine for each story
     machineWithChildren.send(event);
-    storiesOf('Wallet with invoked children', module).add(
-      'Init + ' + event,
+    storiesOf('Application Workflow', module).add(
+      'Initialising + ' + event,
       renderWalletInFrontOfApp(machineWithChildren)
     );
     machineWithChildren.stop();

--- a/packages/xstate-wallet/src/ui/stories/channel-id.stories.tsx
+++ b/packages/xstate-wallet/src/ui/stories/channel-id.stories.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import {ChannelId} from '../channel-id';
+export default {title: 'X-state wallet'};
+import {storiesOf} from '@storybook/react';
+
+const testContext = {
+  channelId: '0x697ecf681033a2514ed19c90299a67ae8677f3c78b5877fe4550c4f0960e87b7'
+};
+
+storiesOf('ChannelId', module).add('empty', () => <ChannelId channelId={undefined} />);
+storiesOf('ChannelId', module).add('not empty', () => (
+  <ChannelId channelId={testContext.channelId} />
+));

--- a/packages/xstate-wallet/src/ui/stories/confirm-create-channel-workflow.stories.tsx
+++ b/packages/xstate-wallet/src/ui/stories/confirm-create-channel-workflow.stories.tsx
@@ -46,25 +46,11 @@ if (config.states) {
         devTools: true
       }
     ); // start a new interpreted machine for each story
-    machine.start(state);
-    storiesOf('Workflows / Confirm Channel Creation', module).add(
+    machine.onEvent(event => console.log(event.type)).start(state);
+    storiesOf('Workflows / Confirm Create Channel', module).add(
       state.toString(),
       renderWalletInFrontOfApp(machine)
     );
-    machine.stop();
+    machine.stop(); // the machine will be stopped before it can be transitioned. This means the console.log on L49 throws a warning that we sent an event to a stopped machine.
   });
 }
-
-// if (config.states) {
-//   ['CREATE_CHANNEL', 'OPEN_CHANNEL'].forEach(event => {
-//     const machineWithChildren = interpret<any, any, any>(
-//       confirmChannelCreationWorkflow(store).withContext(testContext)
-//     ).start(); // start a new interpreted machine for each story
-//     machineWithChildren.send(event);
-//     storiesOf('Application Workflow', module).add(
-//       'Initialising + ' + event,
-//       renderWalletInFrontOfApp(machineWithChildren)
-//     );
-//     machineWithChildren.stop();
-//   });
-// }

--- a/packages/xstate-wallet/src/ui/stories/confirm-create-channel-workflow.stories.tsx
+++ b/packages/xstate-wallet/src/ui/stories/confirm-create-channel-workflow.stories.tsx
@@ -1,0 +1,70 @@
+import {
+  confirmChannelCreationWorkflow,
+  config,
+  WorkflowContext
+} from '../../workflows/confirm-create-channel';
+export default {title: 'X-state wallet'};
+import {storiesOf} from '@storybook/react';
+import {interpret} from 'xstate';
+import {EphemeralStore} from '@statechannels/wallet-protocols';
+import {Participant} from '@statechannels/client-api-schema/types/definitions';
+import {renderWalletInFrontOfApp} from './helpers';
+
+const store = new EphemeralStore({
+  privateKeys: {
+    ['0xaddress']: '0xkey'
+  },
+  ethAssetHolderAddress: '0xassetholder'
+});
+
+const alice: Participant = {
+  participantId: 'a',
+  signingAddress: '0xa',
+  destination: '0xad'
+};
+
+const bob: Participant = {
+  participantId: 'b',
+  signingAddress: '0xb',
+  destination: '0xbd'
+};
+
+const testContext: WorkflowContext = {
+  participants: [alice, bob],
+  allocations: [],
+  appDefinition: '0x0',
+  appData: '0x0',
+  chainId: '0',
+  challengeDuration: 1
+};
+
+if (config.states) {
+  Object.keys(config.states).forEach(state => {
+    const machine = interpret<any, any, any>(
+      confirmChannelCreationWorkflow(store).withContext(testContext),
+      {
+        devTools: true
+      }
+    ); // start a new interpreted machine for each story
+    machine.start(state);
+    storiesOf('Workflows / Confirm Channel Creation', module).add(
+      state.toString(),
+      renderWalletInFrontOfApp(machine)
+    );
+    machine.stop();
+  });
+}
+
+// if (config.states) {
+//   ['CREATE_CHANNEL', 'OPEN_CHANNEL'].forEach(event => {
+//     const machineWithChildren = interpret<any, any, any>(
+//       confirmChannelCreationWorkflow(store).withContext(testContext)
+//     ).start(); // start a new interpreted machine for each story
+//     machineWithChildren.send(event);
+//     storiesOf('Application Workflow', module).add(
+//       'Initialising + ' + event,
+//       renderWalletInFrontOfApp(machineWithChildren)
+//     );
+//     machineWithChildren.stop();
+//   });
+// }

--- a/packages/xstate-wallet/src/ui/stories/helpers.tsx
+++ b/packages/xstate-wallet/src/ui/stories/helpers.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import {Wallet} from '../wallet';
+import {Image} from 'rimble-ui';
+import fakeApp from '../../images/fake-app.png';
+
+export function renderWalletInFrontOfApp(machine) {
+  function renderFunction() {
+    return (
+      <div>
+        <Image src={fakeApp} />
+        <Wallet workflow={machine} />
+      </div>
+    );
+  }
+  return renderFunction;
+}

--- a/packages/xstate-wallet/src/ui/stories/index.stories.tsx
+++ b/packages/xstate-wallet/src/ui/stories/index.stories.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
-import Wallet from '../src/ui/wallet';
-import {applicationWorkflow, config} from '../src/workflows/application';
-import {ChannelId} from '../src/ui/channel-id';
+import {Wallet} from '../wallet';
+import {
+  applicationWorkflow,
+  config as applicationWorkflowConfig
+} from '../../workflows/application';
+import {ChannelId} from '../channel-id';
 export default {title: 'X-state wallet'};
 import {storiesOf} from '@storybook/react';
 import {Image} from 'rimble-ui';
-import fakeApp from '../src/images/fake-app.png';
+import fakeApp from '../../images/fake-app.png';
 import {interpret} from 'xstate';
-import {Store} from '@statechannels/wallet-protocols';
+import {EphemeralStore} from '@statechannels/wallet-protocols';
 
-const store = new Store({
+const store = new EphemeralStore({
   privateKeys: {
     ['0xaddress']: '0xkey'
   },
@@ -20,13 +23,16 @@ const testContext = {
   channelId: '0x697ecf681033a2514ed19c90299a67ae8677f3c78b5877fe4550c4f0960e87b7'
 };
 
-if (config.states) {
-  Object.keys(config.states).forEach(state => {
+if (applicationWorkflowConfig.states) {
+  Object.keys(applicationWorkflowConfig.states).forEach(state => {
     const machine = interpret<any, any, any>(applicationWorkflow(store).withContext(testContext), {
       devTools: true
     }); // start a new interpreted machine for each story
     machine.start(state);
-    storiesOf('Wallet', module).add(state.toString(), renderWalletInFrontOfApp(machine));
+    storiesOf('Application Workflow', module).add(
+      state.toString(),
+      renderWalletInFrontOfApp(machine)
+    );
     machine.stop();
   });
 }
@@ -48,7 +54,7 @@ storiesOf('ChannelId', module).add('not empty', () => (
   <ChannelId channelId={testContext.channelId} />
 ));
 
-if (config.states) {
+if (applicationWorkflowConfig.states) {
   ['CREATE_CHANNEL', 'OPEN_CHANNEL'].forEach(event => {
     const machineWithChildren = interpret<any, any, any>(
       applicationWorkflow(store).withContext(testContext)

--- a/packages/xstate-wallet/src/ui/wallet.tsx
+++ b/packages/xstate-wallet/src/ui/wallet.tsx
@@ -3,77 +3,29 @@ import {Interpreter} from 'xstate';
 import {useService} from '@xstate/react';
 import './wallet.scss';
 import logo from '../images/logo.svg';
-import {Modal, Card, Flex, Image, Progress} from 'rimble-ui';
-import {ChannelId} from './channel-id';
+import {Modal, Card, Flex, Image} from 'rimble-ui';
+import ApplicationWorkflow from './application-workflow';
+import ConfirmCreateChannelWorkflow from './confirm-create-channel-workflow';
 
 interface Props {
   workflow: Interpreter<any, any, any>;
 }
 
 export const Wallet = (props: Props) => {
-  const [current] = useService(props.workflow);
-  const messages = {
-    initializing: 'Initializing...',
-    join: 'Joining channel...',
-    opening: 'Opening channel...',
-    create: 'Creating channel...',
-    running: 'Running channel...',
-    closing: 'Closing channel...',
-    done: 'Channel closed'
-  };
+  const [current, send] = useService(props.workflow);
   return (
     <Modal isOpen={true}>
       <Card width={'320px'} height={'450px'}>
         <Flex px={[3, 3, 4]} height={3} borderBottom={1} borderColor={'#E8E8E8'} mt={'0.8'}>
           <Image alt="State Channels" borderRadius={8} height="auto" src={logo} />
         </Flex>
-        <div
-          style={{
-            paddingTop: '50px',
-            textAlign: 'center'
-          }}
-        >
-          <h1>{messages[current.value.toString()]}</h1>
-          <Flex px={3} height={3} mt={'0.8'} mx={'0.4'}>
-            <ChannelId channelId={current.context.channelId} />
-          </Flex>
-          {/* {JSON.stringify(current.children.createMachine.state)} */}
-          {current.children &&
-            current.children.createMachine &&
-            current.children.createMachine.state && (
-              <Progress
-                value={progressThroughCreateMachine[current.children.createMachine.state.value]}
-              />
-            )}
-          {current.children &&
-            current.children.joinMachine &&
-            current.children.joinMachine.state && (
-              <Progress
-                value={progressThroughJoinMachine[current.children.joinMachine.state.value]}
-              />
-            )}
-        </div>
+        {props.workflow.id === 'application-workflow' && <ApplicationWorkflow current={current} />}
+        {props.workflow.id === 'confirm-create-channel' && (
+          <ConfirmCreateChannelWorkflow current={current} send={send} />
+        )}
       </Card>
     </Modal>
   );
 };
 
 export default Wallet;
-
-const progressThroughCreateMachine = {
-  initializeChannel: 0.15,
-  sendOpenChannelMessage: 0.3,
-  preFundSetup: 0.45,
-  funding: 0.6,
-  postFundSetup: 0.75,
-  success: 0.9
-};
-
-const progressThroughJoinMachine = {
-  checkNonce: 0.15,
-  askClient: 0.3,
-  preFundSetup: 0.45,
-  funding: 0.6,
-  postFundSetup: 0.75,
-  success: 0.9
-};

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -48,6 +48,7 @@ type Event = PlayerRequestConclude | PlayerStateUpdate | SendStates | OpenEvent 
 export type ApplicationWorkflowEvent = Event;
 
 const generateConfig = (actions: Actions): MachineConfig<Context, any, Event> => ({
+  id: 'application-workflow',
   initial: 'initializing',
   states: {
     initializing: {on: {CREATE_CHANNEL: 'create', OPEN_CHANNEL: 'join'}},

--- a/packages/xstate-wallet/src/workflows/confirm-create-channel.ts
+++ b/packages/xstate-wallet/src/workflows/confirm-create-channel.ts
@@ -22,7 +22,7 @@ interface WorkflowGuards {
 }
 // While this context info may not be used by the workflow
 // it may be used when displaying a UI
-interface WorkflowContext {
+export interface WorkflowContext {
   participants: Participant[];
   allocations: Allocations;
   appDefinition: string;

--- a/packages/xstate-wallet/src/workflows/confirm-create-channel.ts
+++ b/packages/xstate-wallet/src/workflows/confirm-create-channel.ts
@@ -53,6 +53,7 @@ const generateConfig = (
   actions: WorkflowActions,
   guards: WorkflowGuards
 ): MachineConfig<WorkflowContext, WorkflowStateSchema, WorkflowEvent> => ({
+  id: 'confirm-create-channel',
   initial: 'needUserConfirmation',
   states: {
     needUserConfirmation: {


### PR DESCRIPTION
Plus some organisation of components and stories. The buttons work!

For now application workflow and confirm-create-channel workflow treated entirely independently -- this may change soon, see #969 .


<img width="1117" alt="Screenshot 2020-02-05 at 14 55 22" src="https://user-images.githubusercontent.com/1833419/73852702-8e818a00-4827-11ea-8aca-b9a1775a4516.png">

