### PR TITLE
[WIP] Fix inconsistent pricing 

### DIFF
--- a/packages/web3torrent/src/library/paid-streaming-extension.ts
+++ b/packages/web3torrent/src/library/paid-streaming-extension.ts
@@ -25,7 +25,9 @@ export abstract class PaidStreamingExtension implements Extension {
 
   pseChannelId: string;
   peerChannelId: string;
+
   isForceChoking = false;
+  isBeingChoked = false;
 
   constructor(wireToUse: PaidStreamingWire) {
     this.wire = wireToUse;
@@ -87,15 +89,19 @@ export abstract class PaidStreamingExtension implements Extension {
   }
 
   stop() {
-    this.isForceChoking = true;
-    this.wire.choke();
-    this.executeExtensionCommand(PaidStreamingExtensionNotices.STOP, this.pseChannelId);
+    if (!this.isForceChoking) {
+      this.isForceChoking = true;
+      this.executeExtensionCommand(PaidStreamingExtensionNotices.STOP, this.pseChannelId);
+    }
   }
 
   start() {
-    this.isForceChoking = false;
-    this.wire.unchoke();
-    this.executeExtensionCommand(PaidStreamingExtensionNotices.START);
+    if (this.isForceChoking) {
+      setTimeout(() => {
+        this.isForceChoking = false;
+        this.executeExtensionCommand(PaidStreamingExtensionNotices.START);
+      }, 0);
+    }
   }
 
   ack() {
@@ -111,11 +117,34 @@ export abstract class PaidStreamingExtension implements Extension {
   onMessage(buffer: Buffer) {
     try {
       const jsonData = bencode.decode(buffer, undefined, undefined, 'utf8');
-      this.messageBus.emit(PaidStreamingExtensionEvents.NOTICE, jsonData);
+      this.messageHandler(jsonData);
     } catch (err) {
-      log('ERROR: decoding', err);
+      log('ERROR: onMessage decoding', err);
       return;
     }
+  }
+
+  protected messageHandler({command, data}) {
+    switch (command) {
+      case PaidStreamingExtensionNotices.ACK:
+        return;
+      case PaidStreamingExtensionNotices.START:
+        log(`START received from ${this.peerAccount}`);
+        this.isBeingChoked = false;
+        this.wire.requests = [];
+        this.wire.unchoke();
+        break;
+      case PaidStreamingExtensionNotices.STOP:
+        log(`STOP received from ${this.peerAccount}`);
+        this.peerChannelId = data;
+        if (this.isBeingChoked) return;
+        this.isBeingChoked = true;
+        break;
+      default:
+        log(`MESSAGE received from ${this.peerAccount}`, data);
+    }
+    this.ack();
+    this.messageBus.emit(PaidStreamingExtensionEvents.NOTICE, {command, data});
   }
 
   protected executeExtensionCommand(command: PaidStreamingExtensionNotices, data = {}) {
@@ -133,25 +162,30 @@ export abstract class PaidStreamingExtension implements Extension {
   }
 
   protected interceptRequests() {
-    const undecoratedOnRequestFunction = this.wire._onRequest;
-    const extension = this;
-    const {messageBus} = extension;
-    const wire = this.wire as PaidStreamingWire;
+    const {messageBus, wire} = this;
 
-    this.wire._onRequest = function(index: number, offset: number, length: number) {
-      log(`!> Incoming request for piece - index ${arguments[0]}`);
+    // for debugging purposes. It logs when a piece is received
+    const _onPiece = wire._onPiece;
+    wire._onPiece = function(index, offset, buffer) {
+      log(`_onPiece PIECE: ${index}`, arguments);
+      _onPiece.apply(wire, [index, offset, buffer]);
+    };
 
-      messageBus.emit(PaidStreamingExtensionEvents.REQUEST, index, offset, length);
+    const _onRequest = wire._onRequest;
+    wire._onRequest = function(index, offset, length) {
+      log(`_onRequest: ${index}`);
 
-      // Call onRequest after the handlers triggered by this event have been called
-
-      setTimeout(() => {
-        if (!extension.isForceChoking) {
-          undecoratedOnRequestFunction.apply(wire, [index, offset, length]);
+      messageBus.emit(PaidStreamingExtensionEvents.REQUEST, index, offset, length, function(
+        allow = false
+      ) {
+        if (allow) {
+          _onRequest.apply(wire, [index, offset, length]);
+          log(`_onRequest PASS - ${index}`);
         } else {
-          log('!> dropped request - index: ' + index);
+          wire._onCancel(index, offset, length);
+          log(`_onRequest CHOKED - ${index}`);
         }
-      }, 0);
+      });
     };
   }
 }

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -22,14 +22,14 @@ export enum TorrentEvents {
 export enum WireEvents {
   DOWNLOAD = 'download',
   FIRST_REQUEST = 'first_request',
-  REQUEST = 'request'
+  REQUEST = 'request',
+  KEEP_ALIVE = 'keep-alive'
 }
 
 export enum PaidStreamingExtensionEvents {
   WARNING = 'warning',
   PSE_HANDSHAKE = 'pse_handshake',
   NOTICE = 'notice',
-  FIRST_REQUEST = 'first_request',
   REQUEST = 'request'
 }
 
@@ -61,6 +61,8 @@ export type PaidStreamingWire = Omit<Wire, 'requests'> &
 
     _clearTimeout(): void;
     _onRequest(index: number, offset: number, length: number): void;
+    _onCancel(index: number, offset: number, length: number): void;
+    _onPiece(index: number, offset: number, buffer: Buffer): void;
   };
 
 export type ExtendedHandshake = PaidStreamingExtendedHandshake & {
@@ -97,7 +99,9 @@ export type ExtendedTorrent = Omit<WebTorrent.Torrent, OverridenTorrentPropertie
 
   _startDiscovery(): void;
   _selections: unknown;
+  _update(): void;
   _updateWire(wire: PaidStreamingWire): void;
+  _reservations: unknown;
 };
 
 export type ArgumentTypes<F extends Function> = F extends (...args: infer A) => any ? A : never;


### PR DESCRIPTION
This PR should close #1148

There were quite a lot of issues that caused the issue:
- The **STOP** and **START** messages were being emitted and handled several times (on response to each blocked request). This provoked that sometimes funds were being transferred more than once. It also affected the process of jumpstarting the download and provoked several inconsistencies.
**Solutions:** 
I added a message interceptor at the wire level, that automates things, avoids message repetition at the leecher side, and adds some encapsulation to the wire.
I also added more checks in the stop() and start() methods to avoid spamming the leecher with messages, if possible.

- _The **REQUEST** interceptor implementation was horrible_, and I hate myself for leaving it as it was 'till now. It was hard to read and understand, and it seems that it added inconsistencies in its execution, provoked, I believe, by the stack not being always the same.
**Solution:**
I now pass a callback with the REQUEST event, that gives the client the power to allow or block a request.

- _The **STOP** and  **START** logic was/is problematic:_ for some reason, as it was (and until an hour ago) if the seeder choked the leecher, but the leecher had still some responses of requests left to process, all those responses got dropped. 
**Solution:**
I make the seeder wait 'till it finishes to process all requests (_by using setTimeout, yes, I hate it, I need to see if I can avoid it_), and only then emit the START event. 

Besides that, I added some more improvements to the codebase:
- Now we can see when a request is responded (by intercepting the _onPiece method).
- I merged the listeners of the **REQUEST** event to a single one so that it gets easier to read, and all requests share the same interface and behaviour.
- I removed unnecessary method calls in the jumpstart function (I believe they were unnecessary, but we don't have the tests that could help check that, like the one that tested if the leecher could start downloading files after 2+ minutes idle).

**Everything seems to be working, but I need to do some more manual testing. With the last basic runs that I made to test this, it worked great, but if someone else wants to give it a run, that would be great.**