### PR TITLE
Rename Protocol Store to Obsolete Store

### DIFF
--- a/packages/wallet-protocols/src/__tests__/createAndJoinoChannel.integration.test.ts
+++ b/packages/wallet-protocols/src/__tests__/createAndJoinoChannel.integration.test.ts
@@ -10,7 +10,7 @@ import {
   Init,
   machine,
 } from '../protocols/wallet/protocol';
-import { EphemeralStore, Store } from '../store';
+import { EphemeralObsoleteStore, ObsoleteStore } from '../store';
 import { messageService } from '../messaging';
 import { AddressableMessage } from '../wire-protocol';
 import { log } from '../utils';
@@ -47,12 +47,12 @@ const createChannel: CreateChannelEvent = {
 
 const chain = new Chain();
 
-const stores: Record<string, Store> = {};
+const stores: Record<string, ObsoleteStore> = {};
 
 const connect = (wallet: ethers.Wallet, store?) => {
   store =
     store ||
-    new EphemeralStore({
+    new EphemeralObsoleteStore({
       privateKeys: { [wallet.address]: wallet.privateKey },
       chain,
     });
@@ -116,14 +116,14 @@ test('opening a channel', async () => {
 
 test('concluding a channel', async () => {
   const data1 = storeWithFundedChannel(wallet1.privateKey);
-  const firstStore = new EphemeralStore({
+  const firstStore = new EphemeralObsoleteStore({
     nonces: data1._nonces,
     privateKeys: data1._privateKeys,
     store: data1._store,
   });
 
   const data2 = storeWithFundedChannel(wallet2.privateKey);
-  const secondStore = new EphemeralStore({
+  const secondStore = new EphemeralObsoleteStore({
     nonces: data2._nonces,
     privateKeys: data2._privateKeys,
     store: data2._store,

--- a/packages/wallet-protocols/src/__tests__/data.ts
+++ b/packages/wallet-protocols/src/__tests__/data.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 import { State } from '@statechannels/nitro-protocol';
 
-import { Participant, EphemeralStore } from '../store';
+import { Participant, EphemeralObsoleteStore } from '../store';
 
 export const wallet1 = new ethers.Wallet(
   '0x95942b296854c97024ca3145abef8930bf329501b718c0f66d57dba596ff1318'
@@ -91,7 +91,7 @@ export const ledgerState: State = {
 };
 
 export const storeWithKey = (chain, privateKey) =>
-  new EphemeralStore({
+  new EphemeralObsoleteStore({
     privateKeys: {
       [new ethers.Wallet(privateKey).address]: privateKey,
     },

--- a/packages/wallet-protocols/src/__tests__/directFunding.integration.test.ts
+++ b/packages/wallet-protocols/src/__tests__/directFunding.integration.test.ts
@@ -18,7 +18,7 @@ import { IChannelStoreEntry } from '../ChannelStoreEntry';
 import { log } from '../utils';
 import { MachineFactory } from '../machine-utils';
 import { messageService } from '../messaging';
-import { Store, Participant } from '../store';
+import { ObsoleteStore, Participant } from '../store';
 
 import { wallet1, wallet2, participants, storeWithKey } from './data';
 import { invokedState } from './utils';
@@ -29,7 +29,7 @@ const EXPECT_TIMEOUT = process.env.CI ? 9500 : 2000;
 
 const chain = new Chain();
 
-const stores: Record<string, Store> = {};
+const stores: Record<string, ObsoleteStore> = {};
 
 function connect<T>(
   wallet: Wallet,
@@ -65,7 +65,10 @@ test('directly funding a channel', async () => {
     },
   ];
 
-  const entry: (store: Store, channel: Channel) => IChannelStoreEntry = (store, channel) => ({
+  const entry: (store: ObsoleteStore, channel: Channel) => IChannelStoreEntry = (
+    store,
+    channel
+  ) => ({
     channel,
     participants: participants.filter(p =>
       channel.participants.find(addr => addr === p.signingAddress)

--- a/packages/wallet-protocols/src/__tests__/virtualFunding.integration.test.ts
+++ b/packages/wallet-protocols/src/__tests__/virtualFunding.integration.test.ts
@@ -3,7 +3,7 @@ import waitForExpect from 'wait-for-expect';
 import { interpret } from 'xstate';
 import { Channel } from '@statechannels/nitro-protocol';
 
-import { Store, Participant } from '../store';
+import { ObsoleteStore, Participant } from '../store';
 import { messageService } from '../messaging';
 import { AddressableMessage } from '../wire-protocol';
 import { Chain } from '../chain';
@@ -22,7 +22,7 @@ const EXPECT_TIMEOUT = process.env.CI ? 9500 : 2000;
 
 const chain = new Chain();
 
-const stores: Record<string, Store> = {};
+const stores: Record<string, ObsoleteStore> = {};
 
 function connect<T>(
   wallet: ethers.Wallet,
@@ -74,7 +74,10 @@ test('virtually funding a channel', async () => {
     channelNonce: '0xaa',
   };
 
-  const entry: (store: Store, channel: Channel) => IChannelStoreEntry = (store, channel) => ({
+  const entry: (store: ObsoleteStore, channel: Channel) => IChannelStoreEntry = (
+    store,
+    channel
+  ) => ({
     channel,
     participants: participants.filter(p =>
       channel.participants.find(addr => addr === p.signingAddress)

--- a/packages/wallet-protocols/src/index.ts
+++ b/packages/wallet-protocols/src/index.ts
@@ -54,7 +54,7 @@ export function checkThat<T, S>(t: T | S, isTypeT: TypeGuard<T, S>): T {
   return t;
 }
 
-export { EphemeralStore, Store, Constructor, ChannelUpdated } from './store';
+export { EphemeralObsoleteStore, ObsoleteStore, Constructor, ChannelUpdated } from './store';
 export { IChain, ChainEvent, ChainEventType, ChainEventListener } from './chain';
 export { ChannelStoreEntry } from './ChannelStoreEntry';
 export { SignedState } from './types';

--- a/packages/wallet-protocols/src/machine-utils.ts
+++ b/packages/wallet-protocols/src/machine-utils.ts
@@ -1,6 +1,6 @@
 import { DoneInvokeEvent, EventObject, Machine, MachineConfig, StateMachine } from 'xstate';
 
-import { FINAL, Store } from '.';
+import { FINAL, ObsoleteStore } from '.';
 
 /*
 Since machines typically  don't have sync access to a store, we invoke a promise to get the
@@ -30,17 +30,17 @@ export function getDataAndInvoke<T>(data: string, src: string, onDone?: string, 
 // Some machine factories require a context, and some don't
 // Sort this out.
 export type MachineFactory<I, E extends EventObject> = (
-  store: Store,
+  store: ObsoleteStore,
   context?: I
 ) => StateMachine<I, any, E>;
 
-type Options = (store: Store) => any;
+type Options = (store: ObsoleteStore) => any;
 type Config<T> = MachineConfig<T, any, any>;
 export const connectToStore: <T>(config: Config<T>, options: Options) => MachineFactory<T, any> = <
   T
 >(
   config: Config<T>,
   options: Options
-) => (store: Store, context?: T | undefined) => {
+) => (store: ObsoleteStore, context?: T | undefined) => {
   return Machine(config).withConfig(options(store), context);
 };

--- a/packages/wallet-protocols/src/protocols/advance-channel/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/advance-channel/protocol.ts
@@ -1,7 +1,7 @@
 import { AnyEventObject, MachineConfig, assign, spawn } from 'xstate';
 import { filter, map } from 'rxjs/operators';
 
-import { Store, observeChannel } from '../../store';
+import { ObsoleteStore, observeChannel } from '../../store';
 import { connectToStore } from '../../machine-utils';
 
 const PROTOCOL = 'advance-channel';
@@ -42,7 +42,7 @@ export type Services = {
   sendState(ctx: Init): Promise<void>;
 };
 
-const notifyWhenAdvanced = (store: Store, ctx: Init) => {
+const notifyWhenAdvanced = (store: ObsoleteStore, ctx: Init) => {
   return observeChannel(store, ctx.channelId).pipe(
     map(event => event.entry),
     filter(e => {
@@ -52,7 +52,7 @@ const notifyWhenAdvanced = (store: Store, ctx: Init) => {
   );
 };
 
-const sendState = (store: Store) => async ({ channelId, targetTurnNum }: Init) => {
+const sendState = (store: ObsoleteStore) => async ({ channelId, targetTurnNum }: Init) => {
   const turnNum = targetTurnNum;
   /*
   TODO: the actual turnNum is calculated below. However, to determine whether
@@ -73,7 +73,7 @@ const sendState = (store: Store) => async ({ channelId, targetTurnNum }: Init) =
   }
 };
 
-const options = (store: Store) => ({
+const options = (store: ObsoleteStore) => ({
   services: {
     sendState: sendState(store),
   },

--- a/packages/wallet-protocols/src/protocols/conclude-channel/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/conclude-channel/protocol.ts
@@ -3,7 +3,7 @@ import { Machine } from 'xstate';
 import { FINAL, checkThat, outcomesEqual } from '../..';
 import { MachineFactory, getDataAndInvoke } from '../../machine-utils';
 import { add } from '../../mathOps';
-import { Store } from '../../store';
+import { ObsoleteStore } from '../../store';
 import { isIndirectFunding } from '../../ChannelStoreEntry';
 import { ethAllocationOutcome, getEthAllocation } from '../../calculations';
 
@@ -65,7 +65,7 @@ export const mockOptions = {
   },
 };
 
-export const machine: MachineFactory<Init, any> = (store: Store, ctx: Init) => {
+export const machine: MachineFactory<Init, any> = (store: ObsoleteStore, ctx: Init) => {
   async function getFinalState({ channelId }: Init): Promise<SupportState.Init> {
     const { latestStateSupportedByMe, latestState } = store.getEntry(channelId);
 

--- a/packages/wallet-protocols/src/protocols/create-and-direct-fund/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/create-and-direct-fund/protocol.ts
@@ -5,7 +5,7 @@ import { AllocationAssetOutcome } from '@statechannels/nitro-protocol';
 import { AddressZero } from 'ethers/constants';
 
 import { MachineFactory } from '../../machine-utils';
-import { Store } from '../..';
+import { ObsoleteStore } from '../..';
 
 import { Participant } from '../../store';
 
@@ -91,7 +91,7 @@ export const config: MachineConfig<Context, any, any> = {
   },
 };
 
-export const machine: MachineFactory<Init, any> = (store: Store, init: Init) => {
+export const machine: MachineFactory<Init, any> = (store: ObsoleteStore, init: Init) => {
   async function constructFirstState(ctx: Init): Promise<void> {
     const { appData, appDefinition, channelId, challengeDuration } = ctx;
 

--- a/packages/wallet-protocols/src/protocols/create-channel/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/create-channel/protocol.ts
@@ -2,7 +2,7 @@ import { DoneInvokeEvent, Machine, MachineConfig, assign, sendParent } from 'xst
 import { Channel, State } from '@statechannels/nitro-protocol';
 import { CreateChannelParams, AllocationItem } from '@statechannels/client-api-schema';
 
-import { Store, success } from '../..';
+import { ObsoleteStore, success } from '../..';
 import { MachineFactory } from '../../machine-utils';
 import { ethAllocationOutcome } from '../../calculations';
 import { ChannelStoreEntry } from '../../ChannelStoreEntry';
@@ -95,7 +95,7 @@ export const config: MachineConfig<Context, any, any> = {
   },
 };
 
-export const machine: MachineFactory<Init, any> = (store: Store, init: Init) => {
+export const machine: MachineFactory<Init, any> = (store: ObsoleteStore, init: Init) => {
   async function initializeChannel(ctx: Init): Promise<SetChannel> {
     const participants = ctx.participants.map(p => p.signingAddress);
     const channelNonce = store.getNextNonce(participants);

--- a/packages/wallet-protocols/src/protocols/depositing/protocol.test.ts
+++ b/packages/wallet-protocols/src/protocols/depositing/protocol.test.ts
@@ -3,7 +3,7 @@ import { ethers } from 'ethers';
 import waitForExpect from 'wait-for-expect';
 
 import { Chain } from '../../chain';
-import { EphemeralStore } from '../..';
+import { EphemeralObsoleteStore } from '../..';
 import { log } from '../../utils';
 
 import { Init, machine } from './protocol';
@@ -12,7 +12,7 @@ jest.setTimeout(50000);
 
 it('handles the basic case going first', async () => {
   const chain = new Chain();
-  const store = new EphemeralStore({ chain });
+  const store = new EphemeralObsoleteStore({ chain });
   const channelId = ethers.utils.id('channel');
   const context: Init = {
     channelId: ethers.utils.id('channel'),
@@ -40,7 +40,7 @@ it('handles the basic case going first', async () => {
 
 it('handles the basic case', async () => {
   const chain = new Chain();
-  const store = new EphemeralStore({ chain });
+  const store = new EphemeralObsoleteStore({ chain });
   const channelId = ethers.utils.id('channel');
   const context: Init = {
     channelId: ethers.utils.id('channel'),

--- a/packages/wallet-protocols/src/protocols/depositing/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/depositing/protocol.ts
@@ -3,7 +3,7 @@ import { InvokeCallback, Machine, MachineConfig } from 'xstate';
 
 import { FINAL } from '../..';
 import { MachineFactory } from '../../machine-utils';
-import { Store } from '../../store';
+import { ObsoleteStore } from '../../store';
 import { ChainEvent } from '../../chain';
 
 export type Init = {
@@ -51,7 +51,7 @@ type Services = {
 };
 
 type Options = { services: Services };
-export const machine: MachineFactory<Init, any> = (store: Store, context: Init) => {
+export const machine: MachineFactory<Init, any> = (store: ObsoleteStore, context: Init) => {
   const subscribeDepositEvent = (ctx: Init): InvokeCallback => cb => {
     if (bigNumberify(ctx.depositAt).eq(0)) cb('SAFE_TO_DEPOSIT');
 

--- a/packages/wallet-protocols/src/protocols/direct-funding/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/direct-funding/protocol.ts
@@ -7,7 +7,7 @@ import { AddressZero, HashZero } from 'ethers/constants';
 import { MachineFactory, getDataAndInvoke } from '../../machine-utils';
 import { FINAL } from '../../';
 import { add, gt, subtract } from '../../mathOps';
-import { Store } from '../../store';
+import { ObsoleteStore } from '../../store';
 import { ethAllocationOutcome, getEthAllocation } from '../../calculations';
 
 import { Depositing, SupportState } from '..';
@@ -75,7 +75,7 @@ type Services = {
 
 type Options = { services: Services };
 
-export const machine: MachineFactory<Init, any> = (store: Store, context: Init) => {
+export const machine: MachineFactory<Init, any> = (store: ObsoleteStore, context: Init) => {
   async function checkCurrentLevel(ctx: Init) {
     const entry = store.getEntry(ctx.channelId);
 

--- a/packages/wallet-protocols/src/protocols/funding/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/funding/protocol.ts
@@ -1,6 +1,6 @@
 import { DoneInvokeEvent, Machine, assign } from 'xstate';
 
-import { failure, Store, success } from '../..';
+import { failure, ObsoleteStore, success } from '../..';
 import { MachineFactory, getDataAndInvoke } from '../../machine-utils';
 
 import { FundingStrategy, FundingStrategyProposed } from '../../wire-protocol';
@@ -93,7 +93,7 @@ const fundVirtually = {
   },
 };
 
-const getTargetAllocation = (store: Store) => async ({
+const getTargetAllocation = (store: ObsoleteStore) => async ({
   targetChannelId,
 }: Init): Promise<LedgerFunding.Init> => {
   const deductions = getEthAllocation(
@@ -174,7 +174,7 @@ function strategyChoice({
 }
 export const mockOptions: Partial<Options> = { guards };
 
-export const machine: MachineFactory<Init, any> = (store: Store, context: Init) => {
+export const machine: MachineFactory<Init, any> = (store: ObsoleteStore, context: Init) => {
   function sendClientChoice(ctx: ClientChoiceKnown) {
     store.sendStrategyChoice(strategyChoice(ctx));
   }

--- a/packages/wallet-protocols/src/protocols/join-channel/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/join-channel/protocol.ts
@@ -2,7 +2,7 @@ import { DoneInvokeEvent, Machine, MachineConfig, assign, sendParent } from 'xst
 import { getChannelId } from '@statechannels/nitro-protocol';
 
 import { MachineFactory } from '../../machine-utils';
-import { ChannelUpdated, Store } from '../../store';
+import { ChannelUpdated, ObsoleteStore } from '../../store';
 import { CloseChannel, OpenChannel } from '../../wire-protocol';
 import { OpenChannelEvent } from '../wallet/protocol';
 import { forwardChannelUpdated } from '../..';
@@ -120,7 +120,7 @@ export type Actions = {
   sendCloseChannel({ channelId }: Context): void;
 };
 
-export const machine: MachineFactory<Init, any> = (store: Store, ctx: Init) => {
+export const machine: MachineFactory<Init, any> = (store: ObsoleteStore, ctx: Init) => {
   const actions: Actions = {
     sendCloseChannel: () => {
       console.log('TODO: Send close channel');

--- a/packages/wallet-protocols/src/protocols/ledger-funding/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/ledger-funding/protocol.ts
@@ -2,7 +2,7 @@ import { assign, DoneInvokeEvent, Machine, MachineConfig } from 'xstate';
 import { Allocation } from '@statechannels/nitro-protocol';
 
 import { allocateToTarget, getEthAllocation } from '../../calculations';
-import { Channel, Store, success } from '../..';
+import { Channel, ObsoleteStore, success } from '../..';
 import { MachineFactory, getDataAndInvoke } from '../../machine-utils';
 import { Funding } from '../../ChannelStoreEntry';
 
@@ -116,7 +116,7 @@ export const guards = {
   channelFound: (_, { data }: DoneInvokeEvent<LedgerLookup>) => data.type === 'FOUND',
 };
 
-export const machine: MachineFactory<Init, any> = (store: Store, context: Init) => {
+export const machine: MachineFactory<Init, any> = (store: ObsoleteStore, context: Init) => {
   async function getNullChannelArgs({ targetChannelId }: Init): Promise<CreateNullChannel.Init> {
     const { channel: targetChannel } = store.getEntry(targetChannelId);
 

--- a/packages/wallet-protocols/src/protocols/support-state/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/support-state/protocol.ts
@@ -3,7 +3,7 @@ import { State, getChannelId } from '@statechannels/nitro-protocol';
 import { filter, map } from 'rxjs/operators';
 
 import { outcomesEqual, statesEqual } from '../..';
-import { Store, observeChannel } from '../../store';
+import { ObsoleteStore, observeChannel } from '../../store';
 import { connectToStore } from '../../machine-utils';
 
 const PROTOCOL = 'support-state';
@@ -35,7 +35,7 @@ type Options = {
   actions: { spawnObserver: AssignAction<Init, any> };
 };
 
-const sendState = (store: Store) => async ({ state }: Init) => {
+const sendState = (store: ObsoleteStore) => async ({ state }: Init) => {
   const entry = store.getEntry(getChannelId(state.channel));
   const { latestStateSupportedByMe, hasSupportedState } = entry;
   // TODO: Should these safety checks be performed in the store?
@@ -57,7 +57,7 @@ const sendState = (store: Store) => async ({ state }: Init) => {
   }
 };
 
-const notifyWhenSupported = (store: Store, { state }: Init) => {
+const notifyWhenSupported = (store: ObsoleteStore, { state }: Init) => {
   return observeChannel(store, getChannelId(state.channel)).pipe(
     map(event => event.entry),
     filter(e => e.hasSupportedState && statesEqual(e.latestSupportedState, state)),
@@ -65,7 +65,7 @@ const notifyWhenSupported = (store: Store, { state }: Init) => {
   );
 };
 
-const options = (store: Store): Options => ({
+const options = (store: ObsoleteStore): Options => ({
   services: {
     sendState: sendState(store),
   },

--- a/packages/wallet-protocols/src/protocols/virtual-fund-as-hub/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/virtual-fund-as-hub/protocol.ts
@@ -1,6 +1,6 @@
 import { Channel } from '@statechannels/nitro-protocol';
 
-import { Store } from '../../store';
+import { ObsoleteStore } from '../../store';
 import { Balance } from '../../types';
 import { connectToStore, getDataAndInvoke } from '../../machine-utils';
 import { VirtualLeaf, CreateNullChannel, SupportState, LedgerFunding } from '../';
@@ -15,7 +15,7 @@ export interface Init {
   guarantorChannels: [Channel, Channel];
 }
 
-const jointChannelArgs = (store: Store) => async ({
+const jointChannelArgs = (store: ObsoleteStore) => async ({
   jointChannel,
   balances,
 }: Init): Promise<CreateNullChannel.Init> =>
@@ -32,7 +32,7 @@ const createJointChannel = getDataAndInvoke(
   'joint'
 );
 
-const guarantorArgs = (index: VirtualLeaf.Indices) => (store: Store) => async ({
+const guarantorArgs = (index: VirtualLeaf.Indices) => (store: ObsoleteStore) => async ({
   jointChannel,
   guarantorChannels,
 }: Init): Promise<CreateNullChannel.Init> =>
@@ -108,7 +108,7 @@ export const config = {
   states: { createChannels, fundGuarantors, fundTarget, success: { type: FINAL } },
 };
 
-const options = (store: Store) => ({
+const options = (store: ObsoleteStore) => ({
   services: {
     fundTargetArgs: VirtualLeaf.fundTargetArgs(store),
     createNullChannel: CreateNullChannel.machine(store),

--- a/packages/wallet-protocols/src/protocols/virtual-fund-as-leaf/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/virtual-fund-as-leaf/protocol.ts
@@ -6,7 +6,7 @@ import { Channel, getChannelId, outcomesEqual } from '../../';
 import { add } from '../../mathOps';
 import { Balance } from '../../types';
 import { ethGuaranteeOutcome, ethAllocationOutcome } from '../../calculations';
-import { Store } from '../../store';
+import { ObsoleteStore } from '../../store';
 import { connectToStore, getDataAndInvoke } from '../../machine-utils';
 
 import { CreateNullChannel, SupportState, LedgerFunding } from '..';
@@ -32,7 +32,7 @@ const allocationItem = (balance: Balance): AllocationItem => ({
   amount: balance.wei,
 });
 
-export const jointChannelArgs = (store: Store) => async ({
+export const jointChannelArgs = (store: ObsoleteStore) => async ({
   jointChannel,
   balances,
   hubAddress,
@@ -61,7 +61,7 @@ function jointChannelAllocation(balances: Balance[], hubAddress: string) {
   return allocation;
 }
 
-export const guarantorChannelArgs = (store: Store) => async ({
+export const guarantorChannelArgs = (store: ObsoleteStore) => async ({
   jointChannel,
   index,
   guarantorChannel,
@@ -109,7 +109,7 @@ const fundGuarantor = {
   invoke: { src: 'ledgerFunding', data: fundGuarantorArgs, onDone: 'fundTarget' },
 };
 
-export function fundTargetArgs(store: Store) {
+export function fundTargetArgs(store: ObsoleteStore) {
   return async ({
     jointChannel,
     balances,
@@ -152,7 +152,7 @@ export const config = {
   states: { createChannels, fundGuarantor, fundTarget, success: { type: 'final' as 'final' } },
 };
 
-const options = (store: Store) => ({
+const options = (store: ObsoleteStore) => ({
   services: {
     fundGuarantorArgs,
     fundTargetArgs: fundTargetArgs(store),

--- a/packages/wallet-protocols/src/protocols/wallet/protocol.ts
+++ b/packages/wallet-protocols/src/protocols/wallet/protocol.ts
@@ -1,7 +1,7 @@
 import { AssignAction, Interpreter, Machine, MachineConfig, assign, spawn } from 'xstate';
 
 import { getChannelId } from '../..';
-import { Store } from '../../store';
+import { ObsoleteStore } from '../../store';
 import { FundingStrategyProposed, OpenChannel, SendStates } from '../../wire-protocol';
 
 import { ConcludeChannel, CreateChannel, JoinChannel } from '..';
@@ -58,7 +58,7 @@ export type Actions = {
   updateStore: any; // TODO
 };
 
-export function machine(store: Store, context: Init) {
+export function machine(store: ObsoleteStore, context: Init) {
   const spawnCreateChannel = assign(
     (ctx: Init, { type, ...init }: CreateChannelEvent): Init => {
       const processId = `create-channel`;

--- a/packages/wallet-protocols/src/store.ts
+++ b/packages/wallet-protocols/src/store.ts
@@ -23,8 +23,8 @@ export interface ChannelUpdated {
 export type StoreEvent = ChainEvent | ChannelUpdated;
 export type StoreEventType = ChainEventType | ChannelUpdated['type'];
 export type StoreEventListener = (event: StoreEvent) => void;
-
-export interface Store {
+// TODO: This store is obsolete and should be removed when everything is migrated to the new store
+export interface ObsoleteStore {
   getEntry(channelId: string): ChannelStoreEntry;
   getParticipant(signingAddress: string): Participant;
   getHoldings: IChain['getHoldings'];
@@ -74,7 +74,7 @@ export type Constructor = Partial<{
   messagingService: IMessageService;
   ethAssetHolderAddress: string;
 }>;
-export class EphemeralStore implements Store {
+export class EphemeralObsoleteStore implements ObsoleteStore {
   public static equals(left: SignedState[], right: SignedState[]) {
     // TODO: Delete this; we should use statesEqual and outcomesEqual
     return _.isEqual(
@@ -288,7 +288,7 @@ export class EphemeralStore implements Store {
     const entry = this.getEntry(channelId);
     const newEntry = { ...entry, states: merge(states, entry.states) };
     this._store[channelId] = newEntry;
-    if (!EphemeralStore.equals(entry.states, newEntry.states)) {
+    if (!EphemeralObsoleteStore.equals(entry.states, newEntry.states)) {
       const channelUpdated: ChannelUpdated = {
         type: 'CHANNEL_UPDATED',
         channelId,
@@ -302,7 +302,7 @@ export class EphemeralStore implements Store {
 
 // For subscriber convenience, construct a ChannelStoreEntry
 type T = { type: ChannelUpdated['type']; channelId: string; entry: ChannelStoreEntry };
-export function observeChannel(store: Store, channelId: string): rxjs.Observable<T> {
+export function observeChannel(store: ObsoleteStore, channelId: string): rxjs.Observable<T> {
   const firstEntry: Promise<ChannelUpdated | { type: 'NOT_FOUND' }> = new Promise(resolve => {
     try {
       const entry = store.getEntry(channelId);

--- a/packages/wallet-protocols/src/temp-store.ts
+++ b/packages/wallet-protocols/src/temp-store.ts
@@ -1,5 +1,5 @@
 // TODO: This is temporary until all protocols have been updated
 // to not depend on a global store being defined
-import { Store } from './store';
-const store: Store = {} as Store;
+import { ObsoleteStore } from './store';
+const store: ObsoleteStore = {} as ObsoleteStore;
 export { store };

--- a/packages/xstate-wallet/src/index.ts
+++ b/packages/xstate-wallet/src/index.ts
@@ -1,6 +1,6 @@
 import {handleMessage, sendMessage} from './messaging';
 
-import {Store, EphemeralStore} from '@statechannels/wallet-protocols';
+import {ObsoleteStore, EphemeralObsoleteStore} from '@statechannels/wallet-protocols';
 import {ethers} from 'ethers';
 
 import {ChainWatcher} from './chain';
@@ -11,7 +11,7 @@ const ourWallet = ethers.Wallet.createRandom();
 
 const chain = new ChainWatcher();
 
-const store: Store = new EphemeralStore({
+const store: ObsoleteStore = new EphemeralObsoleteStore({
   chain,
   privateKeys: {
     [ourWallet.address]: ourWallet.privateKey

--- a/packages/xstate-wallet/src/messaging.ts
+++ b/packages/xstate-wallet/src/messaging.ts
@@ -8,7 +8,7 @@ import {
 import {
   getChannelId,
   Channel,
-  Store,
+  ObsoleteStore,
   CreateChannelEvent,
   ChannelStoreEntry,
   AddressableMessage
@@ -76,7 +76,7 @@ async function metamaskUnlocked(): Promise<string> {
 export async function handleMessage(
   event,
   workflowManager: WorkflowManager,
-  store: Store,
+  store: ObsoleteStore,
   ourWallet: ethers.Wallet
 ) {
   if (event.data && event.data.jsonrpc && event.data.jsonrpc === '2.0') {
@@ -135,7 +135,10 @@ export async function handleMessage(
   }
 }
 
-async function handleJoinChannel(payload: {id: jrs.ID; params: JoinChannelParams}, store: Store) {
+async function handleJoinChannel(
+  payload: {id: jrs.ID; params: JoinChannelParams},
+  store: ObsoleteStore
+) {
   // TODO: The application workflow should be updated to wait until we get a  join channel from the client
   const {id} = payload;
   const {channelId} = payload.params;
@@ -146,7 +149,7 @@ async function handleJoinChannel(payload: {id: jrs.ID; params: JoinChannelParams
 async function handleCloseChannel(
   payload: jrs.RequestObject,
   workflowManager: WorkflowManager,
-  store: Store
+  store: ObsoleteStore
 ) {
   const {id} = payload;
   const {channelId} = payload.params as CloseChannelParams;
@@ -158,7 +161,7 @@ async function handleCloseChannel(
 async function handleUpdateChannel(
   payload: jrs.RequestObject,
   workflowManager: WorkflowManager,
-  store: Store
+  store: ObsoleteStore
 ) {
   const params = payload.params as UpdateChannelParams;
   const entry = store.getEntry(params.channelId);
@@ -192,7 +195,7 @@ async function handlePushMessage(payload: jrs.RequestObject, workflowManager: Wo
 async function handleCreateChannelMessage(
   payload: jrs.RequestObject,
   workflowManager: WorkflowManager,
-  store: Store,
+  store: ObsoleteStore,
   ethersWallet: ethers.Wallet
 ) {
   const params = payload.params as CreateChannelParams;

--- a/packages/xstate-wallet/src/ui/stories/application-workflow.stories.tsx
+++ b/packages/xstate-wallet/src/ui/stories/application-workflow.stories.tsx
@@ -5,10 +5,10 @@ import {
 export default {title: 'X-state wallet'};
 import {storiesOf} from '@storybook/react';
 import {interpret} from 'xstate';
-import {EphemeralStore} from '@statechannels/wallet-protocols';
+import {EphemeralObsoleteStore} from '@statechannels/wallet-protocols';
 import {renderWalletInFrontOfApp} from './helpers';
 
-const store = new EphemeralStore({
+const store = new EphemeralObsoleteStore({
   privateKeys: {
     ['0xaddress']: '0xkey'
   },

--- a/packages/xstate-wallet/src/ui/stories/confirm-create-channel-workflow.stories.tsx
+++ b/packages/xstate-wallet/src/ui/stories/confirm-create-channel-workflow.stories.tsx
@@ -6,11 +6,11 @@ import {
 export default {title: 'X-state wallet'};
 import {storiesOf} from '@storybook/react';
 import {interpret} from 'xstate';
-import {EphemeralStore} from '@statechannels/wallet-protocols';
+import {EphemeralObsoleteStore} from '@statechannels/wallet-protocols';
 import {Participant} from '@statechannels/client-api-schema/types/definitions';
 import {renderWalletInFrontOfApp} from './helpers';
 
-const store = new EphemeralStore({
+const store = new EphemeralObsoleteStore({
   privateKeys: {
     ['0xaddress']: '0xkey'
   },

--- a/packages/xstate-wallet/src/workflow-manager.ts
+++ b/packages/xstate-wallet/src/workflow-manager.ts
@@ -1,6 +1,6 @@
 import {Actor, Interpreter, interpret} from 'xstate';
 import {
-  Store,
+  ObsoleteStore,
   ChannelUpdated,
   CreateChannelEvent,
   OpenChannelEvent,
@@ -37,9 +37,9 @@ export interface Workflow {
 
 export class WorkflowManager {
   workflows: Workflow[];
-  store: Store;
+  store: ObsoleteStore;
   tempMachine;
-  constructor(store: Store) {
+  constructor(store: ObsoleteStore) {
     this.workflows = [];
     this.store = store;
   }

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -14,7 +14,7 @@ import {
 import {
   FINAL,
   ConcludeChannel,
-  Store,
+  ObsoleteStore,
   SendStates,
   ChannelUpdated,
   ChannelStoreEntry,
@@ -217,7 +217,7 @@ const generateConfig = (
   }
 });
 
-export const applicationWorkflow = (store: Store, context?: WorkflowContext) => {
+export const applicationWorkflow = (store: ObsoleteStore, context?: WorkflowContext) => {
   const notifyOnChannelMessage = ({channelId}: ChannelIdExists) => {
     return observeRequests(channelId).pipe(
       map(params => {

--- a/packages/xstate-wallet/src/workflows/confirm-create-channel.ts
+++ b/packages/xstate-wallet/src/workflows/confirm-create-channel.ts
@@ -1,6 +1,6 @@
 import {MachineConfig, Action, StateSchema, Machine, Condition, StateMachine} from 'xstate';
 import {Participant, TokenAllocations} from '@statechannels/client-api-schema';
-import {Store} from '@statechannels/wallet-protocols';
+import {ObsoleteStore} from '@statechannels/wallet-protocols';
 import {sendDisplayMessage} from '../messaging';
 import {createMockGuard} from '../utils/workflow-utils';
 
@@ -94,7 +94,7 @@ const actions = {
 };
 export const config = generateConfig(actions, guards);
 export const confirmChannelCreationWorkflow = (
-  _store: Store,
+  _store: ObsoleteStore,
   context: WorkflowContext
 ): WorkflowMachine => {
   // TODO: Once budgets are a thing this should check for a budget

--- a/packages/xstate-wallet/src/workflows/tests/application.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/application.test.ts
@@ -2,7 +2,7 @@ import {interpret} from 'xstate';
 import {ethers} from 'ethers';
 import waitForExpect from 'wait-for-expect';
 import {
-  EphemeralStore,
+  EphemeralObsoleteStore,
   CreateChannelEvent,
   SignedState,
   getChannelId,
@@ -23,7 +23,7 @@ const createChannelEvent: CreateChannelEvent = {
 };
 
 it('initializes and starts confirmCreateChannelWorkflow', async () => {
-  const store = new EphemeralStore();
+  const store = new EphemeralObsoleteStore();
   const services: Partial<WorkflowServices> = {
     invokeCreateChannelConfirmation: jest.fn().mockReturnValue(
       new Promise(() => {
@@ -44,7 +44,7 @@ it('initializes and starts confirmCreateChannelWorkflow', async () => {
 });
 
 it('invokes the createChannelAndFund protocol', async () => {
-  const store = new EphemeralStore();
+  const store = new EphemeralObsoleteStore();
   const services: Partial<WorkflowServices> = {
     invokeCreateChannelAndDirectFundProtocol: jest.fn().mockReturnValue(
       new Promise(() => {
@@ -71,7 +71,7 @@ it('invokes the createChannelAndFund protocol', async () => {
 });
 
 it('raises an channel updated action when the channel is updated', async () => {
-  const store = new EphemeralStore();
+  const store = new EphemeralObsoleteStore();
   const mockOptions = {
     actions: {
       sendChannelUpdatedNotification: jest.fn()
@@ -91,7 +91,7 @@ it('raises an channel updated action when the channel is updated', async () => {
 });
 
 it('handles confirmCreateChannel workflow finishing', async () => {
-  const store = new EphemeralStore();
+  const store = new EphemeralObsoleteStore();
   const services: Partial<WorkflowServices> = {
     createChannel: jest.fn().mockReturnValue(Promise.resolve('0xb1ab1a')),
     invokeCreateChannelAndDirectFundProtocol: jest.fn().mockReturnValue(
@@ -118,7 +118,7 @@ it('handles confirmCreateChannel workflow finishing', async () => {
 });
 
 it('initializes and starts the join channel machine', async () => {
-  const store = new EphemeralStore();
+  const store = new EphemeralObsoleteStore();
   const event: OpenChannelEvent = {
     type: 'OPEN_CHANNEL',
     channelId: '0xabc'
@@ -141,7 +141,7 @@ it('initializes and starts the join channel machine', async () => {
 });
 
 it('starts concluding when requested', async () => {
-  const store = new EphemeralStore();
+  const store = new EphemeralObsoleteStore();
   const channelId = ethers.utils.id('channel');
   const services: Partial<WorkflowServices> = {
     invokeClosingProtocol: jest.fn().mockReturnValue(
@@ -163,7 +163,7 @@ it('starts concluding when requested', async () => {
 });
 
 it('starts concluding when receiving a final state', async () => {
-  const store = new EphemeralStore();
+  const store = new EphemeralObsoleteStore();
   const states: SignedState[] = [
     {
       state: {


### PR DESCRIPTION
Renames `Store` to `ObsoleteStore` so it's clear that the old store is no longer used.