### PR TITLE
Downgrade solc, do not use native solc in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,6 @@ defaults: &defaults
   resource_class: medium
   docker:
     - image: counterfactual/statechannels:0.5.13 # Fast contract compilation with solc installed
-      environment:
-        USE_NATIVE_SOLC: true
     - image: circleci/postgres:12.0-alpine
       environment:
         POSTGRES_USER: root

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -15,7 +15,7 @@
     "fs-extra": "8.1.0",
     "jest": "25.1.0",
     "loglevel": "1.6.6",
-    "solc": "0.6.2",
+    "solc": "0.5.13",
     "yargs": "15.1.0"
   },
   "devDependencies": {

--- a/packages/jest-gas-reporter/package.json
+++ b/packages/jest-gas-reporter/package.json
@@ -8,7 +8,7 @@
     "easy-table": "1.1.1",
     "ethers": "4.0.44",
     "path": "0.12.7",
-    "solc": "0.6.2",
+    "solc": "0.5.13",
     "typescript": "3.7.5"
   },
   "devDependencies": {

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -42,7 +42,7 @@
     "prettier": "1.19.1",
     "prettier-plugin-solidity": "1.0.0-alpha.34",
     "server-destroy": "1.0.1",
-    "solc": "0.6.2",
+    "solc": "0.5.13",
     "solidoc": "https://github.com/statechannels/solidoc.git",
     "ts-jest": "25.0.0",
     "ts-node": "8.6.2",

--- a/patches/@counterfactual+cf-adjudicator-contracts+0.0.11.patch
+++ b/patches/@counterfactual+cf-adjudicator-contracts+0.0.11.patch
@@ -1,10 +1,10 @@
 diff --git a/node_modules/@counterfactual/cf-adjudicator-contracts/contracts/interfaces/CounterfactualApp.sol b/node_modules/@counterfactual/cf-adjudicator-contracts/contracts/interfaces/CounterfactualApp.sol
-index 5ba3e0e..5f684e1 100644
+index d823033..31595b9 100644
 --- a/node_modules/@counterfactual/cf-adjudicator-contracts/contracts/interfaces/CounterfactualApp.sol
 +++ b/node_modules/@counterfactual/cf-adjudicator-contracts/contracts/interfaces/CounterfactualApp.sol
 @@ -1,4 +1,4 @@
 -pragma solidity 0.5.12;
-+pragma solidity 0.5.13;
++pragma solidity ^0.5.13;
  pragma experimental "ABIEncoderV2";
  
  

--- a/yarn.lock
+++ b/yarn.lock
@@ -26134,10 +26134,10 @@ socks@~2.3.2:
     ip "1.1.5"
     smart-buffer "^4.1.0"
 
-solc@0.6.2:
-  version "0.6.2"
-  resolved "https://registry.npmjs.org/solc/-/solc-0.6.2.tgz#0340520782caef3e8230af6785aba17625415c73"
-  integrity sha512-PIFb/i7HSQXXfsXHlGDR+B2BCaQ+Bx7gpZ7bz+zLz2rPePyxkIJgLmb4rgRKYxEnIp5dKilcjKRPbrz8GNlIHQ==
+solc@0.5.13:
+  version "0.5.13"
+  resolved "https://registry.npmjs.org/solc/-/solc-0.5.13.tgz#2a5ba2b7681898c6293759441e0a768fb6955def"
+  integrity sha512-osybDVPGjAqcmSKLU3vh5iHuxbhGlJjQI5ZvI7nRDR0fgblQqYte4MGvNjbew8DPvCrmoH0ZBiz/KBBLlPxfMg==
   dependencies:
     command-exists "^1.2.8"
     commander "3.0.2"


### PR DESCRIPTION
1. Downgrade `solc` npm package since our contracts still use solidity version `^0.5.13`. `openzeppelin` does not support solidity version 0.6 yet, and our contracts import `openzeppelin` contracts.
1. Maybe more controversial. Do not use native solc on CircleCI. The downside is that the prepare step is 30 seconds slower. The upside the following. With native solc (installed through apt-get in the docker image), we are not able to control what version of solc is used. As a result, every time we rebuild the docker image, we are forced to upgrade to the latest solc package.