### PR TITLE
[wallet, rps] Call ethereum.enable() in the wallet

### DIFF
--- a/packages/rps/.env
+++ b/packages/rps/.env
@@ -12,7 +12,7 @@ CHAIN_NETWORK_ID=9001
 TARGET_NETWORK='development'
 FIREBASE_PROJECT='rock-paper-scissors-dev-4ff8d'
 FIREBASE_API_KEY='AIzaSyAOvhDzJir_El3O6SJ2xQlrpOisnObq6zw'
-WALLET_URL='http://localhost:3055'
+WALLET_URL='http://127.0.0.1:3055'
 BOT_URL=http://localhost:3002
 ##
 

--- a/packages/rps/.env
+++ b/packages/rps/.env
@@ -16,6 +16,10 @@ WALLET_URL='http://127.0.0.1:3055'
 BOT_URL=http://localhost:3002
 ##
 
+# Using 127.0.0.1 instead of localhost for WALLET_URL makes development more like production
+# in the sense that metamask sees the app and the wallet being served from two different domains,
+# therefore requiring two seperate connection authorizations
+
 # These values are required if contracts will be deployed to a test network (TARGET_NETWORK!='development')
 # and should be overriden in a .env.local file
 ETH_ACCOUNT_MNENOMIC='A valid account mnemonic is required to deploy to a test network'

