### PR TITLE
Move event conversion to MessagingService

### DIFF
--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -7,7 +7,6 @@ import React from 'react';
 import {Wallet as WalletUi} from './ui/wallet';
 import {interpret, Interpreter, State} from 'xstate';
 import {Guid} from 'guid-typescript';
-import {convertToOpenEvent} from './utils/workflow-utils';
 import {Notification, Response} from '@statechannels/client-api-schema';
 import {filter, map} from 'rxjs/operators';
 import {Message, OpenChannel} from './store/types';
@@ -49,11 +48,11 @@ export class ChannelWallet {
       });
 
     this.messagingService.requestFeed.subscribe(r => {
-      if (r.method === 'CreateChannel' || r.method === 'JoinChannel') {
+      if (r.type === 'CREATE_CHANNEL' || r.type === 'JOIN_CHANNEL') {
         const workflow = this.startApplicationWorkflow();
         this.workflows.push(workflow);
 
-        workflow.machine.send(convertToOpenEvent(r));
+        workflow.machine.send(r);
       }
     });
   }

--- a/packages/xstate-wallet/src/event-types.ts
+++ b/packages/xstate-wallet/src/event-types.ts
@@ -40,9 +40,11 @@ export interface PlayerRequestConclude {
   channelId: string;
 }
 
-export type WorkflowEvent =
+export type AppRequestEvent =
   | PlayerRequestConclude
   | PlayerStateUpdate
   | OpenEvent
   | ChannelUpdated
   | JoinChannelEvent;
+
+export type WorkflowEvent = AppRequestEvent;

--- a/packages/xstate-wallet/src/event-types.ts
+++ b/packages/xstate-wallet/src/event-types.ts
@@ -1,0 +1,48 @@
+import {SimpleAllocation, Participant} from './store/types';
+import {BigNumber} from 'ethers/utils';
+import {ChannelStoreEntry} from './store/memory-channel-storage';
+
+export interface JoinChannelEvent {
+  type: 'JOIN_CHANNEL';
+  channelId: string;
+  requestId: number;
+}
+// Events
+export type OpenEvent = CreateChannelEvent | JoinChannelEvent;
+
+export interface CreateChannelEvent {
+  type: 'CREATE_CHANNEL';
+  participants: Participant[];
+  outcome: SimpleAllocation;
+  appDefinition: string;
+  appData: string;
+  challengeDuration: BigNumber;
+  chainId: string;
+  requestId: number;
+}
+
+export interface ChannelUpdated {
+  type: 'CHANNEL_UPDATED';
+  storeEntry: ChannelStoreEntry;
+  requestId: number;
+}
+
+export interface PlayerStateUpdate {
+  type: 'PLAYER_STATE_UPDATE';
+  requestId: number;
+  outcome: SimpleAllocation;
+  channelId: string;
+  appData: string;
+}
+export interface PlayerRequestConclude {
+  requestId: number;
+  type: 'PLAYER_REQUEST_CONCLUDE';
+  channelId: string;
+}
+
+export type WorkflowEvent =
+  | PlayerRequestConclude
+  | PlayerStateUpdate
+  | OpenEvent
+  | ChannelUpdated
+  | JoinChannelEvent;

--- a/packages/xstate-wallet/src/utils/workflow-utils.ts
+++ b/packages/xstate-wallet/src/utils/workflow-utils.ts
@@ -8,16 +8,6 @@ import {
   StateNodeConfig
 } from 'xstate';
 import {Store} from '../store';
-import {
-  CreateChannelRequest,
-  JoinChannelRequest,
-  UpdateChannelRequest
-} from '@statechannels/client-api-schema';
-import {NETWORK_ID, CHALLENGE_DURATION} from '../constants';
-import {bigNumberify} from 'ethers/utils';
-import {OpenEvent, PlayerStateUpdate} from '../workflows/application';
-import {deserializeAllocations} from '../serde/app-messages/deserialize';
-import {isSimpleEthAllocation} from './outcome';
 
 export function createMockGuard(guardName: string): GuardPredicate<any, any> {
   return {
@@ -73,37 +63,4 @@ export function getDataAndInvoke<T>(
     },
     onDone
   };
-}
-
-export function convertToPlayerStateUpdateEvent(request: UpdateChannelRequest): PlayerStateUpdate {
-  const outcome = deserializeAllocations(request.params.allocations);
-  if (!isSimpleEthAllocation(outcome)) {
-    throw new Error('Currently only a simple ETH allocation is supported');
-  }
-  return {
-    type: 'PLAYER_STATE_UPDATE',
-    requestId: request.id,
-    outcome,
-    channelId: request.params.channelId,
-    appData: request.params.appData
-  };
-}
-
-export function convertToOpenEvent(request: CreateChannelRequest | JoinChannelRequest): OpenEvent {
-  if (request.method === 'CreateChannel') {
-    const outcome = deserializeAllocations(request.params.allocations);
-    if (!isSimpleEthAllocation(outcome)) {
-      throw new Error('Currently only a simple ETH allocation is supported');
-    }
-    return {
-      type: 'CREATE_CHANNEL',
-      ...request.params,
-      outcome,
-      challengeDuration: bigNumberify(CHALLENGE_DURATION),
-      chainId: NETWORK_ID,
-      requestId: request.id
-    };
-  } else {
-    return {type: 'JOIN_CHANNEL', ...request.params, requestId: request.id};
-  }
 }

--- a/packages/xstate-wallet/src/workflows/tests/application.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/application.test.ts
@@ -1,14 +1,7 @@
 import {interpret} from 'xstate';
 import {ethers} from 'ethers';
 import waitForExpect from 'wait-for-expect';
-import {
-  applicationWorkflow,
-  JoinChannelEvent,
-  WorkflowServices,
-  ChannelUpdated,
-  CreateChannelEvent,
-  WorkflowActions
-} from '../application';
+import {applicationWorkflow, WorkflowServices, WorkflowActions} from '../application';
 import {AddressZero} from 'ethers/constants';
 import {MemoryStore, Store} from '../../store/memory-store';
 import {StateVariables, SignedState} from '../../store/types';
@@ -17,6 +10,7 @@ import {MessagingService, MessagingServiceInterface} from '../../messaging';
 import {bigNumberify} from 'ethers/utils';
 import {calculateChannelId} from '../../store/state-utils';
 import {simpleEthAllocation} from '../../utils/outcome';
+import {CreateChannelEvent, ChannelUpdated, JoinChannelEvent} from '../../event-types';
 
 jest.setTimeout(50000);
 const createChannelEvent: CreateChannelEvent = {


### PR DESCRIPTION
Previously we converted from the `client-api-schema` types in several places: the `MessagingService`, the `ChannelWallet`, and the `ApplicationWorkflow`. This PR:

1. Pulls out the internal event types (previously defined in the `ApplicationWorkflow`) out into their own file.
2. Moves all conversion from `client-api-schema` types to internal events into the `MessagingService`

