### PR TITLE
Build job out of memory errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,8 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - log_stats:
+          file: build-stats
       - attach_workspace:
           at: /home/circleci/project
       - run: yarn lint:check
@@ -160,6 +162,8 @@ jobs:
             else
                 yarn build:ci:incremental
             fi
+      - upload_logs:
+          file: build-stats
       - notify_slack
 
   test:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "private": true,
   "scripts": {
     "build": "lerna run build",
-    "build:ci": "lerna run build:ci",
+    "build:ci": "lerna run build:ci --concurrency 2",
     "build:ci:incremental": "yarn build:ci --since $(git merge-base $CIRCLE_BRANCH origin/master)",
     "build:netlify": "lerna run build:netlify --stream",
     "build:netlify:incremental": "yarn build:netlify --since $(git merge-base $CIRCLE_BRANCH origin/master)",


### PR DESCRIPTION
- Decrease lerna concurrency to 2 for `build:ci` and `build:ci:incremental`.
- Log memory usage for CircleCi build step.