### PR TITLE
Update web3torrent calls

### DIFF
--- a/packages/channel-client/src/channel-client.ts
+++ b/packages/channel-client/src/channel-client.ts
@@ -109,7 +109,7 @@ export class ChannelClient implements ChannelClientInterface<ChannelResult> {
     return this.provider.send('GetBudget', {hubAddress});
   }
 
-  async CloseAndWithdraw(hubAddress: string): Promise<SiteBudget> {
+  async closeAndWithdraw(hubAddress: string): Promise<SiteBudget> {
     return this.provider.send('CloseAndWithdraw', {hubAddress});
   }
 }

--- a/packages/channel-client/src/types.ts
+++ b/packages/channel-client/src/types.ts
@@ -55,6 +55,8 @@ export interface ChannelClientInterface<Payload = object> {
     hubAddress: string,
     hubDestinationAddress: string
   ): Promise<SiteBudget>;
+  getBudget(hubAddress: string): Promise<SiteBudget>;
+  closeAndWithdraw(hubAddress: string): Promise<SiteBudget>;
 }
 export interface EventsWithArgs {
   MessageQueued: [Message<ChannelResult>];

--- a/packages/channel-client/tests/fakes/fake-channel-provider.ts
+++ b/packages/channel-client/tests/fakes/fake-channel-provider.ts
@@ -59,7 +59,7 @@ export class FakeChannelProvider implements ChannelProviderInterface {
       case 'ApproveBudgetAndFund':
         return this.approveBudgetAndFund(params) as Promise<MethodType[K]>;
       case 'CloseAndWithdraw':
-        return this.CloseAndWithdraw(params) as Promise<MethodType[K]>;
+        return this.closeAndWithdraw(params) as Promise<MethodType[K]>;
       default:
         return Promise.reject(`No callback available for ${method}`);
     }
@@ -300,7 +300,7 @@ export class FakeChannelProvider implements ChannelProviderInterface {
       direct: {playerAmount: '0x0', hubAmount: '0x0'}
     };
   }
-  private async CloseAndWithdraw(params: {
+  private async closeAndWithdraw(params: {
     playerAmount: string;
     hubAmount: string;
     hubAddress: string;

--- a/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
+++ b/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
@@ -104,6 +104,18 @@ class MockChannelClient implements ChannelClientInterface {
       /* */
     });
   });
+
+  getBudget = jest.fn(async function(hubAddress: string) {
+    return new Promise<SiteBudget>(() => {
+      /* */
+    });
+  });
+
+  closeAndWithdraw = jest.fn(async function(hubAddress: string) {
+    return new Promise<SiteBudget>(() => {
+      /* */
+    });
+  });
 }
 
 let mockChannelClient;

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -183,7 +183,7 @@ export class PaymentChannelClient implements PaymentChannelClientInterface {
     payerBalance: string,
     beneficiaryOutcomeAddress: string,
     payerOutcomeAddress: string
-  ) {
+  ): Promise<ChannelState> {
     const allocations = formatAllocations(
       beneficiaryOutcomeAddress,
       payerOutcomeAddress,

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -4,6 +4,7 @@ import {FakeChannelProvider} from '@statechannels/channel-client';
 import {ChannelClient} from '@statechannels/channel-client';
 import React from 'react';
 import {ChannelStatus} from '@statechannels/client-api-schema';
+import {SiteBudget} from '@statechannels/client-api-schema';
 
 export interface ChannelState {
   channelId: string;
@@ -289,6 +290,14 @@ export class PaymentChannelClient implements PaymentChannelClientInterface {
       hubAddress,
       hubDestinationAddress
     );
+  }
+
+  async getBudget(hubAddress: string): Promise<SiteBudget> {
+    return await this.channelClient.getBudget(hubAddress);
+  }
+
+  async closeAndWithdraw(hubAddress: string): Promise<SiteBudget> {
+    return await this.channelClient.closeAndWithdraw(hubAddress);
   }
 }
 

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -197,7 +197,6 @@ export class PaymentChannelClient implements PaymentChannelClientInterface {
       payerOutcomeAddress
     );
 
-    // ignore return val for now and stub out response
     const channelResult = await this.channelClient.updateChannel(
       channelId,
       participants,


### PR DESCRIPTION
I renamed the method capitalized `CloseAndWithdraw` method to follow conventions with the rest.

Some methods still ignore the return values from channel-clients, e.g., 
- ~~acceptPayment~~
- approveBudgetAndFund

It's unclear whether we should take their return values and add them to cached states.