### PR TITLE
Sign on join channel

### DIFF
--- a/packages/xstate-wallet/src/integration-tests/funding.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/funding.test.ts
@@ -44,15 +44,13 @@ it('allows for two wallets to fund an app', async () => {
   playerA.channelWallet.workflows[0].machine.send({type: 'USER_APPROVES'});
 
   const createResponse = await createPromise;
-
   expect(createResponse.result).toBeDefined();
 
   const {channelId} = createResponse.result;
   const joinEvent: JoinChannelRequest = generateJoinChannelRequest(channelId);
   const joinPromise = playerB.messagingService.outboxFeed
     .pipe(
-      filter(r => 'id' in r && r.id === joinEvent.id),
-      map(r => r as JoinChannelResponse),
+      filter((r): r is JoinChannelResponse => 'id' in r && r.id === joinEvent.id),
       first()
     )
     .toPromise();
@@ -61,7 +59,7 @@ it('allows for two wallets to fund an app', async () => {
   // Wait for the create channel service to start
   await waitForExpect(async () => {
     expect(playerB.workflowState).toMatchObject({
-      confirmJoinChannelWorkflow: 'invokeCreateChannelConfirmation'
+      confirmJoinChannelWorkflow: {confirmChannelCreation: 'invokeCreateChannelConfirmation'}
     });
   }, 3000);
 

--- a/packages/xstate-wallet/src/workflows/tests/application.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/application.test.ts
@@ -168,11 +168,8 @@ it('initializes and starts the join channel machine', async () => {
   service.send(event);
 
   await waitForExpect(async () => {
-    expect(service.state.value).toEqual({
-      confirmJoinChannelWorkflow: 'getDataForCreateChannelConfirmation'
-    });
-    expect(service.state.context).toBeDefined();
-    expect(service.state.context.channelId).toEqual('0xabc');
+    expect(service.state.value).toEqual({confirmJoinChannelWorkflow: 'signFirstState'});
+    expect(service.state.context).toMatchObject({channelId: '0xabc'});
   }, 2000);
 });
 


### PR DESCRIPTION
While incorporating virtual-funding into the create-and-fund workflow, I ran into the issue of validating the app definition and data before supporting the first state. It turns out that there's no benefit to validating the first state at a later point -- the only code capable of validating the first state is the application itself. Therefore, when the app calls JOIN_CHANNEL, the wallet should assume an acceptable first state, and might as well sign it straight away.