### PR TITLE
Get storybook working again

### DIFF
--- a/packages/xstate-wallet/.storybook/main.js
+++ b/packages/xstate-wallet/.storybook/main.js
@@ -6,16 +6,10 @@ module.exports = {
   webpackFinal: async config => {
     config.module.rules.push(
       {
-        test: /\.(ts|tsx)$/,
-        use: [
-          {
-            loader: require.resolve('awesome-typescript-loader')
-          },
-          // Optional
-          {
-            loader: require.resolve('react-docgen-typescript-loader')
-          }
-        ]
+        test: /\.tsx?$/,
+        loader: 'ts-loader',
+        exclude: /node_modules/,
+        options: {projectReferences: true}
       },
       {
         test: /\.s[ac]ss$/i,

--- a/packages/xstate-wallet/src/ui/stories/application-workflow.stories.tsx
+++ b/packages/xstate-wallet/src/ui/stories/application-workflow.stories.tsx
@@ -9,7 +9,7 @@ import {renderComponentInFrontOfApp} from './helpers';
 import {MemoryStore} from '../../store/memory-store';
 import {MessagingServiceInterface, MessagingService} from '../../messaging';
 import React from 'react';
-import ApplicationWorkflow from '../application-workflow';
+import {ApplicationWorkflow} from '../application-workflow';
 
 const store = new MemoryStore([
   '0x8624ebe7364bb776f891ca339f0aaa820cc64cc9fca6a28eec71e6d8fc950f29'
@@ -21,7 +21,8 @@ const testContext = {
 
 if (applicationWorkflowConfig.states) {
   Object.keys(applicationWorkflowConfig.states).forEach(state => {
-    if (typeof state === 'string') {
+    // TODO: We should figure out a nice way of dealing with nested workflows
+    if (state !== 'confirmJoinChannelWorkflow' && state !== 'confirmCreateChannelWorkflow') {
       const machine = interpret<any, any, any>(
         applicationWorkflow(store, messagingService).withContext(testContext),
         {

--- a/packages/xstate-wallet/src/ui/stories/application-workflow.stories.tsx
+++ b/packages/xstate-wallet/src/ui/stories/application-workflow.stories.tsx
@@ -9,7 +9,9 @@ import {renderWalletInFrontOfApp} from './helpers';
 import {MemoryStore} from '../../store/memory-store';
 import {MessagingServiceInterface, MessagingService} from '../../messaging';
 
-const store = new MemoryStore(['0xkey']);
+const store = new MemoryStore([
+  '0x8624ebe7364bb776f891ca339f0aaa820cc64cc9fca6a28eec71e6d8fc950f29'
+]);
 const messagingService: MessagingServiceInterface = new MessagingService(store);
 const testContext = {
   channelId: '0x697ecf681033a2514ed19c90299a67ae8677f3c78b5877fe4550c4f0960e87b7'

--- a/packages/xstate-wallet/src/ui/stories/application-workflow.stories.tsx
+++ b/packages/xstate-wallet/src/ui/stories/application-workflow.stories.tsx
@@ -5,9 +5,11 @@ import {
 export default {title: 'X-state wallet'};
 import {storiesOf} from '@storybook/react';
 import {interpret} from 'xstate';
-import {renderWalletInFrontOfApp} from './helpers';
+import {renderComponentInFrontOfApp} from './helpers';
 import {MemoryStore} from '../../store/memory-store';
 import {MessagingServiceInterface, MessagingService} from '../../messaging';
+import React from 'react';
+import ApplicationWorkflow from '../application-workflow';
 
 const store = new MemoryStore([
   '0x8624ebe7364bb776f891ca339f0aaa820cc64cc9fca6a28eec71e6d8fc950f29'
@@ -19,31 +21,21 @@ const testContext = {
 
 if (applicationWorkflowConfig.states) {
   Object.keys(applicationWorkflowConfig.states).forEach(state => {
-    const machine = interpret<any, any, any>(
-      applicationWorkflow(store, messagingService).withContext(testContext),
-      {
-        devTools: true
-      }
-    ); // start a new interpreted machine for each story
-    machine.start(state);
-    storiesOf('Workflows / Application', module).add(
-      state.toString(),
-      renderWalletInFrontOfApp(machine)
-    );
-    machine.stop();
-  });
-}
-
-if (applicationWorkflowConfig.states) {
-  ['CREATE_CHANNEL', 'OPEN_CHANNEL'].forEach(event => {
-    const machineWithChildren = interpret<any, any, any>(
-      applicationWorkflow(store, messagingService).withContext(testContext)
-    ).start(); // start a new interpreted machine for each story
-    machineWithChildren.send(event);
-    storiesOf('Workflows / Application', module).add(
-      'Initialising + ' + event,
-      renderWalletInFrontOfApp(machineWithChildren)
-    );
-    machineWithChildren.stop();
+    if (typeof state === 'string') {
+      const machine = interpret<any, any, any>(
+        applicationWorkflow(store, messagingService).withContext(testContext),
+        {
+          devTools: true
+        }
+      ); // start a new interpreted machine for each story
+      machine.start(state);
+      storiesOf('Workflows / Application', module).add(
+        state.toString(),
+        renderComponentInFrontOfApp(
+          <ApplicationWorkflow current={machine.state} send={machine.send} />
+        )
+      );
+      machine.stop();
+    }
   });
 }

--- a/packages/xstate-wallet/src/ui/stories/confirm-create-channel-workflow.stories.tsx
+++ b/packages/xstate-wallet/src/ui/stories/confirm-create-channel-workflow.stories.tsx
@@ -12,7 +12,9 @@ import {MemoryStore} from '../../store/memory-store';
 import {bigNumberify} from 'ethers/utils';
 import {simpleEthAllocation} from '../../utils/outcome';
 
-const store = new MemoryStore(['0xkey']);
+const store = new MemoryStore([
+  '0x8624ebe7364bb776f891ca339f0aaa820cc64cc9fca6a28eec71e6d8fc950f29'
+]);
 
 const alice: Participant = {
   participantId: 'a',

--- a/packages/xstate-wallet/src/ui/stories/confirm-create-channel-workflow.stories.tsx
+++ b/packages/xstate-wallet/src/ui/stories/confirm-create-channel-workflow.stories.tsx
@@ -7,10 +7,12 @@ export default {title: 'X-state wallet'};
 import {storiesOf} from '@storybook/react';
 import {interpret} from 'xstate';
 import {Participant} from '@statechannels/client-api-schema';
-import {renderWalletInFrontOfApp} from './helpers';
+import {renderComponentInFrontOfApp} from './helpers';
 import {MemoryStore} from '../../store/memory-store';
 import {bigNumberify} from 'ethers/utils';
 import {simpleEthAllocation} from '../../utils/outcome';
+import React from 'react';
+import {ConfirmCreateChannel} from '../confirm-create-channel-workflow';
 
 const store = new MemoryStore([
   '0x8624ebe7364bb776f891ca339f0aaa820cc64cc9fca6a28eec71e6d8fc950f29'
@@ -48,7 +50,9 @@ if (config.states) {
     machine.onEvent(event => console.log(event.type)).start(state);
     storiesOf('Workflows / Confirm Create Channel', module).add(
       state.toString(),
-      renderWalletInFrontOfApp(machine)
+      renderComponentInFrontOfApp(
+        <ConfirmCreateChannel current={machine.state} send={machine.send} />
+      )
     );
     machine.stop(); // the machine will be stopped before it can be transitioned. This means the console.log on L49 throws a warning that we sent an event to a stopped machine.
   });

--- a/packages/xstate-wallet/src/ui/stories/helpers.tsx
+++ b/packages/xstate-wallet/src/ui/stories/helpers.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import fakeApp from '../../images/fake-app.png';
 import {Modal, Card, Flex, Image} from 'rimble-ui';
+import logo from '../../images/logo.svg';
 
 export function renderComponentInFrontOfApp(component) {
   function renderFunction() {

--- a/packages/xstate-wallet/src/ui/stories/helpers.tsx
+++ b/packages/xstate-wallet/src/ui/stories/helpers.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
-import {Wallet} from '../wallet';
-import {Image} from 'rimble-ui';
-import fakeApp from '../../images/fake-app.png';
 
-export function renderWalletInFrontOfApp(machine) {
+import fakeApp from '../../images/fake-app.png';
+import {Modal, Card, Flex, Image} from 'rimble-ui';
+
+export function renderComponentInFrontOfApp(component) {
   function renderFunction() {
     return (
       <div>
         <Image src={fakeApp} />
-        <Wallet workflow={machine} />
+        <Modal isOpen={true}>
+          <Card width={'320px'} height={'450px'}>
+            <Flex px={[3, 3, 4]} height={3} borderBottom={1} borderColor={'#E8E8E8'} mt={'0.8'}>
+              <Image alt="State Channels" borderRadius={8} height="auto" src={logo} />
+            </Flex>
+            {component}
+          </Card>
+        </Modal>
       </div>
     );
   }


### PR DESCRIPTION
This gets storybook functioning in `xstate-wallet` again. Storybook was broken when we started using nested workflows.

The fix I've implemented isn't too elegant but I think it should be good enough to allow us to develop the UI using storybook.

Fixes #1114 