### PR TITLE
Fix skipped test

### DIFF
--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -176,11 +176,6 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
           response(false);
 
           this.blockPeer(torrent.infoHash, wire, peerAccount);
-          this.emit(ClientEvents.PEER_STATUS_CHANGED, {
-            torrentPeers: this.peersList[torrent.infoHash],
-            torrentInfoHash: torrent.infoHash,
-            peerAccount
-          });
         } else if (!knownPeerAccount.allowed || reqPrice.gt(knownPeerAccount.buffer)) {
           response(false);
           log('> BLOCKED: ' + index, 'BUFFER: ' + knownPeerAccount.buffer);


### PR DESCRIPTION
Fixes https://github.com/statechannels/monorepo/issues/1099

Fake client has a very subtle bug that makes the skipped test failed and the wrong turn error we saw:

![image](https://user-images.githubusercontent.com/2715151/76267488-5bc11c00-6241-11ea-9150-f858f41ef3c4.png)

~~The bug was due to fake client sets the wrong turn number when a participant joins the channel.~~