### PR TITLE
RPS: Decrease default round buy-in from 0.1 eth to 0.01 eth

### DIFF
--- a/packages/app-wallet-interface/package.json
+++ b/packages/app-wallet-interface/package.json
@@ -8,6 +8,5 @@
   "scripts": {
     "build:netlify": "gem install bundler:2.0.2 && bundle update --bundler && bundle exec middleman build --clean",
     "release:netlify": "netlify deploy --site $APP_WALLET_INTERFACE_NETLIFY_ID --dir=build"
-  },
-  "devDependencies": {}
+  }
 }

--- a/packages/rps/package.json
+++ b/packages/rps/package.json
@@ -66,9 +66,9 @@
   "devDependencies": {
     "@babel/runtime": "7.8.3",
     "@sentry/browser": "5.12.1",
+    "@statechannels/channel-provider": "0.0.3",
     "@statechannels/devtools": "0.1.21",
     "@statechannels/jest-gas-reporter": "0.0.2",
-    "@statechannels/channel-provider": "0.0.3",
     "@storybook/react": "5.3.9",
     "@types/autoprefixer": "9.6.1",
     "@types/babel__core": "7.1.3",

--- a/packages/rps/src/components/CreatingOpenGameModal.tsx
+++ b/packages/rps/src/components/CreatingOpenGameModal.tsx
@@ -22,7 +22,7 @@ export default class CreatingOpenGameModal extends React.PureComponent<Props, St
   constructor(props) {
     super(props);
     this.buyInInput = React.createRef();
-    this.state = {errorMessage: '', buyIn: '0.1', buyInChanged: true};
+    this.state = {errorMessage: '', buyIn: '0.01', buyInChanged: true};
     this.createOpenGameHandler = this.createOpenGameHandler.bind(this);
     this.handleBuyInChange = this.handleBuyInChange.bind(this);
     this.modalClosed = this.modalClosed.bind(this);


### PR DESCRIPTION
At the moment, the hub does not withdraw funds deposited in the asset holder. A default game buy in of 0.5 eth ends up draining hub's Ropsten funds. Decreasing the game buy in to 0.05 eth will drain hub's funds 10 times slower.