--- a/packages/rps/src/components/LobbyPage.tsx
+++ b/packages/rps/src/components/LobbyPage.tsx
@@ -9,6 +9,7 @@ import {OpenGameEntry} from './OpenGameCard';
 import CreatingOpenGameContainer from '../containers/CreatingOpenGameContainer';
 
 interface Props {
+  createAGameButtonDisabled: boolean;
   openGames: OpenGame[];
   joinOpenGame: (
     opponentName: string,
@@ -40,8 +41,9 @@ export default class LobbyPage extends React.PureComponent<Props, State> {
               outline={true}
               onClick={newOpenGame}
               id="create-a-game"
+              disabled={this.props.createAGameButtonDisabled}
             >
-              Create a game
+              {this.props.createAGameButtonDisabled ? 'Unlock Metamask' : 'Create a game'}
             </Button>
           </div>
           <div className="mt-5">

--- a/packages/rps/src/components/LobbyPage.tsx
+++ b/packages/rps/src/components/LobbyPage.tsx
@@ -54,6 +54,7 @@ export default class LobbyPage extends React.PureComponent<Props, State> {
                     key={openGame.address}
                     openGame={openGame}
                     joinOpenGame={joinOpenGame}
+                    joinGameButtonDisabled={this.props.createAGameButtonDisabled}
                   />
                 ))
               ) : (

--- a/packages/rps/src/components/OpenGameCard.tsx
+++ b/packages/rps/src/components/OpenGameCard.tsx
@@ -5,6 +5,7 @@ import {bigNumberify, formatUnits} from 'ethers/utils';
 import {Blockie} from 'rimble-ui';
 
 interface Props {
+  joinGameButtonDisabled: boolean;
   openGame: OpenGame;
   joinOpenGame: (
     opponentName: string,
@@ -50,8 +51,13 @@ export class OpenGameEntry extends React.PureComponent<Props> {
             <div className="ogc-stake-currency">ETH</div>
           </div>
         </div>
-        <Button className="ogc-join" onClick={joinThisGame} id="join">
-          Join
+        <Button
+          className="ogc-join"
+          onClick={joinThisGame}
+          id="join"
+          disabled={this.props.joinGameButtonDisabled}
+        >
+          {this.props.joinGameButtonDisabled ? 'Unlock Metamask' : 'Join'}
         </Button>
       </div>
     );

--- a/packages/rps/src/containers/LobbyContainer.tsx
+++ b/packages/rps/src/containers/LobbyContainer.tsx
@@ -8,6 +8,7 @@ import {OpenGame} from '../redux/open-games/state';
 
 const mapStateToProps = (state: SiteState) => ({
   openGames: state.openGames as OpenGame[],
+  createAGameButtonDisabled: 'address' in state.game.localState ? false : true,
 });
 
 const mapDispatchToProps = {

--- a/packages/rps/src/redux/message-service/firebase-inbox-listener.ts
+++ b/packages/rps/src/redux/message-service/firebase-inbox-listener.ts
@@ -6,9 +6,7 @@ import {Message} from '@statechannels/channel-client';
 import {buffers} from 'redux-saga';
 import {FIREBASE_PREFIX} from '../../constants';
 
-export function* firebaseInboxListener(client: RPSChannelClient) {
-  const address: string = (yield call([client, 'getAddress'])).toLowerCase();
-  // ^ ensure this matches the to in message-queued-listener.ts
+export function* firebaseInboxListener(client: RPSChannelClient, address: string) {
   const channel = yield call(
     reduxSagaFirebase.database.channel as any,
     `${FIREBASE_PREFIX}/messages/${address.toLowerCase()}`,

--- a/packages/rps/src/redux/open-games/saga.ts
+++ b/packages/rps/src/redux/open-games/saga.ts
@@ -21,11 +21,13 @@ export default function* openGameSaga(address: string) {
   let myGameIsOnFirebase = false;
 
   while (true) {
-    const action = yield take('*');
-
     const localState: LocalState = yield select(getLocalState);
 
-    if (localState.type === 'Setup.Lobby' || localState.type === 'B.WaitingRoom') {
+    if (
+      localState.type === 'Setup.Lobby' ||
+      localState.type === 'Setup.NeedAddress' ||
+      localState.type === 'B.WaitingRoom'
+    ) {
       // if we're in the lobby we need to sync openGames
       if (!openGameSyncerProcess || !openGameSyncerProcess.isRunning()) {
         openGameSyncerProcess = yield fork(openGameSyncer);
@@ -36,6 +38,7 @@ export default function* openGameSaga(address: string) {
         yield cancel(openGameSyncerProcess);
       }
     }
+    const action = yield take('*');
 
     if (action.type === 'JoinOpenGame' && localState.type === 'A.GameChosen') {
       const openGameKey = `/${FIREBASE_PREFIX}/challenges/${localState.opponentAddress}`;

--- a/packages/rps/src/redux/store.ts
+++ b/packages/rps/src/redux/store.ts
@@ -54,9 +54,7 @@ function* rootSaga() {
     // wait for the address from wallet before starting firebase sagas
     const action: GotAddressFromWallet = yield take('GotAddressFromWallet');
     yield fork(firebaseInboxListener, client, action.address);
-    console.log('firebaseinboxlistener started with address' + action.address);
     yield fork(openGameSaga, action.address);
-    console.log('opengamesafa started with address' + action.address);
   }
 }
 

--- a/packages/wallet/src/redux/sagas/messaging/__tests__/message-handler.test.ts
+++ b/packages/wallet/src/redux/sagas/messaging/__tests__/message-handler.test.ts
@@ -42,6 +42,20 @@ describe("message listener", () => {
       params: {}
     };
 
+    async function enable() {
+      return new Promise(r => r());
+    }
+
+    const ethereum = {
+      enable
+    };
+
+    // mock out window.ethereum.enable
+    Object.defineProperty(window, "ethereum", {
+      enumerable: true,
+      value: ethereum
+    });
+
     return (
       expectSaga(messageHandler, requestMessage, "localhost")
         .withState(initialState)

--- a/packages/wallet/src/redux/sagas/messaging/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-handler.ts
@@ -75,6 +75,10 @@ function* handleMessage(payload: RequestObject) {
     case "GetAddress":
       const address = yield select(getAddress);
       yield fork(messageSender, outgoingMessageActions.addressResponse({id, address}));
+      if (window.ethereum.selectedAddress === null) {
+        //  ask metamask permission to access accounts
+        yield call([window.ethereum, "enable"]);
+      }
       break;
     case "CreateChannel":
       yield handleCreateChannelMessage(payload);

--- a/packages/wallet/src/redux/sagas/messaging/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-handler.ts
@@ -96,6 +96,8 @@ function* handleMessage(payload: RequestObject) {
     case "GetAddress":
       //  ask metamask permission to access accounts
       yield call([window.ethereum, "enable"]);
+      //  block until accounts changed
+      //  (indicating user acceptance)
       yield accountsChangedSaga;
       const address = yield select(getAddress);
       yield fork(messageSender, outgoingMessageActions.addressResponse({id, address}));

--- a/packages/wallet/src/redux/sagas/messaging/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-handler.ts
@@ -75,10 +75,8 @@ function* handleMessage(payload: RequestObject) {
     case "GetAddress":
       const address = yield select(getAddress);
       yield fork(messageSender, outgoingMessageActions.addressResponse({id, address}));
-      if (window.ethereum.selectedAddress === null) {
-        //  ask metamask permission to access accounts
-        yield call([window.ethereum, "enable"]);
-      }
+      //  ask metamask permission to access accounts
+      yield call([window.ethereum, "enable"]);
       break;
     case "CreateChannel":
       yield handleCreateChannelMessage(payload);

--- a/packages/wallet/src/redux/sagas/messaging/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-handler.ts
@@ -18,6 +18,8 @@ import {Web3Provider} from "ethers/providers";
 
 import {ProtocolState} from "src/redux/protocols";
 
+import {eventChannel} from "redux-saga";
+
 import {APPLICATION_PROCESS_ID} from "../../protocols/application/reducer";
 import {
   createStateFromCreateChannelParams,
@@ -45,7 +47,6 @@ import * as actions from "../../actions";
 import {messageSender} from "./message-sender";
 
 import * as outgoingMessageActions from "./outgoing-api-actions";
-import {eventChannel} from "redux-saga";
 
 export function* messageHandler(jsonRpcMessage: object, _domain: string) {
   const parsedMessage = jrs.parseObject(jsonRpcMessage);


### PR DESCRIPTION
Fixes #955 

Any ostensibly easy fix snowballed as I tried to get a reasonable user experience. Currently both the app and the wallet try to access `window.etherem.selectedAddress`, meaning that both should call `window.ethereum.enable()` at some early stage.

The app has some extra machinery to make sure that the user is 
 - not surprised by the ensuing metamask popup
 - not able to progress until authorizing

The wallet does not have that machinery, so the interim solution of this PR is:

-  to not release the state channel signing address to the app until the wallets own `window.ethereum.enable()` workflow resolves.
- to disable buttons in the lobby until the signing address is released

In practice the app and wallet make their `enable()` calls in quick succession, but the prompt from the wallet's call does not pop up (just get the little [1] on the fox's face). 


Starting from a fresh metamask (no connections):

![mm-enable](https://user-images.githubusercontent.com/1833419/74044992-ed7c0600-49c3-11ea-8534-8fd2a53c0db0.gif)

TODO 

- [ ] fix unknown problem where cannot fund game