### PR TITLE
Upgrade solidity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,6 +189,7 @@ jobs:
       USE_GANACHE_DEPLOYMENT_CACHE: true
       GANACHE_CACHE_FOLDER: ../../.ganache-deployments
       GANACHE_PORT: 8547
+      NODE_ENV: test
     steps:
       - checkout
       - puppeteer/install

--- a/packages/app-wallet-interface/package.json
+++ b/packages/app-wallet-interface/package.json
@@ -8,6 +8,5 @@
   "scripts": {
     "build:netlify": "gem install bundler:2.0.2 && bundle update --bundler && bundle exec middleman build --clean",
     "release:netlify": "netlify deploy --site $APP_WALLET_INTERFACE_NETLIFY_ID --dir=build"
-  },
-  "devDependencies": {}
+  }
 }

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -15,7 +15,7 @@
     "fs-extra": "8.1.0",
     "jest": "25.1.0",
     "loglevel": "1.6.6",
-    "solc": "0.5.13",
+    "solc": "0.6.0",
     "yargs": "15.1.0"
   },
   "devDependencies": {

--- a/packages/jest-gas-reporter/package.json
+++ b/packages/jest-gas-reporter/package.json
@@ -8,7 +8,7 @@
     "easy-table": "1.1.1",
     "ethers": "4.0.44",
     "path": "0.12.7",
-    "solc": "0.5.13",
+    "solc": "0.6.0",
     "typescript": "3.7.5"
   },
   "devDependencies": {

--- a/packages/nitro-protocol/contracts/AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/AssetHolder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 import './Outcome.sol';
 import '@openzeppelin/contracts/math/SafeMath.sol';
@@ -113,7 +113,7 @@ contract AssetHolder is IAssetHolder {
     * @param channelId Unique identifier for a state channel.
     * @param allocationBytes The abi.encode of AssetOutcome.Allocation
     */
-    function transferAll(bytes32 channelId, bytes memory allocationBytes) public {
+    function transferAll(bytes32 channelId, bytes memory allocationBytes) public override {
         // checks
         require(
             assetOutcomeHashes[channelId] ==
@@ -136,7 +136,7 @@ contract AssetHolder is IAssetHolder {
     * @param channelId Unique identifier for a state channel.
     * @param allocationBytes The abi.encode of AssetOutcome.Allocation
     */
-    function transferAllAdjudicatorOnly(bytes32 channelId, bytes calldata allocationBytes) external AdjudicatorOnly {
+    function transferAllAdjudicatorOnly(bytes32 channelId, bytes calldata allocationBytes) external AdjudicatorOnly virtual {
         _transferAll(channelId, allocationBytes);
     }
 
@@ -151,7 +151,7 @@ contract AssetHolder is IAssetHolder {
         bytes32 guarantorChannelId,
         bytes memory guaranteeBytes,
         bytes memory allocationBytes
-    ) public {
+    ) public override {
         // checks
 
         require(
@@ -333,7 +333,7 @@ contract AssetHolder is IAssetHolder {
     * @param destination ethereum address to be credited.
     * @param amount Quantity of assets to be transferred.
     */
-    function _transferAsset(address payable destination, uint256 amount) internal {}
+    function _transferAsset(address payable destination, uint256 amount) internal virtual {}
 
     /**
     * @notice Checks if a given destination is external (and can therefore have assets transferred to it) or not.

--- a/packages/nitro-protocol/contracts/ConsensusApp.sol
+++ b/packages/nitro-protocol/contracts/ConsensusApp.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 import './interfaces/ForceMoveApp.sol';
@@ -35,7 +35,7 @@ contract ConsensusApp is ForceMoveApp {
         VariablePart memory b,
         uint256, // turnNumB, unused
         uint256 nParticipants
-    ) public pure returns (bool) {
+    ) public pure override returns (bool) {
         ConsensusAppData memory appDataA = appData(a.appData);
         ConsensusAppData memory appDataB = appData(b.appData);
 

--- a/packages/nitro-protocol/contracts/CounterfactualAdapterApp.sol
+++ b/packages/nitro-protocol/contracts/CounterfactualAdapterApp.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 import '@counterfactual/cf-adjudicator-contracts/contracts/interfaces/CounterfactualApp.sol';
@@ -22,7 +22,7 @@ contract CounterfactualAdapterApp is ForceMoveApp {
         VariablePart memory b,
         uint256, // turnNumB
         uint256 // nParticipants
-    ) public pure returns (bool) {
+    ) public pure override returns (bool) {
         CounterfactualAdapterAppData memory prevState = appData(a.appData);
         CounterfactualAdapterAppData memory nextState = appData(b.appData);
         require(

--- a/packages/nitro-protocol/contracts/CountingApp.sol
+++ b/packages/nitro-protocol/contracts/CountingApp.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 import './interfaces/ForceMoveApp.sol';
@@ -33,7 +33,7 @@ contract CountingApp is ForceMoveApp {
         VariablePart memory b,
         uint256, // turnNumB, unused
         uint256 // nParticipants, unused
-    ) public pure returns (bool) {
+    ) public pure override returns (bool) {
         require(
             appData(b.appData).counter == appData(a.appData).counter + 1,
             'CountingApp: Counter must be incremented'

--- a/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ERC20AssetHolder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 import './AssetHolder.sol';
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
@@ -7,7 +7,6 @@ import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
   * @dev Ther ERC20AssetHolder contract extends the AssetHolder contract, and adds the following functionality: it allows ERC20 tokens to be escrowed against a state channelId and to be transferred to external destinations.
 */
 contract ERC20AssetHolder is AssetHolder {
-    address AdjudicatorAddress;
     IERC20 Token;
 
     /**
@@ -19,11 +18,6 @@ contract ERC20AssetHolder is AssetHolder {
     constructor(address _AdjudicatorAddress, address _TokenAddress) public {
         AdjudicatorAddress = _AdjudicatorAddress;
         Token = IERC20(_TokenAddress);
-    }
-
-    modifier AdjudicatorOnly {
-        require(msg.sender == AdjudicatorAddress, 'Only the NitroAdjudicator is authorized');
-        _;
     }
 
     /**
@@ -69,7 +63,7 @@ contract ERC20AssetHolder is AssetHolder {
     * @param destination Ethereum address to be credited.
     * @param amount Quantity of tokens to be transferred.
     */
-    function _transferAsset(address payable destination, uint256 amount) internal {
+    function _transferAsset(address payable destination, uint256 amount) internal override {
         Token.transfer(destination, amount);
     }
 

--- a/packages/nitro-protocol/contracts/ETHAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/ETHAssetHolder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 import './AssetHolder.sol';
 
@@ -6,8 +6,6 @@ import './AssetHolder.sol';
   * @dev Ther ETHAssetHolder contract extends the AssetHolder contract, and adds the following functionality: it allows ETH to be escrowed against a state channelId and to be transferred to external destinations.
 */
 contract ETHAssetHolder is AssetHolder {
-    address AdjudicatorAddress;
-
     /**
     * @notice Constructor function storing the AdjudicatorAddress.
     * @dev Constructor function storing the AdjudicatorAddress.
@@ -15,11 +13,6 @@ contract ETHAssetHolder is AssetHolder {
     */
     constructor(address _AdjudicatorAddress) public {
         AdjudicatorAddress = _AdjudicatorAddress;
-    }
-
-    modifier AdjudicatorOnly {
-        require(msg.sender == AdjudicatorAddress, 'Only the NitroAdjudicator is authorized');
-        _;
     }
 
     /**
@@ -64,7 +57,7 @@ contract ETHAssetHolder is AssetHolder {
     * @param destination Ethereum address to be credited.
     * @param amount Quantity of wei to be transferred.
     */
-    function _transferAsset(address payable destination, uint256 amount) internal {
+    function _transferAsset(address payable destination, uint256 amount) internal override {
         destination.transfer(amount);
     }
 

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 import './interfaces/IForceMove.sol';
@@ -16,7 +16,9 @@ contract ForceMove is IForceMove {
     * @notice Unpacks turnNumRecord, finalizesAt and fingerprint from the channelStorageHash of a particular channel.
     * @dev Unpacks turnNumRecord, finalizesAt and fingerprint from the channelStorageHash of a particular channel.
     * @param channelId Unique identifier for a state channel.
-    * @return (turnNumRecord, finalizesAt, fingerprint) -  A turnNum that (the adjudicator knows) is supported by a signature from each participant; The unix timestamp when `channelId` will finalize; Unique identifier for the channel's current state, up to hash collisions.
+    * @return turnNumRecord A turnNum that (the adjudicator knows) is supported by a signature from each participant.
+    * @return finalizesAt The unix timestamp when `channelId` will finalize.
+    * @return fingerprint Unique identifier for the channel's current state, up to hash collisions.
     */
     function getData(bytes32 channelId)
         public
@@ -45,7 +47,7 @@ contract ForceMove is IForceMove {
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat,
         Signature memory challengerSig
-    ) public {
+    ) public override {
         bytes32 channelId = _getChannelId(fixedPart);
 
         if (_mode(channelId) == ChannelMode.Open) {
@@ -114,7 +116,7 @@ contract ForceMove is IForceMove {
         // variablePartAB[0] = challengeVariablePart
         // variablePartAB[1] = responseVariablePart
         Signature memory sig
-    ) public {
+    ) public override {
         bytes32 channelId = _getChannelId(fixedPart);
         (uint48 turnNumRecord, uint48 finalizesAt, ) = _getData(channelId);
 
@@ -186,7 +188,7 @@ contract ForceMove is IForceMove {
         uint8 isFinalCount, // how many of the states are final
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat
-    ) public {
+    ) public override {
         bytes32 channelId = _getChannelId(fixedPart);
 
         // checks
@@ -226,7 +228,7 @@ contract ForceMove is IForceMove {
         uint8 numStates,
         uint8[] memory whoSignedWhat,
         Signature[] memory sigs
-    ) public {
+    ) public override {
         bytes32 channelId = _getChannelId(fixedPart);
         _requireChannelNotFinalized(channelId);
 
@@ -688,7 +690,9 @@ contract ForceMove is IForceMove {
     * @notice Unpacks turnNumRecord, finalizesAt and fingerprint from the channelStorageHash of a particular channel.
     * @dev Unpacks turnNumRecord, finalizesAt and fingerprint from the channelStorageHash of a particular channel.
     * @param channelId Unique identifier for a state channel.
-    * @return (turnNumRecord, finalizesAt, fingerprint) -  A turnNum that (the adjudicator knows) is supported by a signature from each participant; The unix timestamp when `channelId` will finalize; Unique identifier for the channel's current state, up to hash collisions.
+    * @return turnNumRecord A turnNum that (the adjudicator knows) is supported by a signature from each participant.
+    * @return finalizesAt The unix timestamp when `channelId` will finalize.
+    * @return fingerprint Unique identifier for the channel's current state, up to hash collisions.
     */
     function _getData(bytes32 channelId)
         internal
@@ -765,7 +769,7 @@ contract ForceMove is IForceMove {
     * @notice Computes the unique id of a channel.
     * @dev Computes the unique id of a channel.
     * @param fixedPart Part of the state that does not change
-    * @return The channelId
+    * @return channelId
     */
     function _getChannelId(FixedPart memory fixedPart) internal pure returns (bytes32 channelId) {
         channelId = keccak256(

--- a/packages/nitro-protocol/contracts/NitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/NitroAdjudicator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 import './interfaces/Adjudicator.sol';
@@ -27,7 +27,7 @@ contract NitroAdjudicator is Adjudicator, ForceMove {
         bytes32 stateHash,
         address challengerAddress,
         bytes memory outcomeBytes
-    ) public {
+    ) public override {
         // requirements
         _requireChannelFinalized(channelId);
 

--- a/packages/nitro-protocol/contracts/Outcome.sol
+++ b/packages/nitro-protocol/contracts/Outcome.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 library Outcome {

--- a/packages/nitro-protocol/contracts/Token.sol
+++ b/packages/nitro-protocol/contracts/Token.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 
 /**

--- a/packages/nitro-protocol/contracts/TrivialApp.sol
+++ b/packages/nitro-protocol/contracts/TrivialApp.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 import './interfaces/ForceMoveApp.sol';
@@ -18,7 +18,7 @@ contract TrivialApp is ForceMoveApp {
         VariablePart memory, // b
         uint256, // turnNumB
         uint256 // nParticipants
-    ) public pure returns (bool) {
+    ) public pure override returns (bool) {
         return true;
     }
 }

--- a/packages/nitro-protocol/contracts/examples/SingleAssetPayments.sol
+++ b/packages/nitro-protocol/contracts/examples/SingleAssetPayments.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 import '../interfaces/ForceMoveApp.sol';
@@ -24,7 +24,7 @@ contract SingleAssetPayments is ForceMoveApp {
         VariablePart memory b,
         uint256 turnNumB,
         uint256 nParticipants
-    ) public pure returns (bool) {
+    ) public pure override returns (bool) {
 
         Outcome.OutcomeItem[] memory outcomeA = abi.decode(a.outcome, (Outcome.OutcomeItem[]));
         Outcome.OutcomeItem[] memory outcomeB = abi.decode(b.outcome, (Outcome.OutcomeItem[]));

--- a/packages/nitro-protocol/contracts/interfaces/Adjudicator.sol
+++ b/packages/nitro-protocol/contracts/interfaces/Adjudicator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/packages/nitro-protocol/contracts/interfaces/ForceMoveApp.sol
+++ b/packages/nitro-protocol/contracts/interfaces/ForceMoveApp.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IAssetHolder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 /**

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 import './ForceMoveApp.sol';
@@ -6,7 +6,7 @@ import './ForceMoveApp.sol';
 /**
   * @dev The IForceMove contract abstraction defines the interface that an implementation of ForceMove should implement. ForceMove protocol allows state channels to be adjudicated and finalized.
 */
-contract IForceMove {
+abstract contract IForceMove {
     struct Signature {
         uint8 v;
         bytes32 r;
@@ -65,7 +65,7 @@ contract IForceMove {
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat,
         Signature memory challengerSig
-    ) public;
+    ) public virtual;
 
     /**
     * @notice Repsonds to an ongoing challenge registered against a state channel.
@@ -84,7 +84,7 @@ contract IForceMove {
         // variablePartAB[0] = challengeVariablePart
         // variablePartAB[1] = responseVariablePart
         Signature memory sig
-    ) public;
+    ) public virtual;
 
     /**
     * @notice Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
@@ -103,7 +103,7 @@ contract IForceMove {
         uint8 isFinalCount, // how many of the states are final
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat
-    ) public;
+    ) public virtual;
 
     /**
     * @notice Finalizes a channel by providing a finalization proof.
@@ -124,7 +124,7 @@ contract IForceMove {
         uint8 numStates,
         uint8[] memory whoSignedWhat,
         Signature[] memory sigs
-    ) public;
+    ) public virtual;
 
     // events
 

--- a/packages/nitro-protocol/contracts/test/TESTAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/test/TESTAssetHolder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 import '../AssetHolder.sol';
 
@@ -6,8 +6,6 @@ import '../AssetHolder.sol';
   * @dev This contract extends the AssetHolder contract to enable it to be more easily unit-tested. It exposes public or external functions that set storage variables or wrap otherwise internal functions. It should not be deployed in a production environment.
 */
 contract TESTAssetHolder is AssetHolder {
-    address AdjudicatorAddress;
-
     /**
     * @notice Constructor function storing the AdjudicatorAddress.
     * @dev Constructor function storing the AdjudicatorAddress.
@@ -15,11 +13,6 @@ contract TESTAssetHolder is AssetHolder {
     */
     constructor(address _AdjudicatorAddress) public {
         AdjudicatorAddress = _AdjudicatorAddress;
-    }
-
-    modifier AdjudicatorOnly {
-        require(msg.sender == AdjudicatorAddress, 'Only the NitroAdjudicator is authorized');
-        _;
     }
 
     // Public wrappers for internal methods:
@@ -52,7 +45,7 @@ contract TESTAssetHolder is AssetHolder {
     * @param channelId Unique identifier for a state channel.
     * @param allocationBytes The abi.encode of AssetOutcome.Allocation
     */
-    function transferAllAdjudicatorOnly(bytes32 channelId, bytes calldata allocationBytes) external {
+    function transferAllAdjudicatorOnly(bytes32 channelId, bytes calldata allocationBytes) external override {
         _transferAll(channelId, allocationBytes);
     }
 

--- a/packages/nitro-protocol/contracts/test/TESTAssetHolder2.sol
+++ b/packages/nitro-protocol/contracts/test/TESTAssetHolder2.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 import './TESTAssetHolder.sol';
 

--- a/packages/nitro-protocol/contracts/test/TESTForceMove.sol
+++ b/packages/nitro-protocol/contracts/test/TESTForceMove.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 import '../ForceMove.sol';
 

--- a/packages/nitro-protocol/contracts/test/TESTNitroAdjudicator.sol
+++ b/packages/nitro-protocol/contracts/test/TESTNitroAdjudicator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 import '../NitroAdjudicator.sol';
 

--- a/packages/nitro-protocol/contracts/test/TestErc20AssetHolder.sol
+++ b/packages/nitro-protocol/contracts/test/TestErc20AssetHolder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 import '../ERC20AssetHolder.sol';
 

--- a/packages/nitro-protocol/contracts/test/TestEthAssetHolder.sol
+++ b/packages/nitro-protocol/contracts/test/TestEthAssetHolder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 import '../ETHAssetHolder.sol';
 

--- a/packages/nitro-protocol/docs/forcemove-and-nitro/asset-holder.md
+++ b/packages/nitro-protocol/docs/forcemove-and-nitro/asset-holder.md
@@ -31,7 +31,7 @@ The adjudicator stores (the hash of) an encoded `outcome` for each finalized cha
 In `Outcome.sol`:
 
 ```solidity
-pragma solidity ^0.5.13;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 library Outcome {

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/statechannels/nitro-protocol/",
   "dependencies": {
     "@counterfactual/cf-adjudicator-contracts": "0.0.11",
-    "@openzeppelin/contracts": "2.4.0",
+    "@openzeppelin/contracts": "3.0.0",
     "ethers": "4.0.44"
   },
   "devDependencies": {
@@ -29,7 +29,7 @@
     "eslint-plugin-import": "2.20.0",
     "eslint-plugin-jest": "23.6.0",
     "eslint-plugin-prettier": "3.1.2",
-    "etherlime": "2.2.4",
+    "etherlime": "2.2.6",
     "etherlime-lib": "1.1.5",
     "ganache-cli": "6.8.2",
     "ganache-core": "2.8.0",
@@ -42,7 +42,7 @@
     "prettier": "1.19.1",
     "prettier-plugin-solidity": "1.0.0-alpha.34",
     "server-destroy": "1.0.1",
-    "solc": "0.5.13",
+    "solc": "0.6.0",
     "solidoc": "https://github.com/statechannels/solidoc.git",
     "ts-jest": "25.0.0",
     "ts-node": "8.6.2",

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/statechannels/nitro-protocol/",
   "dependencies": {
     "@counterfactual/cf-adjudicator-contracts": "0.0.11",
-    "@openzeppelin/contracts": "3.0.0",
+    "@openzeppelin/contracts": "3.0.0-beta.0",
     "ethers": "4.0.44"
   },
   "devDependencies": {

--- a/packages/rps/contracts/RockPaperScissors.sol
+++ b/packages/rps/contracts/RockPaperScissors.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.11;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 import '@statechannels/nitro-protocol/contracts/interfaces/ForceMoveApp.sol';
@@ -53,7 +53,7 @@ contract RockPaperScissors is ForceMoveApp {
         VariablePart memory toPart,
         uint256, /* turnNumB */
         uint256  /* nParticipants */
-    ) public pure returns (bool) {
+    ) public pure override returns (bool) {
         Outcome.AllocationItem[] memory fromAllocation = extractAllocation(fromPart);
         Outcome.AllocationItem[] memory toAllocation = extractAllocation(toPart);
         _requireDestinationsUnchanged(fromAllocation, toAllocation);

--- a/packages/rps/package.json
+++ b/packages/rps/package.json
@@ -66,9 +66,9 @@
   "devDependencies": {
     "@babel/runtime": "7.8.3",
     "@sentry/browser": "5.12.1",
+    "@statechannels/channel-provider": "0.0.3",
     "@statechannels/devtools": "0.1.21",
     "@statechannels/jest-gas-reporter": "0.0.2",
-    "@statechannels/channel-provider": "0.0.3",
     "@storybook/react": "5.3.9",
     "@types/autoprefixer": "9.6.1",
     "@types/babel__core": "7.1.3",

--- a/packages/rps/package.json
+++ b/packages/rps/package.json
@@ -39,7 +39,7 @@
     "npm-run-all": "4.1.5",
     "object-assign": "4.1.1",
     "object-hash": "2.0.1",
-    "openzeppelin-solidity": "2.2.0",
+    "openzeppelin-solidity": "3.0.0-beta.0",
     "promise": "8.0.3",
     "prop-types": "15.6.2",
     "raf": "3.4.1",

--- a/packages/tic-tac-toe/contracts/TicTacToe.sol
+++ b/packages/tic-tac-toe/contracts/TicTacToe.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.11;
+pragma solidity ^0.6.0;
 pragma experimental ABIEncoderV2;
 
 import '@statechannels/nitro-protocol/contracts/interfaces/ForceMoveApp.sol';
@@ -55,7 +55,7 @@ contract TicTacToe is ForceMoveApp {
         VariablePart memory toPart,
         uint256, // turnNumB, (Not implemented)
         uint256 nParticipants
-    ) public pure returns (bool) {
+    ) public pure override returns (bool) {
         require(nParticipants == 2, 'There should be 2 participants');
         Outcome.AllocationItem[] memory fromAllocation = extractAllocation(fromPart);
         Outcome.AllocationItem[] memory toAllocation = extractAllocation(toPart);

--- a/packages/tic-tac-toe/package.json
+++ b/packages/tic-tac-toe/package.json
@@ -29,7 +29,7 @@
     "npm-run-all": "4.1.5",
     "object-assign": "4.1.1",
     "object-hash": "2.0.1",
-    "openzeppelin-solidity": "2.2.0",
+    "openzeppelin-solidity": "3.0.0-beta.0",
     "promise": "8.0.3",
     "prop-types": "15.6.2",
     "raf": "3.4.1",
@@ -37,7 +37,8 @@
     "webpack": "4.41.5",
     "webpack-dev-server": "3.10.1",
     "webpack-manifest-plugin": "2.2.0",
-    "whatwg-fetch": "3.0.0"
+    "whatwg-fetch": "3.0.0",
+    "@openzeppelin/contracts": "3.0.0-beta.0"
   },
   "devDependencies": {
     "@babel/runtime": "7.8.3",

--- a/patches/@counterfactual+cf-adjudicator-contracts+0.0.11.patch
+++ b/patches/@counterfactual+cf-adjudicator-contracts+0.0.11.patch
@@ -4,7 +4,7 @@ index d823033..31595b9 100644
 +++ b/node_modules/@counterfactual/cf-adjudicator-contracts/contracts/interfaces/CounterfactualApp.sol
 @@ -1,4 +1,4 @@
 -pragma solidity 0.5.12;
-+pragma solidity ^0.5.13;
++pragma solidity ^0.6.0;
  pragma experimental "ABIEncoderV2";
  
  

--- a/yarn.lock
+++ b/yarn.lock
@@ -3376,7 +3376,7 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@openzeppelin/contracts@3.0.0":
+"@openzeppelin/contracts@3.0.0-beta.0":
   version "3.0.0-beta.0"
   resolved "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.0.0-beta.0.tgz#bf62bb570ff1abd57e15dfa145893f81c209d021"
   integrity sha512-UDYQdvSDjXcnHXBs3QVVoPY2nxpr56cRPN2jo1ahjPsalilr5LPGlCW85zkoHx6AInqm4ZdGnbspgBS5/DvzDw==
@@ -21146,7 +21146,7 @@ openzeppelin-solidity@2.2.0:
   resolved "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.2.0.tgz#1f0e857f53bda29b77a8e72f9a629db81015fd34"
   integrity sha512-HfQq0xyT+EPs/lTWEd5Odu4T7CYdYe+qwf54EH28FQZthp4Bs6IWvOlOumTdS2dvpwZoTXURAopHn2LN1pwAGQ==
 
-openzeppelin-solidity@3.0.0:
+openzeppelin-solidity@3.0.0-beta.0:
   version "3.0.0-beta.0"
   resolved "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-3.0.0-beta.0.tgz#9be6d4ffc1975a13e01594c1ad9bcc70eec58e65"
   integrity sha512-lwCPDIj2CMBcUGOHAMtJbWn2Rb1R6pJJeH/Gzari/VEt5XwgU/fWVo9TRjWyE9KBhH+36mlSKpCaskzvn+KMZw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3376,10 +3376,10 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@openzeppelin/contracts@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.4.0.tgz#7270f79ed1463370fe6e664d36a779aa4d3ee896"
-  integrity sha512-xeKP59REgow5TPBJh3S9BRIm7DDG+Rz3Nt4ANWGUkjk4305DHpyUD5CyMJ6nd2JMmZuFyx4mjvvlCtSJLRnN6w==
+"@openzeppelin/contracts@3.0.0":
+  version "3.0.0-beta.0"
+  resolved "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.0.0-beta.0.tgz#bf62bb570ff1abd57e15dfa145893f81c209d021"
+  integrity sha512-UDYQdvSDjXcnHXBs3QVVoPY2nxpr56cRPN2jo1ahjPsalilr5LPGlCW85zkoHx6AInqm4ZdGnbspgBS5/DvzDw==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -6815,6 +6815,13 @@ axios@^0.18.0:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
 
+axios@^0.19.0:
+  version "0.19.2"
+  resolved "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 axobject-query@^2.0.2:
   version "2.1.1"
   resolved "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.1.tgz#2a3b1271ec722d48a4cd4b3fcc20c853326a49a7"
@@ -9164,6 +9171,13 @@ clean-stack@^2.0.0, clean-stack@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
+
+cli-analytics-sdk@LimeChain/cli-analytics-sdk:
+  version "1.0.0"
+  resolved "https://codeload.github.com/LimeChain/cli-analytics-sdk/tar.gz/a6889825b171d1a146936b13287357c93b5535b9"
+  dependencies:
+    axios "^0.19.0"
+    typescript "^3.6.4"
 
 cli-boxes@^1.0.0:
   version "1.0.0"
@@ -12906,10 +12920,24 @@ etherlime-logger@^1.1.3:
   dependencies:
     fs-extra "7.0.1"
 
+etherlime-logger@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/etherlime-logger/-/etherlime-logger-1.1.4.tgz#b1ded2144686b91420c37afddc79e3f0373a73fc"
+  integrity sha512-FQuB8tAVTN0YL/xXJRJbmDzYdctr5Kl4o25mQyJf5fxgc+zT2duMMBCOLl/S+8uI5yyB6CjUUu4RP3rkcv8QhQ==
+  dependencies:
+    fs-extra "7.0.1"
+
 etherlime-utils@^1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/etherlime-utils/-/etherlime-utils-1.1.3.tgz#237fe3ca6046dd4ea896766d5e2d6b912e2ff65a"
   integrity sha512-h5Kc5OM2YJM5aB1OIivh4pRMrT2Jjc1bS5eZIy0Jpuu8x6aH+EXjVJ1GavetCj+Qm7L+/oTgk5F9ZTU1BZ74CA==
+  dependencies:
+    chalk "2.4.1"
+
+etherlime-utils@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/etherlime-utils/-/etherlime-utils-1.1.4.tgz#1c15dcdd695d878b4a7af6222f5a55a54cab1187"
+  integrity sha512-kzvjA9f7e7mlOIY4pUve5+ynoVYIqThIzU6ENQjF/d6ZyIyEA3LR7MLTHwkuVHyJq6iV7nKnMTPZZfGlW9I71Q==
   dependencies:
     chalk "2.4.1"
 
@@ -12940,6 +12968,37 @@ etherlime@2.2.4:
     simple-git "^1.107.0"
     snarkjs LimeChain/snarkjs
     solc "^0.5.1"
+    tcp-port-used "^1.0.1"
+    yargs "11.0.0"
+
+etherlime@2.2.6:
+  version "2.2.6"
+  resolved "https://registry.npmjs.org/etherlime/-/etherlime-2.2.6.tgz#699bebcd0cf46a47ac6c7186b578a5b6b3702e27"
+  integrity sha512-aEt+x6B+KBoD6IQmcHcEb1/VvZ+D62jRTZRxe7ke2znOlOUR1fIDvWxQJn7ZT32TrL+rQUcr/JTf84PS4xeIWg==
+  dependencies:
+    "@0x/sol-coverage" "3.0.12"
+    axios "^0.18.0"
+    bn "^1.0.1"
+    chai "4.1.2"
+    circom LimeChain/circom
+    cli-analytics-sdk LimeChain/cli-analytics-sdk
+    cli-table "0.3.1"
+    colors "1.3.2"
+    docker-cli-js "^2.5.2"
+    ethereum-transaction-debugger "0.0.5"
+    etherlime-config "^1.0.0"
+    etherlime-logger "^1.1.4"
+    etherlime-utils "^1.1.4"
+    ethers "^4.0.27"
+    find-cache-dir "2.0.0"
+    fs-extra "7.0.1"
+    ganache-cli "6.5.1"
+    mocha "5.2.0"
+    original-require "1.0.1"
+    require-from-string "2.0.2"
+    simple-git "^1.107.0"
+    snarkjs LimeChain/snarkjs
+    solc "^0.6.1"
     tcp-port-used "^1.0.1"
     yargs "11.0.0"
 
@@ -14319,6 +14378,15 @@ ganache-cli@6.4.1:
     bn.js "4.11.8"
     source-map-support "0.5.9"
     yargs "11.1.0"
+
+ganache-cli@6.5.1:
+  version "6.5.1"
+  resolved "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.5.1.tgz#aaa1feaaa3d58f8ba488edd321a5c5522d1176bf"
+  integrity sha512-0+BoZmA/lrYVektfBTtn8CY/laEptrCl1LMtISLcNEEaLugxOrq0saXAtJTqvSpxdkCNdaTA92Dk8NKANyIuzw==
+  dependencies:
+    ethereumjs-util "6.1.0"
+    source-map-support "0.5.12"
+    yargs "13.2.4"
 
 ganache-cli@6.8.2:
   version "6.8.2"
@@ -21078,6 +21146,11 @@ openzeppelin-solidity@2.2.0:
   resolved "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.2.0.tgz#1f0e857f53bda29b77a8e72f9a629db81015fd34"
   integrity sha512-HfQq0xyT+EPs/lTWEd5Odu4T7CYdYe+qwf54EH28FQZthp4Bs6IWvOlOumTdS2dvpwZoTXURAopHn2LN1pwAGQ==
 
+openzeppelin-solidity@3.0.0:
+  version "3.0.0-beta.0"
+  resolved "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-3.0.0-beta.0.tgz#9be6d4ffc1975a13e01594c1ad9bcc70eec58e65"
+  integrity sha512-lwCPDIj2CMBcUGOHAMtJbWn2Rb1R6pJJeH/Gzari/VEt5XwgU/fWVo9TRjWyE9KBhH+36mlSKpCaskzvn+KMZw==
+
 opn@5.4.0:
   version "5.4.0"
   resolved "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz#cb545e7aab78562beb11aa3bfabc7042e1761035"
@@ -26123,10 +26196,10 @@ socks@~2.3.2:
     ip "1.1.5"
     smart-buffer "^4.1.0"
 
-solc@0.5.13:
-  version "0.5.13"
-  resolved "https://registry.npmjs.org/solc/-/solc-0.5.13.tgz#2a5ba2b7681898c6293759441e0a768fb6955def"
-  integrity sha512-osybDVPGjAqcmSKLU3vh5iHuxbhGlJjQI5ZvI7nRDR0fgblQqYte4MGvNjbew8DPvCrmoH0ZBiz/KBBLlPxfMg==
+solc@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/solc/-/solc-0.6.0.tgz#061a36075087b5ca16e1c4fc4fad565aa2851fe4"
+  integrity sha512-fYVRKbJLbg0oETBuAJN/ts0X/hj2YgOAl3ly3nrm/qhleVr22ecl3OSXW3hRmOWvH81hJ2KHRYRQWgqioK6d0A==
   dependencies:
     command-exists "^1.2.8"
     commander "3.0.2"
@@ -26141,6 +26214,20 @@ solc@^0.5.1, solc@^0.5.5:
   version "0.5.16"
   resolved "https://registry.npmjs.org/solc/-/solc-0.5.16.tgz#6c8d710a3792ccc79db924606b558a1149b1c603"
   integrity sha512-weEtRtisJyf+8UjELs7S4ST1KK7UIq6SRB7tpprfJBL9b5mTrZAT7m4gJKi2h6MiBpuSWfnraK8BnkyWzuTMRA==
+  dependencies:
+    command-exists "^1.2.8"
+    commander "3.0.2"
+    fs-extra "^0.30.0"
+    js-sha3 "0.8.0"
+    memorystream "^0.3.1"
+    require-from-string "^2.0.0"
+    semver "^5.5.0"
+    tmp "0.0.33"
+
+solc@^0.6.1:
+  version "0.6.3"
+  resolved "https://registry.npmjs.org/solc/-/solc-0.6.3.tgz#e8aaa014b28a02c9f1b315135f7a7c9f1eae30c8"
+  integrity sha512-Mu4orZUrNYJAOab4Tdq36EGYsFBnaji4ykiT5COQWOPTo3gJ6dBKKszmeOaox96sKyt1MeZTS0/pcY5n8qQiXg==
   dependencies:
     command-exists "^1.2.8"
     commander "3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -21141,11 +21141,6 @@ openurl@1.1.1:
   resolved "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz#3875b4b0ef7a52c156f0db41d4609dbb0f94b387"
   integrity sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=
 
-openzeppelin-solidity@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.2.0.tgz#1f0e857f53bda29b77a8e72f9a629db81015fd34"
-  integrity sha512-HfQq0xyT+EPs/lTWEd5Odu4T7CYdYe+qwf54EH28FQZthp4Bs6IWvOlOumTdS2dvpwZoTXURAopHn2LN1pwAGQ==
-
 openzeppelin-solidity@3.0.0-beta.0:
   version "3.0.0-beta.0"
   resolved "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-3.0.0-beta.0.tgz#9be6d4ffc1975a13e01594c1ad9bcc70eec58e65"


### PR DESCRIPTION
Got the contracts to compile for ~~nitro-protocol~~ all packages now.

Note that package @openzeppelin/contracts with v0.6.0 support is still in beta: 3.0.0-beta.0.