### PR TITLE
[channel-client] Update new test to multi-channel pattern

### DIFF
--- a/packages/channel-client/tests/channel-client.test.ts
+++ b/packages/channel-client/tests/channel-client.test.ts
@@ -190,7 +190,7 @@ describe('ChannelClient with FakeChannelProvider', () => {
       setProviderStates([providerA, providerB], states['running']);
       const channelResult = await clientA.getState(channelId);
       expect(channelResult).toEqual(states['running']);
-      expect(providerB.latestState).toEqual(states['running']);
+      expect(providerB.latestState[channelId]).toEqual(states['running']);
     });
   });
 


### PR DESCRIPTION
I think the current failing test on `master` was due to was one of those rare cases where tests passed both on `master` and `feature` pre-merge, there were no merge conflicts, but the merge caused the test to fail because `feature` was built against an out of date `master`. 