### PR TITLE
[wallet,rps] Do not call ethereum.enable() from rps

### DIFF
--- a/packages/channel-client/src/channel-client.ts
+++ b/packages/channel-client/src/channel-client.ts
@@ -87,6 +87,11 @@ export class ChannelClient implements ChannelClientInterface<ChannelResult> {
   async getAddress(): Promise<string> {
     return this.provider.send('GetAddress', {});
   }
+
+  async getEthereumSelectedAddress(): Promise<string> {
+    return this.provider.send('GetEthereumSelectedAddress', {});
+  }
+
   async approveBudgetAndFund(
     playerAmount: string,
     hubAmount: string,

--- a/packages/channel-client/src/types.ts
+++ b/packages/channel-client/src/types.ts
@@ -72,6 +72,7 @@ export interface ChannelClientInterface<Payload = object> {
   challengeChannel: (channelId: string) => Promise<ChannelResult>;
   closeChannel: (channelId: string) => Promise<ChannelResult>;
   getAddress: () => Promise<string>;
+  getEthereumSelectedAddress: () => Promise<string>;
 }
 interface Balance {
   playerAmount: string;

--- a/packages/channel-provider/src/types.ts
+++ b/packages/channel-provider/src/types.ts
@@ -6,6 +6,7 @@ import {
   PushMessageResult,
   JoinChannelResult,
   GetAddressResult,
+  GetEthereumSelectedAddressResult,
   ChallengeChannelResult,
   BudgetResult1 as BudgetResult
 } from '@statechannels/client-api-schema';
@@ -62,6 +63,7 @@ export type MethodType = {
   CloseChannel: CloseChannelResult;
   JoinChannel: JoinChannelResult;
   GetAddress: GetAddressResult;
+  GetEthereumSelectedAddress: GetEthereumSelectedAddressResult;
   ChallengeChannel: ChallengeChannelResult;
   ApproveBudgetAndFund: BudgetResult;
   GetBudget: BudgetResult;

--- a/packages/client-api-schema/schema/get-ethereum-selected-address.json
+++ b/packages/client-api-schema/schema/get-ethereum-selected-address.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://statechannels.org/schemas/get-ethereum-selected-address.json",
+  "definitions": {
+    "GetEthereumSelectedAddressResult": {
+      "$ref": "definitions.json#/definitions/Address"
+    },
+
+    "GetEthereumSelectedAddressParams": {
+      "type": "object",
+      "properties": {}
+    }
+  }
+}

--- a/packages/client-api-schema/schema/request.json
+++ b/packages/client-api-schema/schema/request.json
@@ -24,6 +24,7 @@
             "CreateChannel",
             "JoinChannel",
             "GetAddress",
+            "GetEthereumSelectedAddress",
             "PushMessage",
             "UpdateChannel",
             "CloseChannel",

--- a/packages/client-api-schema/types/index.d.ts
+++ b/packages/client-api-schema/types/index.d.ts
@@ -7,6 +7,7 @@ export * from './create-channel';
 //@ts-ignore
 export * from './definitions';
 export * from './get-address';
+export * from './get-ethereum-selected-address';
 //@ts-ignore
 export * from './join-channel';
 export * from './notification';

--- a/packages/rps/.env
+++ b/packages/rps/.env
@@ -12,9 +12,13 @@ CHAIN_NETWORK_ID=9001
 TARGET_NETWORK='development'
 FIREBASE_PROJECT='rock-paper-scissors-dev-4ff8d'
 FIREBASE_API_KEY='AIzaSyAOvhDzJir_El3O6SJ2xQlrpOisnObq6zw'
-WALLET_URL='http://localhost:3055'
+WALLET_URL='http://127.0.0.1:3055'
 BOT_URL=http://localhost:3002
 ##
+
+# Using 127.0.0.1 instead of localhost for WALLET_URL makes development more like production
+# in the sense that metamask sees the app and the wallet being served from two different domains,
+# therefore requiring two seperate connection authorizations
 
 # These values are required if contracts will be deployed to a test network (TARGET_NETWORK!='development')
 # and should be overriden in a .env.local file

--- a/packages/rps/src/__stories__/index.tsx
+++ b/packages/rps/src/__stories__/index.tsx
@@ -41,9 +41,7 @@ const initialState: SiteState = {
     error: undefined,
   },
   metamask: {
-    loading: false,
     network: 0,
-    accounts: [],
   },
   wallet: {
     loading: false,

--- a/packages/rps/src/containers/GameContainer.tsx
+++ b/packages/rps/src/containers/GameContainer.tsx
@@ -22,6 +22,7 @@ import {
   Resigned,
 } from '../components';
 import {unreachable} from '../utils/unreachable';
+import LoadingPage from '../components/LoadingPage';
 
 interface GameProps {
   localState: LocalState;
@@ -44,6 +45,7 @@ function RenderGame(props: GameProps) {
     case 'Setup.Empty':
       return <ProfileContainer />;
     case 'Setup.NeedAddress':
+      return <LoadingPage />;
     case 'Setup.Lobby':
     case 'B.CreatingOpenGame':
       return <LobbyContainer />;

--- a/packages/rps/src/containers/SiteContainer.tsx
+++ b/packages/rps/src/containers/SiteContainer.tsx
@@ -5,14 +5,12 @@ import HomePageContainer from './HomePageContainer';
 import {connect} from 'react-redux';
 import {SiteState} from '../redux/reducer';
 import {WalletError} from '../redux/wallet/actions';
-import LoadingPage from '../components/LoadingPage';
 
 import LoginErrorPage from '../components/LoginErrorPage';
 interface SiteProps {
   isAuthenticated: boolean;
   walletError: WalletError | null;
   loginError: string | undefined;
-  loading: boolean;
 }
 
 class Site extends React.PureComponent<SiteProps> {
@@ -25,9 +23,7 @@ class Site extends React.PureComponent<SiteProps> {
   render() {
     let component;
 
-    if (this.props.loading) {
-      component = <LoadingPage />;
-    } else if (this.props.loginError) {
+    if (this.props.loginError) {
       component = <LoginErrorPage error={this.props.loginError} />;
     } else if (this.props.walletError !== null) {
       component = <code>{JSON.stringify(this.props.walletError, null, 2)}</code>;
@@ -49,7 +45,6 @@ class Site extends React.PureComponent<SiteProps> {
 const mapStateToProps = (state: SiteState) => {
   return {
     isAuthenticated: state.login && state.login.loggedIn,
-    loading: state.metamask.loading,
     walletError: state.wallet.error,
     walletVisible: state.overlay.walletVisible,
     loginError: state.login.error,

--- a/packages/rps/src/containers/__tests__/GameContainer.test.tsx
+++ b/packages/rps/src/containers/__tests__/GameContainer.test.tsx
@@ -19,10 +19,7 @@ describe('GameContainer', () => {
         user: null,
         error: undefined,
       },
-      metamask: {
-        loading: false,
-        accounts: [],
-      },
+      metamask: {},
       wallet: {
         loading: false,
         error: null,

--- a/packages/rps/src/redux/game/saga.ts
+++ b/packages/rps/src/redux/game/saga.ts
@@ -71,10 +71,9 @@ function* gameSagaRun(client: RPSChannelClient) {
   switch (localState.type) {
     case 'Setup.NeedAddress':
       const address: string = yield call([client, 'getAddress']);
-      const outcomeAddress: string = window.ethereum.selectedAddress;
-      if (outcomeAddress) {
-        yield put(a.gotAddressFromWallet(address, outcomeAddress));
-      }
+      // this delegates window.ethereum.enable() to the wallet
+      const outcomeAddress: string = yield call([client, 'getEthereumSelectedAddress']);
+      yield put(a.gotAddressFromWallet(address, outcomeAddress));
       break;
     case 'A.GameChosen':
       if (cs.isEmpty(channelState)) {

--- a/packages/rps/src/redux/game/saga.ts
+++ b/packages/rps/src/redux/game/saga.ts
@@ -73,7 +73,7 @@ function* gameSagaRun(client: RPSChannelClient) {
       const address: string = yield call([client, 'getAddress']);
       // this delegates window.ethereum.enable() to the wallet
       const outcomeAddress: string = yield call([client, 'getEthereumSelectedAddress']);
-      yield put(a.gotAddressFromWallet(address, outcomeAddress));
+      yield put(a.gotAddressFromWallet(address.toLowerCase(), outcomeAddress));
       break;
     case 'A.GameChosen':
       if (cs.isEmpty(channelState)) {

--- a/packages/rps/src/redux/game/saga.ts
+++ b/packages/rps/src/redux/game/saga.ts
@@ -73,7 +73,7 @@ function* gameSagaRun(client: RPSChannelClient) {
       const address: string = yield call([client, 'getAddress']);
       // this delegates window.ethereum.enable() to the wallet
       const outcomeAddress: string = yield call([client, 'getEthereumSelectedAddress']);
-      yield put(a.gotAddressFromWallet(address.toLowerCase(), outcomeAddress));
+      yield put(a.gotAddressFromWallet(address, outcomeAddress));
       break;
     case 'A.GameChosen':
       if (cs.isEmpty(channelState)) {

--- a/packages/rps/src/redux/message-service/firebase-inbox-listener.ts
+++ b/packages/rps/src/redux/message-service/firebase-inbox-listener.ts
@@ -9,7 +9,7 @@ import {FIREBASE_PREFIX} from '../../constants';
 export function* firebaseInboxListener(client: RPSChannelClient, address: string) {
   const channel = yield call(
     reduxSagaFirebase.database.channel as any,
-    `${FIREBASE_PREFIX}/messages/${address.toLowerCase()}`,
+    `${FIREBASE_PREFIX}/messages/${address}`,
     'child_added',
     buffers.fixed(100)
   );

--- a/packages/rps/src/redux/message-service/firebase-inbox-listener.ts
+++ b/packages/rps/src/redux/message-service/firebase-inbox-listener.ts
@@ -6,9 +6,7 @@ import {Message} from '@statechannels/channel-client';
 import {buffers} from 'redux-saga';
 import {FIREBASE_PREFIX} from '../../constants';
 
-export function* firebaseInboxListener(client: RPSChannelClient) {
-  const address: string = (yield call([client, 'getAddress'])).toLowerCase();
-  // ^ ensure this matches the to in message-queued-listener.ts
+export function* firebaseInboxListener(client: RPSChannelClient, address: string) {
   const channel = yield call(
     reduxSagaFirebase.database.channel as any,
     `${FIREBASE_PREFIX}/messages/${address.toLowerCase()}`,

--- a/packages/rps/src/redux/message-service/message-queued-listener.ts
+++ b/packages/rps/src/redux/message-service/message-queued-listener.ts
@@ -10,7 +10,7 @@ export function* messageQueuedListener(client: RPSChannelClient) {
 
   while (true) {
     const notification = yield take(channel);
-    const to = notification.params.recipient.toLowerCase();
+    const to = notification.params.recipient;
     // ^ ensure this matches the address in firebase-inbox-listener.ts
     yield fork(
       reduxSagaFirebase.database.create,

--- a/packages/rps/src/redux/metamask/actions.ts
+++ b/packages/rps/src/redux/metamask/actions.ts
@@ -3,27 +3,9 @@ export interface NetworkChanged {
   network: number;
 }
 
-export interface AccountsChanged {
-  type: 'AccountsChanged';
-  accounts: string[];
-}
-
-export interface Enable {
-  type: 'Enable';
-}
-
 export const networkChanged: (network: number) => NetworkChanged = network => ({
   type: 'NetworkChanged',
   network,
 });
 
-export const accountsChanged: (accounts: string[]) => AccountsChanged = accounts => ({
-  type: 'AccountsChanged',
-  accounts,
-});
-
-export const enable: () => Enable = () => ({
-  type: 'Enable',
-});
-
-export type MetamaskAction = NetworkChanged | AccountsChanged | Enable;
+export type MetamaskAction = NetworkChanged;

--- a/packages/rps/src/redux/metamask/reducer.ts
+++ b/packages/rps/src/redux/metamask/reducer.ts
@@ -2,31 +2,15 @@ import {Reducer} from 'redux';
 import {MetamaskAction} from './actions';
 import {MetamaskState} from './state';
 
-const initialState: MetamaskState = {
-  loading: false,
-  accounts: [],
-};
+const initialState: MetamaskState = {};
 
 export const metamaskReducer: Reducer<MetamaskState> = (
   state: MetamaskState = initialState,
   action: MetamaskAction
 ) => {
-  const accountsExistsFromState = state.accounts[0];
-
   switch (action.type) {
     case 'NetworkChanged': {
       return {...state, network: action.network};
-    }
-    case 'AccountsChanged': {
-      const accountsExistsFromAction = action.accounts[0];
-      return {
-        ...state,
-        accounts: action.accounts,
-        loading: accountsExistsFromAction ? false : state.loading,
-      };
-    }
-    case 'Enable': {
-      return {...state, loading: accountsExistsFromState ? false : true};
     }
     default:
       return state;

--- a/packages/rps/src/redux/metamask/saga.ts
+++ b/packages/rps/src/redux/metamask/saga.ts
@@ -1,14 +1,6 @@
-import {call, put, take, fork} from 'redux-saga/effects';
+import {put, take, fork} from 'redux-saga/effects';
 import * as metamaskActions from './actions';
 import {eventChannel} from 'redux-saga';
-
-function* enableSaga() {
-  while (true) {
-    yield take('UpdateProfile');
-    yield put(metamaskActions.enable());
-    yield call([window.ethereum, 'enable']);
-  }
-}
 
 function* networkChangedSaga() {
   const networkChangedChannel = eventChannel(emit => {
@@ -25,28 +17,10 @@ function* networkChangedSaga() {
   }
 }
 
-function* accountsChangedSaga() {
-  const accountsChangedChannel = eventChannel(emit => {
-    window.ethereum.on('accountsChanged', function(accounts) {
-      emit(accounts);
-    });
-    return () => {
-      /* */
-    };
-  });
-  while (true) {
-    const accounts = yield take(accountsChangedChannel);
-    yield put(metamaskActions.accountsChanged(accounts));
-  }
-}
-
 export default function* metamaskSaga() {
   if (window.ethereum) {
     window.ethereum.autoRefreshOnNetworkChange = false;
     yield put(metamaskActions.networkChanged(window.ethereum.networkVersion));
-    yield put(metamaskActions.accountsChanged([window.ethereum.selectedAddress]));
-    yield fork(accountsChangedSaga);
     yield fork(networkChangedSaga);
-    yield fork(enableSaga);
   }
 }

--- a/packages/rps/src/redux/metamask/state.ts
+++ b/packages/rps/src/redux/metamask/state.ts
@@ -1,5 +1,3 @@
 export interface MetamaskState {
   network?: number;
-  accounts: string[];
-  loading: boolean;
 }

--- a/packages/rps/src/redux/open-games/saga.ts
+++ b/packages/rps/src/redux/open-games/saga.ts
@@ -1,4 +1,4 @@
-import {fork, take, select, cancel, call, apply, put} from 'redux-saga/effects';
+import {fork, take, select, call, apply, put} from 'redux-saga/effects';
 
 export const getLocalState = (storeObj: any) => storeObj.game.localState;
 function getOpenGame(storObj: any, address: string) {
@@ -15,87 +15,34 @@ import {gameJoined} from '../game/actions';
 import {FIREBASE_PREFIX} from '../../constants';
 
 export default function* openGameSaga(address: string) {
-  // could be more efficient by only watching actions that could change the state
-  // this is more robust though, so stick to watching all actions for the time being
-  let openGameSyncerProcess: any = null;
   let myGameIsOnFirebase = false;
+  const localState: LocalState = yield select(getLocalState);
+  const myOpenGameKey = `/${FIREBASE_PREFIX}/challenges/${address}`;
 
+  yield fork(openGameSyncer); // both Players
+  yield fork(joinGameSaga); // player A
+
+  // player B
   while (true) {
-    const localState: LocalState = yield select(getLocalState);
-
-    if (
-      localState.type === 'Setup.Lobby' ||
-      localState.type === 'Setup.NeedAddress' ||
-      localState.type === 'B.WaitingRoom'
-    ) {
-      // if we're in the lobby we need to sync openGames
-      if (!openGameSyncerProcess || !openGameSyncerProcess.isRunning()) {
-        openGameSyncerProcess = yield fork(openGameSyncer);
-      }
-    } else {
-      // if we're not in the lobby, we shouldn't be syncing openGames
-      if (openGameSyncerProcess) {
-        yield cancel(openGameSyncerProcess);
-      }
-    }
     const action = yield take('*');
-
-    if (action.type === 'JoinOpenGame' && localState.type === 'A.GameChosen') {
-      const openGameKey = `/${FIREBASE_PREFIX}/challenges/${localState.opponentAddress}`;
-      const taggedOpenGame = {
-        isPublic: false,
-        playerAName: localState.name,
-        playerAOutcomeAddress: localState.outcomeAddress,
+    if (myGameIsOnFirebase) {
+      myGameIsOnFirebase = yield deleteGameIfJoined(myOpenGameKey); // false if success
+    } else if (action.type === 'CreateGame' && 'outcomeAddress' in localState) {
+      const myPublicOpenGame = {
+        address,
+        outcomeAddress: localState.outcomeAddress,
+        name: localState.name,
+        stake: action.roundBuyIn.toString(),
+        createdAt: new Date().getTime(),
+        isPublic: true,
+        playerAName: 'unknown',
+        playerAOutcomeAddress: 'unknown',
       };
-      yield call(reduxSagaFirebase.database.patch, openGameKey, taggedOpenGame);
+      myGameIsOnFirebase = yield putGameOnFirebase(myOpenGameKey, myPublicOpenGame); // true if success
     }
 
-    if (localState.type === 'B.WaitingRoom') {
-      let myOpenGame;
-      const myOpenGameKey = `/${FIREBASE_PREFIX}/challenges/${address}`;
-
-      if (!myGameIsOnFirebase) {
-        // my game isn't on firebase (as far as the app knows)
-        // attempt to put the game on firebase - will be a no-op if already there
-
-        myOpenGame = {
-          address,
-          outcomeAddress: localState.outcomeAddress || address,
-          name: localState.name,
-          stake: localState.roundBuyIn.toString(),
-          createdAt: new Date().getTime(),
-          isPublic: true,
-          playerAName: 'unknown',
-          playerAOutcomeAddress: 'unknown',
-        };
-
-        const disconnect = firebase
-          .database()
-          .ref(myOpenGameKey)
-          .onDisconnect();
-        yield apply(disconnect, disconnect.remove, []);
-        // use update to allow us to pick our own key
-        yield call(reduxSagaFirebase.database.update, myOpenGameKey, myOpenGame);
-        myGameIsOnFirebase = true;
-      } else {
-        const storeObj = yield select();
-        myOpenGame = getOpenGame(storeObj, myOpenGameKey);
-        if (myOpenGame && !myOpenGame.isPublic) {
-          yield put(
-            gameJoined(
-              myOpenGame.playerAName,
-              myOpenGame.opponentAddress,
-              myOpenGame.playerAOutcomeAddress
-            )
-          );
-          yield call(reduxSagaFirebase.database.delete, myOpenGameKey);
-          myGameIsOnFirebase = false;
-        }
-      }
-    }
-    if (localState.type === 'Setup.Lobby' && myGameIsOnFirebase && localState.address) {
+    if (action.type === 'CancelGame') {
       // we cancelled our game
-      const myOpenGameKey = `/${FIREBASE_PREFIX}/challenges/${localState.address}`;
       yield call(reduxSagaFirebase.database.delete, myOpenGameKey);
       myGameIsOnFirebase = false;
     }
@@ -125,4 +72,48 @@ function* openGameSyncer() {
     },
     'value'
   );
+}
+
+function* joinGameSaga() {
+  while (true) {
+    const action = yield take('JoinOpenGame');
+    const localState: LocalState = yield select(getLocalState);
+    if ('name' in localState && 'outcomeAddress' in localState) {
+      const openGameKey = `/${FIREBASE_PREFIX}/challenges/${action.opponentAddress}`;
+      const taggedOpenGame = {
+        isPublic: false,
+        playerAName: localState.name,
+        playerAOutcomeAddress: localState.outcomeAddress,
+      };
+      yield call(reduxSagaFirebase.database.patch, openGameKey, taggedOpenGame);
+    }
+  }
+}
+
+function* putGameOnFirebase(myOpenGameKey: string, myOpenGame: any) {
+  const disconnect = firebase
+    .database()
+    .ref(myOpenGameKey)
+    .onDisconnect();
+  yield apply(disconnect, disconnect.remove, []);
+  // use update to allow us to pick our own key
+  yield call(reduxSagaFirebase.database.update, myOpenGameKey, myOpenGame);
+  return true; // myGmeIsOnFirebase mutex
+}
+
+function* deleteGameIfJoined(myOpenGameKey: string) {
+  const storeObj = yield select();
+  const myOpenGame = getOpenGame(storeObj, myOpenGameKey);
+  if (myOpenGame && !myOpenGame.isPublic) {
+    yield put(
+      gameJoined(
+        myOpenGame.playerAName,
+        myOpenGame.opponentAddress,
+        myOpenGame.playerAOutcomeAddress
+      )
+    );
+    yield call(reduxSagaFirebase.database.delete, myOpenGameKey);
+    return false; // myGameIsOnFirebase mutex
+  }
+  return true;
 }

--- a/packages/rps/src/redux/open-games/saga.ts
+++ b/packages/rps/src/redux/open-games/saga.ts
@@ -21,11 +21,13 @@ export default function* openGameSaga(address: string) {
   let myGameIsOnFirebase = false;
 
   while (true) {
-    const action = yield take('*');
-
     const localState: LocalState = yield select(getLocalState);
 
-    if (localState.type === 'Setup.Lobby' || localState.type === 'B.WaitingRoom') {
+    if (
+      localState.type === 'Setup.Lobby' ||
+      localState.type === 'Setup.NeedAddress' ||
+      localState.type === 'B.WaitingRoom'
+    ) {
       // if we're in the lobby we need to sync openGames
       if (!openGameSyncerProcess || !openGameSyncerProcess.isRunning()) {
         openGameSyncerProcess = yield fork(openGameSyncer);
@@ -36,6 +38,7 @@ export default function* openGameSaga(address: string) {
         yield cancel(openGameSyncerProcess);
       }
     }
+    const action = yield take('*');
 
     if (action.type === 'JoinOpenGame' && localState.type === 'A.GameChosen') {
       const openGameKey = `/${FIREBASE_PREFIX}/challenges/${localState.opponentAddress}`;

--- a/packages/rps/src/redux/store.ts
+++ b/packages/rps/src/redux/store.ts
@@ -54,9 +54,7 @@ function* rootSaga() {
     // wait for the address from wallet before starting firebase sagas
     const action: GotAddressFromWallet = yield take('GotAddressFromWallet');
     yield fork(firebaseInboxListener, client, action.address);
-    console.log('firebaseinboxlistener started with address' + action.address);
     yield fork(openGameSaga, action.address);
-    console.log('opengamesafa started with address' + action.address);
   }
 }
 

--- a/packages/rps/src/redux/store.ts
+++ b/packages/rps/src/redux/store.ts
@@ -37,8 +37,8 @@ function* rootSaga() {
     yield fork(messageQueuedListener, client);
   }
 
-  yield fork(gameSaga, client);
   yield fork(channelUpdatedListener, client);
+  yield fork(gameSaga, client);
 
   if (process.env.AUTO_PLAYER === 'A') {
     yield fork(autoPlayer, 'A');

--- a/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
+++ b/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
@@ -90,6 +90,9 @@ class MockChannelClient implements ChannelClientInterface {
   getAddress = jest.fn(async function() {
     return await MOCK_ADDRESS;
   });
+  getEthereumSelectedAddress = jest.fn(async function() {
+    return await MOCK_ADDRESS;
+  });
 }
 
 let mockChannelClient;

--- a/packages/rps/src/utils/rps-channel-client.ts
+++ b/packages/rps/src/utils/rps-channel-client.ts
@@ -40,6 +40,10 @@ export class RPSChannelClient {
     return this.channelClient.getAddress();
   }
 
+  async getEthereumSelectedAddress() {
+    return this.channelClient.getEthereumSelectedAddress();
+  }
+
   onMessageQueued(callback: (message: Message) => void) {
     return this.channelClient.onMessageQueued(callback);
   }

--- a/packages/wallet/src/json-rpc-validation/validator.ts
+++ b/packages/wallet/src/json-rpc-validation/validator.ts
@@ -3,6 +3,7 @@ import requestSchema from "@statechannels/client-api-schema/schema/request.json"
 import responseSchema from "@statechannels/client-api-schema/schema/response.json";
 import createChannelSchema from "@statechannels/client-api-schema/schema/create-channel.json";
 import getAddressSchema from "@statechannels/client-api-schema/schema/get-address.json";
+import getEthereumSelectedAddressSchema from "@statechannels/client-api-schema/schema/get-ethereum-selected-address.json";
 import joinChannelSchema from "@statechannels/client-api-schema/schema/join-channel.json";
 import updateChannelSchema from "@statechannels/client-api-schema/schema/update-channel.json";
 import definitionsSchema from "@statechannels/client-api-schema/schema/definitions.json";
@@ -24,6 +25,7 @@ export async function validateRequest(jsonRpcRequest: object): Promise<Validatio
     .addSchema(channelResultSchema)
     .addSchema(createChannelSchema)
     .addSchema(getAddressSchema)
+    .addSchema(getEthereumSelectedAddressSchema)
     .addSchema(joinChannelSchema)
     .addSchema(updateChannelSchema)
     .addSchema(pushMessageSchema)
@@ -42,6 +44,7 @@ export async function validateResponse(jsonRpcResponse: object): Promise<Validat
     .addSchema(channelResultSchema)
     .addSchema(createChannelSchema)
     .addSchema(getAddressSchema)
+    .addSchema(getEthereumSelectedAddressSchema)
     .addSchema(joinChannelSchema)
     .addSchema(updateChannelSchema)
     .addSchema(pushMessageSchema)
@@ -60,6 +63,7 @@ export async function validateNotification(jsonRpcNotification: object): Promise
     .addSchema(channelResultSchema)
     .addSchema(createChannelSchema)
     .addSchema(getAddressSchema)
+    .addSchema(getEthereumSelectedAddressSchema)
     .addSchema(joinChannelSchema)
     .addSchema(updateChannelSchema)
     .addSchema(pushMessageSchema)

--- a/packages/wallet/src/redux/sagas/messaging/__tests__/message-handler.test.ts
+++ b/packages/wallet/src/redux/sagas/messaging/__tests__/message-handler.test.ts
@@ -42,6 +42,20 @@ describe("message listener", () => {
       params: {}
     };
 
+    async function enable() {
+      return new Promise(r => r());
+    }
+
+    const ethereum = {
+      enable
+    };
+
+    // mock out window.ethereum.enable
+    Object.defineProperty(window, "ethereum", {
+      enumerable: true,
+      value: ethereum
+    });
+
     return (
       expectSaga(messageHandler, requestMessage, "localhost")
         .withState(initialState)

--- a/packages/wallet/src/redux/sagas/messaging/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-handler.ts
@@ -18,6 +18,8 @@ import {Web3Provider} from "ethers/providers";
 
 import {ProtocolState} from "src/redux/protocols";
 
+import {eventChannel} from "redux-saga";
+
 import {APPLICATION_PROCESS_ID} from "../../protocols/application/reducer";
 import {
   createStateFromCreateChannelParams,
@@ -75,10 +77,8 @@ function* handleMessage(payload: RequestObject) {
     case "GetAddress":
       const address = yield select(getAddress);
       yield fork(messageSender, outgoingMessageActions.addressResponse({id, address}));
-      if (window.ethereum.selectedAddress === null) {
-        //  ask metamask permission to access accounts
-        yield call([window.ethereum, "enable"]);
-      }
+      //  ask metamask permission to access accounts
+      yield call([window.ethereum, "enable"]);
       break;
     case "CreateChannel":
       yield handleCreateChannelMessage(payload);

--- a/packages/wallet/src/redux/sagas/messaging/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-handler.ts
@@ -75,6 +75,10 @@ function* handleMessage(payload: RequestObject) {
     case "GetAddress":
       const address = yield select(getAddress);
       yield fork(messageSender, outgoingMessageActions.addressResponse({id, address}));
+      if (window.ethereum.selectedAddress === null) {
+        //  ask metamask permission to access accounts
+        yield call([window.ethereum, "enable"]);
+      }
       break;
     case "CreateChannel":
       yield handleCreateChannelMessage(payload);

--- a/packages/wallet/src/redux/sagas/messaging/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-handler.ts
@@ -73,7 +73,6 @@ export function* messageHandler(jsonRpcMessage: object, _domain: string) {
 
 function* accountsChangedSaga() {
   if (window.ethereum.selectedAddress !== null) {
-    console.log(yield window.ethereum.selectedAddress);
     return yield window.ethereum.selectedAddress;
     // saga completes if metamask unlocked
   }

--- a/packages/wallet/src/redux/sagas/messaging/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-handler.ts
@@ -75,6 +75,11 @@ function* handleMessage(payload: RequestObject) {
   const {id} = payload;
   switch (payload.method) {
     case "GetAddress":
+      //  ask metamask permission to access accounts
+      yield call([window.ethereum, "enable"]);
+      //  block until accounts changed
+      //  (indicating user acceptance)
+      yield accountsChangedSaga;
       const address = yield select(getAddress);
       yield fork(messageSender, outgoingMessageActions.addressResponse({id, address}));
       //  ask metamask permission to access accounts

--- a/packages/wallet/src/redux/sagas/messaging/message-sender.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-sender.ts
@@ -41,6 +41,8 @@ function* createResponseMessage(action: OutgoingApiAction) {
       return jrs.success(action.id, yield getChannelInfo(action.channelId));
     case "WALLET.ADDRESS_RESPONSE":
       return jrs.success(action.id, action.address);
+    case "WALLET.ETHEREUM_ADDRESS_RESPONSE":
+      return jrs.success(action.id, action.ethereumSelectedAddress);
     case "WALLET.NO_CONTRACT_ERROR":
       return jrs.error(action.id, new jrs.JsonRpcError("Invalid app definition", 1001));
     case "WALLET.VALIDATION_ERROR":

--- a/packages/wallet/src/redux/sagas/messaging/outgoing-api-actions.ts
+++ b/packages/wallet/src/redux/sagas/messaging/outgoing-api-actions.ts
@@ -41,9 +41,20 @@ export interface AddressResponse extends ApiResponseAction {
   type: "WALLET.ADDRESS_RESPONSE";
   address: string;
 }
+
 export const addressResponse: ActionConstructor<AddressResponse> = p => ({
   ...p,
   type: "WALLET.ADDRESS_RESPONSE"
+});
+
+export interface EthereumAddressResponse extends ApiResponseAction {
+  type: "WALLET.ETHEREUM_ADDRESS_RESPONSE";
+  ethereumSelectedAddress: string;
+}
+
+export const ethereumAddressResponse: ActionConstructor<EthereumAddressResponse> = p => ({
+  ...p,
+  type: "WALLET.ETHEREUM_ADDRESS_RESPONSE"
 });
 
 export interface UnknownSigningAddress extends ApiResponseAction {
@@ -184,6 +195,7 @@ export const closeChannelResponse: ActionConstructor<CloseChannelResponse> = p =
 
 export type OutgoingApiAction =
   | AddressResponse
+  | EthereumAddressResponse
   | CreateChannelResponse
   | UpdateChannelResponse
   | ChallengeChannelResponse


### PR DESCRIPTION
Get `window.ethereum.selectedAddress` via the wallet thru new json-rpc method. 

This pattern can be replicated for `web3torrent`.

+ Some refactoring of the open game saga in `rps`.
- Thin out `rps` metamask saga in `rps` (doesn't do much)

Fixes #955 