### PR TITLE
Throw on contract compilation errors

### DIFF
--- a/packages/nitro-protocol/bin/compile.js
+++ b/packages/nitro-protocol/bin/compile.js
@@ -22,7 +22,7 @@ compile.stdout.on('data', data => {
 });
 
 compile.stderr.on('data', data => {
-  console.log(data.toString());
+  throw data.toString();
 });
 
 compile.on('close', code => {

--- a/packages/rps/bin/compile.js
+++ b/packages/rps/bin/compile.js
@@ -20,7 +20,7 @@ compile.stdout.on('data', data => {
 });
 
 compile.stderr.on('data', data => {
-  console.log(data.toString());
+  throw data.toString();
 });
 
 compile.on('close', code => {

--- a/packages/tic-tac-toe/bin/compile.js
+++ b/packages/tic-tac-toe/bin/compile.js
@@ -20,7 +20,7 @@ compile.stdout.on('data', data => {
 });
 
 compile.stderr.on('data', data => {
-  console.log(data.toString());
+  throw data.toString();
 });
 
 compile.on('close', code => {


### PR DESCRIPTION
My `yarn prepare` script was passing, even when contracts weren't compiling due to an incorrect solidity version. This PR throws on compile error rather than logging.