### PR TITLE
chore: Fix spelling mistakes

### DIFF
--- a/packages/rps/.env
+++ b/packages/rps/.env
@@ -18,13 +18,13 @@ BOT_URL=http://localhost:3002
 
 # Using 127.0.0.1 instead of localhost for WALLET_URL makes development more like production
 # in the sense that metamask sees the app and the wallet being served from two different domains,
-# therefore requiring two seperate connection authorizations
+# therefore requiring two separate connection authorizations
 
 # These values are required if contracts will be deployed to a test network (TARGET_NETWORK!='development')
-# and should be overriden in a .env.local file
+# and should be overridden in a .env.local file
 ETH_ACCOUNT_MNENOMIC='A valid account mnemonic is required to deploy to a test network'
 INFURA_API_KEY='A valid Infura API key is required to deploy to a test network'
 
 # These contract addresses get defined in the start/build scripts 
-# or the contract test setup with the actual adresses of the contracts
+# or the contract test setup with the actual addresses of the contracts
 RPS_CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000


### PR DESCRIPTION
Fix a few spelling mistakes.

Also is this used? `ETH_ACCOUNT_MNENOMIC`
`Mnenomic` is not a word but I can't find usages anywhere :)