### PR TITLE
Duplicate assignChannelId action

### DIFF
--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -278,7 +278,6 @@ export const applicationWorkflow = (
         event: CreateChannelEvent
       ): ChannelParamsExist & RequestIdExists => {
         return {
-          ...context,
           channelParams: event,
           requestId: event.requestId
         };

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -148,7 +148,7 @@ const generateConfig = (
           target: 'confirmCreateChannelWorkflow',
           actions: [actions.assignChannelParams]
         },
-        JOIN_CHANNEL: {target: 'confirmJoinChannelWorkflow', actions: [actions.assignChannelId]}
+        JOIN_CHANNEL: {target: 'confirmJoinChannelWorkflow'}
       }
     },
     confirmCreateChannelWorkflow: getDataAndInvoke(


### PR DESCRIPTION
Remove `assignChannelId` from JOIN_CHANNEL transition. The action is triggered on entry to the `confirmJoinChannelWorkflow`.