### PR TITLE
(Partial) Virtual funding workflow

### DIFF
--- a/packages/xstate-wallet/.vscode/launch.json
+++ b/packages/xstate-wallet/.vscode/launch.json
@@ -22,6 +22,14 @@
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
       "smartStep": true
+    },
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach by Process ID",
+      "processId": "${command:PickProcess}",
+      "skipFiles": ["<node_internals>/**"],
+      "sourceMaps": true
     }
   ]
 }

--- a/packages/xstate-wallet/src/store/memory-channel-storage.ts
+++ b/packages/xstate-wallet/src/store/memory-channel-storage.ts
@@ -74,20 +74,22 @@ export class MemoryChannelStoreEntry implements ChannelStoreEntry {
     });
   }
 
-  private get sortedByTurnNum(): Array<StateVariables & {signatures: string[]}> {
-    return this.signedStates.sort((a, b) => a.turnNum.sub(b.turnNum).toNumber());
+  private get sortedByDescendingTurnNum(): Array<StateVariables & {signatures: string[]}> {
+    return this.signedStates.sort((a, b) => b.turnNum.sub(a.turnNum).toNumber());
   }
 
   get supported() {
     // TODO: proper check
-    return this.sortedByTurnNum.find(s => s.signatures.length === this.participants.length);
+    return this.sortedByDescendingTurnNum.find(
+      s => s.signatures.length === this.participants.length
+    );
   }
 
   get latestSupportedByMe() {
-    return this.sortedByTurnNum.find(s => this.mySignature(s, s.signatures));
+    return this.sortedByDescendingTurnNum.find(s => this.mySignature(s, s.signatures));
   }
   get latest(): StateVariables {
-    return this.sortedByTurnNum[0];
+    return this.sortedByDescendingTurnNum[0];
   }
 
   get channelId(): string {

--- a/packages/xstate-wallet/src/store/memory-channel-storage.ts
+++ b/packages/xstate-wallet/src/store/memory-channel-storage.ts
@@ -20,7 +20,31 @@ export class MemoryChannelStoreEntry implements ChannelStoreEntry {
     private states: Record<string, StateVariables | undefined> = {},
     private signatures: Record<string, string[] | undefined> = {},
     public funding: Funding | undefined = undefined
-  ) {}
+  ) {
+    const {
+      challengeDuration,
+      chainId,
+      channelNonce,
+      appDefinition,
+      participants
+    } = this.channelConstants;
+    this.channelConstants = {
+      challengeDuration,
+      chainId,
+      channelNonce,
+      appDefinition,
+      participants
+    };
+    Object.keys(this.states).forEach(key => {
+      const {turnNum, outcome, appData, isFinal} = this.states[key] as StateVariables;
+      this.states[key] = {
+        turnNum,
+        outcome,
+        appData,
+        isFinal
+      };
+    });
+  }
 
   public setFunding(funding: Funding) {
     this.funding = funding;

--- a/packages/xstate-wallet/src/store/memory-store.test.ts
+++ b/packages/xstate-wallet/src/store/memory-store.test.ts
@@ -75,7 +75,7 @@ describe('stateReceivedFeed', () => {
 
 test('newObjectiveFeed', async () => {
   const objective: Objective = {
-    name: 'OpenChannel',
+    type: 'OpenChannel',
     participants: [],
     data: {targetChannelId: 'foo'}
   };

--- a/packages/xstate-wallet/src/store/memory-store.test.ts
+++ b/packages/xstate-wallet/src/store/memory-store.test.ts
@@ -137,7 +137,7 @@ describe('pushMessage', () => {
       signedState.appDefinition
     );
 
-    const nextState = {...state, turnNum: bigNumberify(1)};
+    const nextState = {...state, turnNum: state.turnNum.add(2)};
     await store.pushMessage({
       signedStates: [{...nextState, signature: signState(nextState, bPrivateKey)}]
     });

--- a/packages/xstate-wallet/src/store/memory-store.ts
+++ b/packages/xstate-wallet/src/store/memory-store.ts
@@ -74,6 +74,10 @@ export interface Store {
   // TODO: This is awkward. Might be better to set the funding on create/initialize channel?
   setFunding(channelId: string, funding: Funding): Promise<void>;
 
+  // TODO: I don't know how the store is mean to send outgoing messages.
+  // But I need one, in order to implement virtual funding.
+  sendMessage(message: Message): void;
+
   // TODO: Should this be part of the store?
   getChainInfo: Chain['getChainInfo'];
   chainUpdatedFeed: Chain['chainUpdatedFeed'];
@@ -234,11 +238,16 @@ export class MemoryStore implements Store {
     this._eventEmitter.emit('addToOutbox', {signedStates: [signedState]});
   }
 
+  sendMessage(message: Message) {
+    this._eventEmitter.emit('addToOutbox', message);
+  }
+
   async addState(state: SignedState): Promise<ChannelStoreEntry> {
     const channelId = calculateChannelId(state);
     const channelStorage = this._channels[channelId] || (await this.initializeChannel(state));
 
     channelStorage.addState(state, state.signature);
+
     return channelStorage;
   }
 

--- a/packages/xstate-wallet/src/store/memory-store.ts
+++ b/packages/xstate-wallet/src/store/memory-store.ts
@@ -1,5 +1,5 @@
 import {Observable, fromEvent, merge, from} from 'rxjs';
-import {filter, catchError} from 'rxjs/operators';
+import {filter, catchError, map} from 'rxjs/operators';
 import {EventEmitter} from 'eventemitter3';
 import * as _ from 'lodash';
 
@@ -13,6 +13,7 @@ import {Objective, Message} from './wire-protocol';
 import {Chain, FakeChain} from '../chain';
 import {calculateChannelId} from './state-utils';
 import {NETWORK_ID} from '../constants';
+import {checkThat, exists} from '../utils';
 
 interface DirectFunding {
   type: 'Direct';
@@ -288,4 +289,12 @@ export class MemoryStore implements Store {
   getChainInfo(channelId: string) {
     return this._chain.getChainInfo(channelId);
   }
+}
+
+export function supportedStateFeed(store: Store, channelId: string) {
+  return store.channelUpdatedFeed(channelId).pipe(
+    map(e => ({
+      state: {...checkThat<StateVariables>(e.supported, exists), ...e.channelConstants}
+    }))
+  );
 }

--- a/packages/xstate-wallet/src/store/memory-store.ts
+++ b/packages/xstate-wallet/src/store/memory-store.ts
@@ -76,7 +76,7 @@ export interface Store {
 
   // TODO: I don't know how the store is mean to send outgoing messages.
   // But I need one, in order to implement virtual funding.
-  sendMessage(message: Message): void;
+  addObjective(objective: Objective): void;
 
   // TODO: Should this be part of the store?
   getChainInfo: Chain['getChainInfo'];
@@ -238,8 +238,8 @@ export class MemoryStore implements Store {
     this._eventEmitter.emit('addToOutbox', {signedStates: [signedState]});
   }
 
-  sendMessage(message: Message) {
-    this._eventEmitter.emit('addToOutbox', message);
+  addObjective(objective: Objective) {
+    this._eventEmitter.emit('addToOutbox', {objectives: [objective]});
   }
 
   async addState(state: SignedState): Promise<ChannelStoreEntry> {

--- a/packages/xstate-wallet/src/store/state-utils.ts
+++ b/packages/xstate-wallet/src/store/state-utils.ts
@@ -7,7 +7,7 @@ import {
   getStateSignerAddress as getNitroSignerAddress,
   getChannelId
 } from '@statechannels/nitro-protocol';
-import {joinSignature, splitSignature} from 'ethers/utils';
+import {joinSignature, splitSignature, bigNumberify} from 'ethers/utils';
 import _ from 'lodash';
 
 export function toNitroState(state: State): NitroState {
@@ -66,3 +66,19 @@ export function outcomesEqual(left: Outcome, right?: Outcome) {
   // TODO: do we need a more detailed check?
   return _.isEqual(left, right);
 }
+
+export const firstState = (
+  outcome: Outcome,
+  {channelNonce, chainId, challengeDuration, appDefinition, participants}: ChannelConstants,
+  appData?: string
+): State => ({
+  appData: appData || '0x',
+  isFinal: false,
+  turnNum: bigNumberify(0),
+  chainId: chainId || '0x01',
+  channelNonce,
+  challengeDuration,
+  appDefinition,
+  participants,
+  outcome: outcome || {type: 'SimpleEthAllocation', allocationItems: []}
+});

--- a/packages/xstate-wallet/src/store/state-utils.ts
+++ b/packages/xstate-wallet/src/store/state-utils.ts
@@ -59,7 +59,7 @@ export function statesEqual(
   left: StateVariables,
   right?: StateVariables
 ): boolean {
-  return right ? hashState({...left, ...constants}) === hashState({...right, ...constants}) : false;
+  return right ? hashState({...constants, ...left}) === hashState({...constants, ...right}) : false;
 }
 
 export function outcomesEqual(left: Outcome, right?: Outcome) {

--- a/packages/xstate-wallet/src/store/types.ts
+++ b/packages/xstate-wallet/src/store/types.ts
@@ -22,24 +22,15 @@ export interface SimpleEthAllocation {
   type: 'SimpleEthAllocation';
   allocationItems: AllocationItem[];
 }
-export function isSimpleEthAllocation(outcome: Outcome): outcome is SimpleEthAllocation {
-  return outcome.type === 'SimpleEthAllocation';
-}
 export interface SimpleTokenAllocation {
   type: 'SimpleTokenAllocation';
   tokenAddress: string;
   allocationItems: AllocationItem[];
 }
-export function isSimpleTokenAllocation(outcome: Outcome): outcome is SimpleTokenAllocation {
-  return outcome.type === 'SimpleTokenAllocation';
-}
-interface SimpleEthGuarantee {
+export interface SimpleEthGuarantee {
   type: 'SimpleEthGuarantee';
   guarantorAddress: string;
   destinations: string[];
-}
-export function isSimpleEthGuarantee(outcome: Outcome): outcome is SimpleEthGuarantee {
-  return outcome.type === 'SimpleEthGuarantee';
 }
 export interface SimpleTokenGuarantee {
   type: 'SimpleTokenGuarantee';
@@ -47,16 +38,10 @@ export interface SimpleTokenGuarantee {
   guarantorAddress: string;
   destinations: string[];
 }
-export function isSimpleTokenGuarantee(outcome: Outcome): outcome is SimpleTokenGuarantee {
-  return outcome.type === 'SimpleTokenGuarantee';
-}
 export interface MixedAllocation {
   type: 'MixedAllocation';
   ethAllocation?: SimpleEthAllocation;
   tokenAllocations?: SimpleTokenAllocation[];
-}
-export function isMixedAllocation(outcome: Outcome): outcome is MixedAllocation {
-  return outcome.type === 'MixedAllocation';
 }
 
 // TODO: Better name?

--- a/packages/xstate-wallet/src/store/wire-protocol.ts
+++ b/packages/xstate-wallet/src/store/wire-protocol.ts
@@ -2,7 +2,7 @@ import {SignedState, Participant} from './types';
 
 type _Objective<Name, Data> = {
   participants: Participant[];
-  name: Name;
+  type: Name;
   data: Data;
 };
 export type OpenChannel = _Objective<
@@ -29,8 +29,8 @@ export type FundGuarantor = _Objective<
 
 export type Objective = OpenChannel | VirtuallyFund | FundGuarantor;
 
-const guard = <T extends Objective>(name: Objective['name']) => (o: Objective): o is T =>
-  o.name === name;
+const guard = <T extends Objective>(name: Objective['type']) => (o: Objective): o is T =>
+  o.type === name;
 export const isOpenChannel = guard<OpenChannel>('OpenChannel');
 export const isVirtuallyFund = guard<VirtuallyFund>('VirtuallyFund');
 export const isFundGuarantor = guard<FundGuarantor>('FundGuarantor');

--- a/packages/xstate-wallet/src/utils.ts
+++ b/packages/xstate-wallet/src/utils.ts
@@ -1,3 +1,18 @@
 export function unreachable(x: never) {
   return x;
 }
+
+export const exists = <T>(t: T | undefined): t is T => !!t;
+
+const throwError = (fn: (t1: any) => boolean, t) => {
+  throw new Error(`not valid, ${fn.name} failed on ${t}`);
+};
+type TypeGuard<T, S> = (t1: T | S) => t1 is T;
+export function checkThat<T, S = undefined>(t: T | S, isTypeT: TypeGuard<T, S>): T {
+  if (!isTypeT(t)) {
+    throwError(isTypeT, t);
+    // Typescrypt doesn't know that throwError throws an error.
+    throw 'Unreachable';
+  }
+  return t;
+}

--- a/packages/xstate-wallet/src/utils/allocation-utils.ts
+++ b/packages/xstate-wallet/src/utils/allocation-utils.ts
@@ -8,6 +8,7 @@ import {
 import {Allocations as TokenAllocations} from '@statechannels/client-api-schema';
 
 import {ETH_TOKEN} from '../constants';
+import {checkThat} from '../utils';
 
 // TODO: Merge wallet-protocols/xstate-wallet so these are shared
 export function getEthAllocation(
@@ -27,19 +28,6 @@ export function getEthAllocation(
     }
   ];
 }
-
-type TypeGuard<T, S> = (t1: T | S) => t1 is T;
-export function checkThat<T, S>(t: T | S, isTypeT: TypeGuard<T, S>): T {
-  if (!isTypeT(t)) {
-    throwError(isTypeT, t);
-    // Typescript doesn't know that throwError throws an error.
-    throw 'Unreachable';
-  }
-  return t;
-}
-const throwError = (fn: (t1: any) => boolean, t) => {
-  throw new Error(`not valid, ${fn.name} failed on ${t}`);
-};
 
 export function ethAllocationOutcome(
   allocations: TokenAllocations,

--- a/packages/xstate-wallet/src/utils/outcome.ts
+++ b/packages/xstate-wallet/src/utils/outcome.ts
@@ -1,0 +1,51 @@
+import {
+  AllocationItem,
+  SimpleEthAllocation,
+  Outcome,
+  SimpleTokenAllocation,
+  SimpleTokenGuarantee,
+  MixedAllocation,
+  SimpleEthGuarantee
+} from '../store/types';
+
+const outcomeGuard = <T extends Outcome>(type: Outcome['type']) => (o: Outcome): o is T =>
+  o.type === type;
+export const isSimpleEthAllocation = outcomeGuard<SimpleEthAllocation>('SimpleEthAllocation');
+export const isSimpleEthGuarantee = outcomeGuard<SimpleEthGuarantee>('SimpleEthGuarantee');
+export const isSimpleTokenAllocation = outcomeGuard<SimpleTokenAllocation>('SimpleTokenAllocation');
+export const isSimpleTokenGuarantee = outcomeGuard<SimpleTokenGuarantee>('SimpleTokenGuarantee');
+export const isMixedAllocation = outcomeGuard<MixedAllocation>('MixedAllocation');
+
+export const simpleEthAllocation = (...allocationItems: AllocationItem[]): SimpleEthAllocation => ({
+  type: 'SimpleEthAllocation',
+  allocationItems
+});
+
+export const simpleTokenAllocation = (
+  tokenAddress: string,
+  ...allocationItems: AllocationItem[]
+): SimpleTokenAllocation => ({
+  type: 'SimpleTokenAllocation',
+  allocationItems,
+  tokenAddress
+});
+
+export const simpleEthGuarantee = (
+  guarantorAddress: string,
+  ...destinations: string[]
+): SimpleEthGuarantee => ({
+  type: 'SimpleEthGuarantee',
+  destinations,
+  guarantorAddress
+});
+
+export const simpleTokenGuarantee = (
+  tokenAddress: string,
+  guarantorAddress: string,
+  ...destinations: string[]
+): SimpleTokenGuarantee => ({
+  type: 'SimpleTokenGuarantee',
+  destinations,
+  guarantorAddress,
+  tokenAddress
+});

--- a/packages/xstate-wallet/src/workflows/conclude-channel.ts
+++ b/packages/xstate-wallet/src/workflows/conclude-channel.ts
@@ -1,11 +1,11 @@
 import {Machine} from 'xstate';
 import * as SupportState from './support-state';
 import {getDataAndInvoke, MachineFactory} from '../utils/workflow-utils';
-import {checkThat} from '../utils/allocation-utils';
 import {Store} from '../store';
 import {outcomesEqual} from '../store/state-utils';
 import {isIndirectFunding} from '../store/memory-store';
 import {add} from '../utils/math-utils';
+import {checkThat} from '../utils';
 const WORKFLOW = 'conclude-channel';
 
 export interface Init {

--- a/packages/xstate-wallet/src/workflows/index.ts
+++ b/packages/xstate-wallet/src/workflows/index.ts
@@ -1,0 +1,3 @@
+import * as SupportState from './support-state';
+
+export {SupportState};

--- a/packages/xstate-wallet/src/workflows/tests/virtual-funding.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/virtual-funding.test.ts
@@ -99,7 +99,17 @@ test('Virtual funding as A', async () => {
   service.onTransition(state => {
     if (_.isEqual(state.value, {fundJointChannel: 'waitForObjective'})) {
       store.pushMessage({
-        objectives: [] // TODO
+        objectives: [
+          {
+            type: 'FundGuarantor',
+            data: {
+              jointChannelId,
+              ledgerId: 'foo',
+              guarantorId: 'bar'
+            },
+            participants: [jointParticipants[2], jointParticipants[1]]
+          }
+        ]
       });
     }
   });

--- a/packages/xstate-wallet/src/workflows/tests/virtual-funding.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/virtual-funding.test.ts
@@ -1,0 +1,76 @@
+import {getChannelId, Channel, signState} from '@statechannels/nitro-protocol';
+
+import {interpret} from 'xstate';
+import waitForExpect from 'wait-for-expect';
+
+import {Init, machine, Role} from '../virtualFunding';
+
+import {MemoryStore} from '../../store/memory-store';
+import {ethers} from 'ethers';
+import {joinSignature} from 'ethers/utils';
+import _ from 'lodash';
+import {toNitroState} from '../../store/state-utils';
+
+const wallet1 = new ethers.Wallet(
+  '0x95942b296854c97024ca3145abef8930bf329501b718c0f66d57dba596ff1318'
+); // 0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf
+const wallet2 = new ethers.Wallet(
+  '0xb3ab7b031311fe1764b657a6ae7133f19bac97acd1d7edca9409daa35892e727'
+); // 0x2222E21c8019b14dA16235319D34b5Dd83E644A9
+const wallet3 = new ethers.Wallet(
+  '0x8624ebe7364bb776f891ca339f0aaa820cc64cc9fca6a28eec71e6d8fc950f29'
+); // 0xaaaacfD9F7b033804ee4f01e5DfB1cd586858490
+
+const wallets = {
+  [wallet1.address]: wallet1,
+  [wallet2.address]: wallet2,
+  [wallet3.address]: wallet3
+};
+
+jest.setTimeout(10000);
+const EXPECT_TIMEOUT = process.env.CI ? 9500 : 2000;
+test('Virtual funding as A', async () => {
+  const channel: Channel = {} as any;
+  const targetChannelId = getChannelId(channel);
+  const context: Init = {targetChannelId, role: Role.A, jointChannelId: 'TODO'};
+
+  const store: MemoryStore = {} as any;
+  const service = interpret(machine(store, context, Role.A));
+
+  store.outboxFeed.subscribe(e => {
+    e.signedStates?.forEach(state => {
+      state.participants.map(p => store.pushMessage({signedStates: []}));
+      store.pushMessage({
+        signedStates: state.participants.map(p => ({
+          ...state,
+          signature: joinSignature(
+            signState(toNitroState(state), wallets[p.signingAddress].privateKey).signature
+          )
+        }))
+      });
+    });
+  });
+
+  service.onTransition(state => {
+    if (_.isEqual(state.value, {fundJointChannel: 'waitForObjective'})) {
+      store.pushMessage({
+        objectives: [] // TODO
+      });
+    }
+  });
+
+  service.start();
+
+  await waitForExpect(
+    () =>
+      expect(service.state.value).toMatchObject({
+        preparation: {
+          prepareJointChannel: 'runTask',
+          prepareTargetChannel: 'runTask'
+        }
+      }),
+    EXPECT_TIMEOUT
+  );
+
+  await waitForExpect(() => expect(service.state.value).toEqual('success'), EXPECT_TIMEOUT);
+});

--- a/packages/xstate-wallet/src/workflows/tests/virtual-funding.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/virtual-funding.test.ts
@@ -30,11 +30,15 @@ const wallets = {
 jest.setTimeout(10000);
 const EXPECT_TIMEOUT = process.env.CI ? 9500 : 2000;
 test('Virtual funding as A', async () => {
-  const channel: Channel = {} as any;
+  const channel: Channel = {
+    participants: [wallet1.address, wallet2.address],
+    chainId: '0x1',
+    channelNonce: '0x11'
+  };
   const targetChannelId = getChannelId(channel);
   const context: Init = {targetChannelId, role: Role.A, jointChannelId: 'TODO'};
 
-  const store: MemoryStore = {} as any;
+  const store = new MemoryStore([wallet1.privateKey]);
   const service = interpret(machine(store, context, Role.A));
 
   store.outboxFeed.subscribe(e => {
@@ -62,13 +66,7 @@ test('Virtual funding as A', async () => {
   service.start();
 
   await waitForExpect(
-    () =>
-      expect(service.state.value).toMatchObject({
-        preparation: {
-          prepareJointChannel: 'runTask',
-          prepareTargetChannel: 'runTask'
-        }
-      }),
+    () => expect(service.state.value).toEqual('setupJointChannel'),
     EXPECT_TIMEOUT
   );
 

--- a/packages/xstate-wallet/src/workflows/virtualFunding.ts
+++ b/packages/xstate-wallet/src/workflows/virtualFunding.ts
@@ -12,10 +12,10 @@ import {
 import {filter, map, take, flatMap, tap} from 'rxjs/operators';
 
 import {Store, supportedStateFeed} from '../store/memory-store';
-import {isSimpleEthAllocation} from '../store/types';
 import {SupportState} from '.';
 import {isFundGuarantor, FundGuarantor} from '../store/wire-protocol';
 import {checkThat} from '../utils';
+import {isSimpleEthAllocation} from '../utils/outcome';
 
 export const enum Role {
   A = 0,

--- a/packages/xstate-wallet/src/workflows/virtualFunding.ts
+++ b/packages/xstate-wallet/src/workflows/virtualFunding.ts
@@ -1,0 +1,109 @@
+import {
+  StateNodeConfig,
+  MachineConfig,
+  assign,
+  Machine,
+  MachineOptions,
+  AnyEventObject
+} from 'xstate';
+
+import {MemoryStore, Store} from '../store/memory-store';
+import {SupportState} from '@statechannels/wallet-protocols';
+import {toNitroState} from '../store/state-utils';
+
+export const enum Role {
+  A,
+  Hub,
+  B
+}
+
+export type Init = {
+  targetChannelId: string;
+  jointChannelId: string;
+  role: Role;
+};
+
+function waitThenRunObjective<Objective extends string = string>(
+  objective: Objective,
+  src: string
+): StateNodeConfig<any, any, any> {
+  return {
+    initial: 'waitForObjective',
+    states: {
+      waitForObjective: {entry: `spawn${objective}Observer`, on: {[objective]: 'runObjective'}},
+      runObjective: {invoke: {src, data: (_, {init}) => init, onDone: 'done'}},
+      done: {type: 'final'}
+    }
+  };
+}
+
+type TEvent = AnyEventObject;
+type Objective = 'FundGuarantorAH' | 'FundGuarantorBH';
+const enum Actions {
+  spawnFundLedgerChannelObserver = 'spawnFundLedgerChannelObserver',
+  triggerGuarantorObjectives = 'triggerGuarantorObjectives'
+}
+const enum States {
+  setupJointChannel = 'setupJointChannel',
+  fundJointChannel = 'fundJointChannel',
+  fundTargetChannel = 'fundTargetChannel'
+}
+
+const fundJointChannel = (role: Role): StateNodeConfig<Init, any, TEvent> => {
+  let config;
+  switch (role) {
+    case Role.A:
+      config = waitThenRunObjective<Objective>('FundGuarantorAH', 'indirectFunding');
+      break;
+    case Role.B:
+      config = waitThenRunObjective<Objective>('FundGuarantorBH', 'indirectFunding');
+      break;
+    case Role.Hub:
+      config = {
+        type: 'parallel',
+        entry: Actions.triggerGuarantorObjectives,
+        states: {
+          fundGuarantorAH: waitThenRunObjective<Objective>('FundGuarantorAH', 'indirectFunding'),
+          fundGuarantorBH: waitThenRunObjective<Objective>('FundGuarantorBH', 'indirectFunding')
+        }
+      };
+  }
+
+  return {...config, onDone: States.fundTargetChannel};
+};
+
+const generateConfig = (role: Role): MachineConfig<Init, any, any> => ({
+  key: 'virtual-funding',
+  initial: States.setupJointChannel,
+  states: {
+    [States.setupJointChannel]: {
+      invoke: {src: 'supportState'},
+      onDone: 'fundJointChannel'
+    },
+    [States.fundJointChannel]: fundJointChannel(role),
+    [States.fundTargetChannel]: {invoke: {src: 'supportState'}, onDone: 'success'},
+    success: {type: 'final'}
+  }
+});
+
+export const config = generateConfig(Role.Hub);
+export const startingJointState = (store: Store) => async ({
+  jointChannelId
+}: Init): Promise<SupportState.Init> => {
+  const {latest, channelConstants} = await store.getEntry(jointChannelId);
+  return {state: toNitroState({...latest, ...channelConstants})};
+};
+
+export const options = (store: MemoryStore): Partial<MachineOptions<Init, TEvent>> => {
+  const actions: Record<Actions, any> = {
+    [Actions.spawnFundLedgerChannelObserver]: assign<any>({
+      ledgerObjectiveWatcher: 'TODO'
+    }),
+    [Actions.triggerGuarantorObjectives]: () => 'TODO'
+  };
+
+  return {actions};
+};
+
+export const machine = (store: MemoryStore, context: Init, role: Role) =>
+  Machine(generateConfig(role), options(store)).withContext(context);

--- a/packages/xstate-wallet/src/workflows/virtualFunding.ts
+++ b/packages/xstate-wallet/src/workflows/virtualFunding.ts
@@ -219,9 +219,8 @@ export const options = (store: Store): Partial<MachineOptions<Init, TEvent>> => 
     [Actions.spawnFundGuarantorObserver]: assign<any>({
       guarantorObserver: spawnFundGuarantorObserver(store)
     }),
-    [Actions.triggerGuarantorObjective]: (_, {data}: DoneInvokeEvent<FundGuarantor>) => {
-      store.sendMessage({objectives: [data]});
-    }
+    [Actions.triggerGuarantorObjective]: (_, {data}: DoneInvokeEvent<FundGuarantor>) =>
+      store.addObjective(data)
   };
 
   const services: Record<Services, ServiceConfig<Init>> = {


### PR DESCRIPTION
This PR adds a virtual funding workflow which works, except that guarantor channels are not created (or funded), and the indirect-funding service is mocked out.

Getting this to work required several other changes:
- Some bugs caused by unsafe use of spread operators are fixed.
- `sortedByTurnNum` is renamed to add clarity, and its implementation fixed
- A `sendMessage` method is placed on the store which simply emits a "Message sent" event.
- The `channelUpdatedFeed` feed is updated to include the current entry, if it exists, as the first value
- The `'channelUpdated'` event is emitted when a state is received