### PR TITLE
[web3t] Handle undefined wire in web3 ChannelList

### DIFF
--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -40,8 +40,9 @@ class ChannelsList extends React.Component<UploadInfoProps> {
         wire.paidStreamingExtension.peerChannelId === channelId ||
         wire.paidStreamingExtension.pseChannelId === channelId
     );
-    const {uploaded} = wire;
-    const {peerAccount} = wire.paidStreamingExtension;
+
+    const uploaded = wire ? wire.uploaded : 0;
+    const peerAccount = wire ? wire.paidStreamingExtension.peerAccount : 'unknown';
 
     return (
       <tr className="peerInfo" key={peerAccount}>


### PR DESCRIPTION
If `wire` is `undefined` (because the connection dropped; browser is closed by peer for example) then the page threw an error.