### PR TITLE
Expose Chain directly on the Store, instead of proxying all methods

### DIFF
--- a/packages/xstate-wallet/src/store/memory-store.ts
+++ b/packages/xstate-wallet/src/store/memory-store.ts
@@ -77,14 +77,12 @@ export interface Store {
   // But I need one, in order to implement virtual funding.
   addObjective(objective: Objective): void;
 
-  // TODO: Should this be part of the store?
-  getChainInfo: Chain['getChainInfo'];
-  chainUpdatedFeed: Chain['chainUpdatedFeed'];
-  deposit: Chain['deposit'];
+  // TODO: should this be exposed via the Store?
+  chain: Chain;
 }
 
 export class MemoryStore implements Store {
-  protected _chain: Chain;
+  public chain: Chain;
   private _channels: Record<string, MemoryChannelStoreEntry | undefined> = {};
   private _objectives: Objective[] = [];
   private _nonces: Record<string, BigNumber | undefined> = {};
@@ -94,8 +92,8 @@ export class MemoryStore implements Store {
   constructor(privateKeys?: string[], chain?: Chain) {
     // TODO: We shouldn't default to a fake chain
     // but I didn't feel like updating all the constructor calls
-    this._chain = chain || new FakeChain();
-    this._chain.initialize();
+    this.chain = chain || new FakeChain();
+    this.chain.initialize();
 
     if (privateKeys && privateKeys.length > 0) {
       // load existing keys
@@ -283,18 +281,6 @@ export class MemoryStore implements Store {
     }
 
     return entry;
-  }
-
-  chainUpdatedFeed(channelId: string) {
-    // TODO: Implement this
-    return this._chain.chainUpdatedFeed(channelId);
-  }
-
-  deposit(channelId: string, expectedHeld: string, amount: string) {
-    return this._chain.deposit(channelId, expectedHeld, amount);
-  }
-  getChainInfo(channelId: string) {
-    return this._chain.getChainInfo(channelId);
   }
 }
 

--- a/packages/xstate-wallet/src/store/memory-store.ts
+++ b/packages/xstate-wallet/src/store/memory-store.ts
@@ -82,7 +82,7 @@ export interface Store {
 }
 
 export class MemoryStore implements Store {
-  public chain: Chain;
+  readonly chain: Chain;
   private _channels: Record<string, MemoryChannelStoreEntry | undefined> = {};
   private _objectives: Objective[] = [];
   private _nonces: Record<string, BigNumber | undefined> = {};

--- a/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
+++ b/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
@@ -30,7 +30,7 @@ let service: Interpreter<any, any, any, any>;
 
 // this service to be invoked by a protocol xstate machine
 const subscribeDepositEvent = (ctx: Init) => {
-  return store.chainUpdatedFeed(ctx.channelId).pipe(
+  return store.chain.chainUpdatedFeed(ctx.channelId).pipe(
     map((chainInfo: ChannelChainInfo) => {
       if (chainInfo.amount.gte(ctx.fundedAt)) {
         return 'FUNDED';

--- a/packages/xstate-wallet/src/workflows/depositing.ts
+++ b/packages/xstate-wallet/src/workflows/depositing.ts
@@ -54,7 +54,7 @@ type Services = {
 type Options = {services: Services};
 export const machine: MachineFactory<Init, any> = (store: Store, context: Init) => {
   const subscribeDepositEvent = (ctx: Init) => {
-    return store.chainUpdatedFeed(ctx.channelId).pipe(
+    return store.chain.chainUpdatedFeed(ctx.channelId).pipe(
       map((chainInfo): 'FUNDED' | 'SAFE_TO_DEPOSIT' | 'NOT_SAFE_TO_DEPOSIT' => {
         if (chainInfo.amount.gte(ctx.fundedAt)) {
           return 'FUNDED';
@@ -68,10 +68,10 @@ export const machine: MachineFactory<Init, any> = (store: Store, context: Init) 
   };
 
   const submitDepositTransaction = async (ctx: Init) => {
-    const currentHoldings = (await store.getChainInfo(ctx.channelId)).amount;
+    const currentHoldings = (await store.chain.getChainInfo(ctx.channelId)).amount;
     const amount = bigNumberify(ctx.totalAfterDeposit).sub(currentHoldings);
     if (amount.gt(0)) {
-      await store.deposit(ctx.channelId, currentHoldings.toHexString(), amount.toHexString());
+      await store.chain.deposit(ctx.channelId, currentHoldings.toHexString(), amount.toHexString());
     }
   };
 

--- a/packages/xstate-wallet/src/workflows/direct-funding.ts
+++ b/packages/xstate-wallet/src/workflows/direct-funding.ts
@@ -90,7 +90,7 @@ export const machine: MachineFactory<Init, any> = (store: Store, context: Init) 
       .reduce((a, b) => {
         return a.add(b);
       }, bigNumberify(0));
-    const chainInfo = await store.getChainInfo(ctx.channelId);
+    const chainInfo = await store.chain.getChainInfo(ctx.channelId);
 
     if (allocated.gt(chainInfo.amount))
       throw new Error('DirectFunding: Channel outcome is already underfunded; aborting');


### PR DESCRIPTION
Currently methods from the `Chain` are made available on the `Store` through proxying - for each `Chain` method, there is a method with the same name and signature on the `Store`, which calls directly through to the corresponding `Chain` method.

In separate work, I've just added three new methods to the `Chain`, and it seems a bit sub-optimal to have to add each of these to the `Store` separately. There's also a question of whether the `Store` should be providing the `Chain` at all, or whether the `Chain` should be independently passed in to any protocols that require it; the `Store` itself doesn't currently call the `Chain` directly, other than to proxy the calls through.

This PR removes the proxied methods, instead exposing a `chain` method directly on the `Store`. This should make it easier to modify the `Chain` interface independently in the short term, while also making it (very slightly) easier to transition to passing the `Chain` into protocols separately at a later date, if required.