### PR TITLE
xstate-wallet: fix generateConfig

### DIFF
--- a/packages/xstate-wallet/bin/generateConfigs.ts
+++ b/packages/xstate-wallet/bin/generateConfigs.ts
@@ -1,3 +1,5 @@
+/// <reference types="../src/global" />
+
 import * as fs from 'fs';
 import path from 'path';
 
@@ -19,7 +21,9 @@ const guards = ${serialize(guards || {})}
 const customActions = ${serialize(actions || {})}
 const machine = Machine(config, {guards, actions: customActions})
     `,
-    console.error
+    err => {
+      if (err) throw err;
+    }
   );
 }
 

--- a/packages/xstate-wallet/package.json
+++ b/packages/xstate-wallet/package.json
@@ -62,7 +62,7 @@
   "scripts": {
     "build": "npx webpack --config ./webpack-build.config.js",
     "build:ci": "yarn build",
-    "generateConfigs": "yarn run ts-node bin/generateConfigs.ts ",
+    "generateConfigs": "yarn run ts-node bin/generateConfigs.ts",
     "lint:check": "eslint . --ext .ts --cache",
     "lint:write": "eslint . --ext .ts --fix",
     "start": "node scripts/start.js",


### PR DESCRIPTION
`generateConfig` is now aware of globally defined typings. Fixes:

```
➜  xstate-wallet✗ npx ts-node src/generateConfigs.ts
Saving /statechannels/monorepo/packages/xstate-wallet/src/workflows/advance-channel.config.js
⨯ Unable to compile TypeScript:
src/messaging.ts:98:22 - error TS2339: Property 'ethereum' does not exist on type 'Window & typeof globalThis'.

98         await window.ethereum.enable();
                        ~~~~~~~~
src/messaging.ts:131:25 - error TS2339: Property 'ethereum' does not exist on type 'Window & typeof globalThis'.

131       if (typeof window.ethereum.selectedAddress === 'string') {
                            ~~~~~~~~
src/messaging.ts:132:24 - error TS2339: Property 'ethereum' does not exist on type 'Window & typeof globalThis'.

132         resolve(window.ethereum.selectedAddress);
                           ~~~~~~~~
src/messaging.ts:136:12 - error TS2339: Property 'ethereum' does not exist on type 'Window & typeof globalThis'.
```