### PR TITLE
Revert "Revert "Store states when they arrive""

### DIFF
--- a/packages/xstate-wallet/src/store/memory-store.ts
+++ b/packages/xstate-wallet/src/store/memory-store.ts
@@ -50,7 +50,7 @@ export interface Store {
   channelUpdatedFeed(channelId: string): Observable<ChannelStoreEntry>;
 
   getAddress(): string;
-  signState(channelId: string, stateVars: StateVariables);
+  signAndAddState(channelId: string, stateVars: StateVariables);
   createChannel(
     participants: Participant[],
     challengeDuration: BigNumber,
@@ -159,7 +159,7 @@ export class MemoryStore implements Store {
     });
 
     // sign the state, store the channel
-    this.signState(entry.channelId, stateVars);
+    this.signAndAddState(entry.channelId, stateVars);
 
     return Promise.resolve(entry);
   }
@@ -176,7 +176,7 @@ export class MemoryStore implements Store {
 
   private nonceKeyFromAddresses = (addresses: string[]): string => addresses.join('::');
 
-  signState(channelId: string, stateVars: StateVariables) {
+  signAndAddState(channelId: string, stateVars: StateVariables) {
     const channelStorage = this._channels[channelId];
 
     if (!channelStorage) {

--- a/packages/xstate-wallet/src/store/memory-store.ts
+++ b/packages/xstate-wallet/src/store/memory-store.ts
@@ -52,7 +52,6 @@ export interface Store {
 
   getAddress(): string;
   signState(channelId: string, stateVars: StateVariables);
-  addState(state: SignedState);
   createChannel(
     participants: Participant[],
     challengeDuration: BigNumber,

--- a/packages/xstate-wallet/src/store/memory-store.ts
+++ b/packages/xstate-wallet/src/store/memory-store.ts
@@ -71,7 +71,7 @@ export class MemoryStore implements Store {
   private _objectives: Objective[] = [];
   private _nonces: Record<string, BigNumber | undefined> = {};
   private _eventEmitter = new EventEmitter<InternalEvents>();
-  private _privateKeys: Record<string, string> = {};
+  private _privateKeys: Record<string, string | undefined> = {};
   // private _channels: Record<string, any> = {};
 
   constructor(privateKeys?: string[], chain?: Chain) {

--- a/packages/xstate-wallet/src/store/memory-store.ts
+++ b/packages/xstate-wallet/src/store/memory-store.ts
@@ -72,7 +72,6 @@ export class MemoryStore implements Store {
   private _nonces: Record<string, BigNumber | undefined> = {};
   private _eventEmitter = new EventEmitter<InternalEvents>();
   private _privateKeys: Record<string, string | undefined> = {};
-  // private _channels: Record<string, any> = {};
 
   constructor(privateKeys?: string[], chain?: Chain) {
     // TODO: We shouldn't default to a fake chain

--- a/packages/xstate-wallet/src/store/memory-store.ts
+++ b/packages/xstate-wallet/src/store/memory-store.ts
@@ -55,6 +55,7 @@ export interface Store {
   createChannel(
     participants: Participant[],
     challengeDuration: BigNumber,
+    stateVars: StateVariables,
     appDefinition?: string
   ): Promise<ChannelStoreEntry>;
   getEntry(channelId): Promise<ChannelStoreEntry>;
@@ -117,6 +118,7 @@ export class MemoryStore implements Store {
   public async createChannel(
     participants: Participant[],
     challengeDuration: BigNumber,
+    stateVars: StateVariables,
     appDefinition = AddressZero
   ): Promise<ChannelStoreEntry> {
     const addresses = participants.map(x => x.signingAddress);
@@ -140,6 +142,9 @@ export class MemoryStore implements Store {
       {channelNonce, chainId, participants, appDefinition, challengeDuration},
       myIndex
     );
+
+    // sign the state, store the channel
+    this.signState(channelId, stateVars);
 
     return Promise.resolve(this._channels[channelId]);
   }
@@ -177,7 +182,12 @@ export class MemoryStore implements Store {
     let channelStorage = this._channels[channelId];
 
     if (!channelStorage) {
-      await this.createChannel(state.participants, state.challengeDuration, state.appDefinition);
+      await this.createChannel(
+        state.participants,
+        state.challengeDuration,
+        state,
+        state.appDefinition
+      );
       channelStorage = this._channels[channelId];
     }
 

--- a/packages/xstate-wallet/src/store/memory-store.ts
+++ b/packages/xstate-wallet/src/store/memory-store.ts
@@ -7,7 +7,7 @@ import {getChannelId} from '@statechannels/nitro-protocol';
 import {BigNumber, bigNumberify} from 'ethers/utils';
 import {Wallet} from 'ethers';
 
-import {Participant, StateVariables, State} from './types';
+import {Participant, StateVariables, State, SignedState} from './types';
 import {MemoryChannelStoreEntry, ChannelStoreEntry} from './memory-channel-storage';
 import {AddressZero} from 'ethers/constants';
 import {Objective, Message} from './wire-protocol';
@@ -47,17 +47,17 @@ interface InternalEvents {
 export interface Store {
   newObjectiveFeed: Observable<Objective>;
   outboxFeed: Observable<Message>;
-  pushMessage: (message: Message) => void;
+  pushMessage: (message: Message) => Promise<void>;
   channelUpdatedFeed(channelId: string): Observable<ChannelStoreEntry>;
 
   getAddress(): string;
-  addState(channelId: string, stateVars: StateVariables);
+  signState(channelId: string, stateVars: StateVariables);
+  addState(state: SignedState);
   createChannel(
     participants: Participant[],
     challengeDuration: BigNumber,
-    stateVars: StateVariables,
     appDefinition?: string
-  ): Promise<string>;
+  ): Promise<ChannelStoreEntry>;
   getEntry(channelId): Promise<ChannelStoreEntry>;
 
   // TODO: Shoud this be part of the store?
@@ -118,9 +118,8 @@ export class MemoryStore implements Store {
   public async createChannel(
     participants: Participant[],
     challengeDuration: BigNumber,
-    stateVars: StateVariables,
     appDefinition = AddressZero
-  ): Promise<string> {
+  ): Promise<ChannelStoreEntry> {
     const addresses = participants.map(x => x.signingAddress);
 
     const myIndex = addresses.findIndex(address => !!this._privateKeys[address]);
@@ -143,10 +142,7 @@ export class MemoryStore implements Store {
       myIndex
     );
 
-    // sign the state, store the channel
-    this.addState(channelId, stateVars);
-
-    return Promise.resolve(channelId);
+    return Promise.resolve(this._channels[channelId]);
   }
 
   private getNonce(addresses: string[]): BigNumber | undefined {
@@ -159,7 +155,7 @@ export class MemoryStore implements Store {
 
   private nonceKeyFromAddresses = (addresses: string[]): string => addresses.join('::');
 
-  addState(channelId: string, stateVars: StateVariables) {
+  signState(channelId: string, stateVars: StateVariables) {
     const channelStorage = this._channels[channelId];
 
     if (!channelStorage) {
@@ -177,24 +173,39 @@ export class MemoryStore implements Store {
     this._eventEmitter.emit('addToOutbox', {signedStates: [signedState]});
   }
 
+  async addState(state: SignedState) {
+    const channelId = calculateChannelId(state);
+    let channelStorage = this._channels[channelId];
+
+    if (!channelStorage) {
+      await this.createChannel(state.participants, state.challengeDuration, state.appDefinition);
+      channelStorage = this._channels[channelId];
+    }
+
+    channelStorage.addState(state, state.signature);
+  }
+
   public getAddress(): string {
     return Object.keys(this._privateKeys)[0];
   }
 
-  pushMessage(message: Message) {
+  async pushMessage(message: Message) {
     const {signedStates, objectives} = message;
 
     if (signedStates) {
       // todo: check sig
       // todo: check the channel involves me
-      signedStates.forEach(signedState => {
-        const {signature, ...state} = signedState;
-        this._eventEmitter.emit('stateReceived', state);
-      });
+      await Promise.all(
+        signedStates.map(async signedState => {
+          const {signature, ...state} = signedState;
+          await this.addState(signedState);
+          this._eventEmitter.emit('stateReceived', state);
+        })
+      );
     }
 
     objectives?.forEach(objective => {
-      if (!this._objectives.find(p => _.isEqual(p, objective))) {
+      if (!_.includes(this._objectives, objective)) {
         this._objectives.push(objective);
         this._eventEmitter.emit('newObjective', objective);
       }
@@ -202,13 +213,7 @@ export class MemoryStore implements Store {
   }
 
   public async getEntry(channelId: string): Promise<ChannelStoreEntry> {
-    const entry = this._channels[channelId];
-    return new MemoryChannelStoreEntry(
-      entry.channelConstants,
-      entry.myIndex,
-      entry.stateVariables,
-      entry.signatures
-    );
+    return this._channels[channelId];
   }
 
   chainUpdatedFeed(channelId: string) {

--- a/packages/xstate-wallet/src/workflows/advance-channel.ts
+++ b/packages/xstate-wallet/src/workflows/advance-channel.ts
@@ -63,10 +63,10 @@ const sendState = (store: Store) => async ({channelId, targetTurnNum}: Init) => 
   const {supported} = await store.getEntry(channelId);
 
   if (!!supported && supported.turnNum.lt(targetTurnNum)) {
-    store.signState(channelId, {...supported, turnNum});
+    store.signAndAddState(channelId, {...supported, turnNum});
   } else if (!supported) {
     const {latest} = await store.getEntry(channelId);
-    store.signState(channelId, {...latest, turnNum});
+    store.signAndAddState(channelId, {...latest, turnNum});
   }
 };
 

--- a/packages/xstate-wallet/src/workflows/advance-channel.ts
+++ b/packages/xstate-wallet/src/workflows/advance-channel.ts
@@ -63,10 +63,10 @@ const sendState = (store: Store) => async ({channelId, targetTurnNum}: Init) => 
   const {supported} = await store.getEntry(channelId);
 
   if (!!supported && supported.turnNum.lt(targetTurnNum)) {
-    store.addState(channelId, {...supported, turnNum});
+    store.signState(channelId, {...supported, turnNum});
   } else if (!supported) {
     const {latest} = await store.getEntry(channelId);
-    store.addState(channelId, {...latest, turnNum});
+    store.signState(channelId, {...latest, turnNum});
   }
 };
 

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -288,18 +288,18 @@ export const applicationWorkflow = (store: Store, context?: WorkflowContext) => 
         appData,
         appDefinition
       } = context.channelParams;
-      const {channelId} = await store.createChannel(
-        participants,
-        bigNumberify(challengeDuration),
-        appDefinition
-      );
       const stateVars: StateVariables = {
         outcome,
         appData,
         turnNum: bigNumberify(0),
         isFinal: false
       };
-      store.signState(channelId, stateVars);
+      const {channelId} = await store.createChannel(
+        participants,
+        bigNumberify(challengeDuration),
+        stateVars,
+        appDefinition
+      );
       return channelId;
     },
     invokeClosingProtocol: (context: ChannelIdExists) => {

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -235,7 +235,7 @@ export const applicationWorkflow = (store: Store, context?: WorkflowContext) => 
     })),
 
     sendToOpponent: (context: ChannelIdExists, event) => {
-      store.addState(context.channelId, event.state);
+      store.signState(context.channelId, event.state);
     },
     sendChannelUpdatedNotification: (
       context: ChannelIdExists,
@@ -280,7 +280,7 @@ export const applicationWorkflow = (store: Store, context?: WorkflowContext) => 
   };
 
   const services: WorkflowServices = {
-    createChannel: (context: ChannelParamsExist) => {
+    createChannel: async (context: ChannelParamsExist) => {
       const {
         participants,
         challengeDuration,
@@ -288,18 +288,19 @@ export const applicationWorkflow = (store: Store, context?: WorkflowContext) => 
         appData,
         appDefinition
       } = context.channelParams;
+      const {channelId} = await store.createChannel(
+        participants,
+        bigNumberify(challengeDuration),
+        appDefinition
+      );
       const stateVars: StateVariables = {
         outcome,
         appData,
         turnNum: bigNumberify(0),
         isFinal: false
       };
-      return store.createChannel(
-        participants,
-        bigNumberify(challengeDuration),
-        stateVars,
-        appDefinition
-      );
+      store.signState(channelId, stateVars);
+      return channelId;
     },
     invokeClosingProtocol: (context: ChannelIdExists) => {
       // TODO: Close machine needs to accept new store

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -235,7 +235,7 @@ export const applicationWorkflow = (store: Store, context?: WorkflowContext) => 
     })),
 
     sendToOpponent: (context: ChannelIdExists, event) => {
-      store.signState(context.channelId, event.state);
+      store.signAndAddState(context.channelId, event.state);
     },
     sendChannelUpdatedNotification: (
       context: ChannelIdExists,

--- a/packages/xstate-wallet/src/workflows/create-and-direct-fund.ts
+++ b/packages/xstate-wallet/src/workflows/create-and-direct-fund.ts
@@ -90,7 +90,7 @@ export const machine: MachineFactory<Init, any> = (store: Store, init: Init) => 
   async function constructFirstState(ctx: Init): Promise<void> {
     const {appData, channelId, outcome} = ctx;
 
-    store.addState(channelId, {
+    store.signState(channelId, {
       appData,
       isFinal: false,
       turnNum: bigNumberify(0),

--- a/packages/xstate-wallet/src/workflows/create-and-direct-fund.ts
+++ b/packages/xstate-wallet/src/workflows/create-and-direct-fund.ts
@@ -90,7 +90,7 @@ export const machine: MachineFactory<Init, any> = (store: Store, init: Init) => 
   async function constructFirstState(ctx: Init): Promise<void> {
     const {appData, channelId, outcome} = ctx;
 
-    store.signState(channelId, {
+    store.signAndAddState(channelId, {
       appData,
       isFinal: false,
       turnNum: bigNumberify(0),

--- a/packages/xstate-wallet/src/workflows/support-state.ts
+++ b/packages/xstate-wallet/src/workflows/support-state.ts
@@ -52,7 +52,7 @@ const sendState = (store: Store) => async ({state, channelId}: HasChannelId) => 
     // We always support a final state if it matches the outcome that we have signed
     (state.isFinal && outcomesEqual(state.outcome, latestSupportedByMe.outcome))
   ) {
-    await store.addState(channelId, state);
+    await store.signState(channelId, state);
   } else {
     throw 'Not safe to send';
   }

--- a/packages/xstate-wallet/src/workflows/support-state.ts
+++ b/packages/xstate-wallet/src/workflows/support-state.ts
@@ -52,7 +52,7 @@ const sendState = (store: Store) => async ({state, channelId}: HasChannelId) => 
     // We always support a final state if it matches the outcome that we have signed
     (state.isFinal && outcomesEqual(state.outcome, latestSupportedByMe.outcome))
   ) {
-    await store.signState(channelId, state);
+    await store.signAndAddState(channelId, state);
   } else {
     throw 'Not safe to send';
   }


### PR DESCRIPTION
- Reverts statechannels/monorepo#1014
- Correctly uses `signState` in ported protocols
-  Replace `Record<string, SomeType>` with `Record<string, SomeType | undefined>`, forcing users to deal with non-existing entries.