### PR TITLE
[web3t] Overhaul buffer system

### DIFF
--- a/packages/web3torrent/package.json
+++ b/packages/web3torrent/package.json
@@ -13,6 +13,7 @@
     "@statechannels/channel-client": "0.0.1",
     "bencode": "2.0.1",
     "debug": "4.1.1",
+    "ethers": "^4.0.45",
     "eventemitter3": "4.0.0",
     "jszip": "3.2.2",
     "node-sass": "4.13.1",

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -232,7 +232,8 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     this.peersList[infoHash][peerId].seederBalance = newSeederBalance.toString();
     // convert payment into number of pieces
     this.peersList[infoHash][peerId].buffer = bigNumberify(this.peersList[infoHash][peerId].buffer)
-      .add(payment.div(WEI_PER_PIECE)) // TODO allow this to vary by piece size
+      .add(payment.div(WEI_PER_PIECE)) // This must remain an integer as long as our check above uses .isZero()
+      // ethers BigNumbers are always integers
       .toString();
 
     log(

--- a/yarn.lock
+++ b/yarn.lock
@@ -15697,7 +15697,7 @@ ethers@4.0.44:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@^4.0.27, ethers@~4.0.4:
+ethers@^4.0.27, ethers@^4.0.45, ethers@~4.0.4:
   version "4.0.45"
   resolved "https://registry.npmjs.org/ethers/-/ethers-4.0.45.tgz#8d4cd764d7c7690836b583d4849203c225eb56e2"
   integrity sha512-N/Wmc6Mw4pQO+Sss1HnKDCSS6KSCx0luoBMiPNq+1GbOaO3YaZOyplBEhj+NEoYsizZYODtkITg2oecPeNnidQ==


### PR DESCRIPTION
This PR tries to improve clarity around the role of the `buffer` (previously known as the `funds`, which is kept by the seeder per torrent and per leecher, and used to decide when to choke them / prompt them to pay us). 

Choices:

- The buffer should have units of "pieces" (in the near future, probably "bytes", but *not* ETH or wei)
- Conversion factor is a new constant, available to seeders and leechers and easily tuneable.
- The threshold for unchoking is when the buffer is nonzero (previously, at a positive constant called `REQUEST_RATE`)
- The number of pieces that a leecher is prepared to pay for upfront in each payment is another tuneable constant  `BUFFER_REFILL_RATE`
