### PR TITLE
[web3t] Display UploadInfo unconditionally 

### DIFF
--- a/packages/web3torrent/src/components/torrent-info/TorrentInfo.test.tsx
+++ b/packages/web3torrent/src/components/torrent-info/TorrentInfo.test.tsx
@@ -78,7 +78,6 @@ describe('<TorrentInfo />', () => {
     expect(fileCostElement.exists()).toEqual(true);
     expect(magnetLinkButtonElement.exists()).toEqual(true);
     expect(downloadInfoElement.exists()).toEqual(false);
-    expect(uploadInfoElement.exists()).toEqual(false);
 
     expect(fileNameElement.text()).toEqual(torrent.name);
     expect(fileSizeElement.text()).toEqual(prettier(torrent.length));
@@ -102,7 +101,6 @@ describe('<TorrentInfo />', () => {
   it('can show the DownloadInfo component when the status allows it', () => {
     const {downloadInfoElement, uploadInfoElement} = mockTorrentInfo({status: Status.Downloading});
     expect(downloadInfoElement.exists()).toEqual(true);
-    expect(uploadInfoElement.exists()).toEqual(false);
   });
 
   it("can show the UploadInfo component when the client is the torrent's author", () => {

--- a/packages/web3torrent/src/components/torrent-info/TorrentInfo.tsx
+++ b/packages/web3torrent/src/components/torrent-info/TorrentInfo.tsx
@@ -1,6 +1,6 @@
 import prettier from 'prettier-bytes';
 import React from 'react';
-import {DownloadingStatuses, Torrent, UploadingStatuses} from '../../types';
+import {DownloadingStatuses, Torrent} from '../../types';
 import {DownloadInfo} from './download-info/DownloadInfo';
 import {DownloadLink} from './download-link/DownloadLink';
 import {MagnetLinkButton} from './magnet-link-button/MagnetLinkButton';
@@ -37,21 +37,18 @@ const TorrentInfo: React.FC<TorrentInfoProps> = ({
           {torrent.magnetURI && <MagnetLinkButton />}
         </div>
       </section>
-      {DownloadingStatuses.includes(torrent.status) ? (
+      {DownloadingStatuses.includes(torrent.status) && !torrent.originalSeed && (
         <DownloadInfo
           torrent={torrent}
           channelCache={channelCache}
           mySigningAddress={mySigningAddress}
         />
-      ) : (
-        UploadingStatuses.includes(torrent.status) && (
-          <UploadInfo
-            torrent={torrent}
-            channelCache={channelCache}
-            mySigningAddress={mySigningAddress}
-          />
-        )
       )}
+      <UploadInfo
+        torrent={torrent}
+        channelCache={channelCache}
+        mySigningAddress={mySigningAddress}
+      />
       {!torrent.originalSeed && <DownloadLink torrent={torrent} />}
     </>
   );

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -9,7 +9,7 @@ import {WebTorrentContext} from '../../../clients/web3torrent-client';
 export type UploadInfoProps = {
   wires: PaidStreamingWire[];
   channels: Dictionary<ChannelState>;
-  peerType: 'seeder' | 'leecher';
+  pseType: 'seeder' | 'leecher';
 };
 
 class ChannelsList extends React.Component<UploadInfoProps> {
@@ -19,7 +19,7 @@ class ChannelsList extends React.Component<UploadInfoProps> {
     channelId: string,
     channels: Dictionary<ChannelState>,
     wires: PaidStreamingWire[],
-    peerType: 'seeder' | 'leecher'
+    pseType: 'seeder' | 'leecher'
   ) {
     let channelButton;
 
@@ -42,7 +42,8 @@ class ChannelsList extends React.Component<UploadInfoProps> {
     );
 
     const uploaded = wire ? wire.uploaded : 0;
-    const peerAccount = wire ? wire.paidStreamingExtension.peerAccount : 'unknown';
+    const peerAccount =
+      pseType === 'leecher' ? channels[channelId].beneficiary : channels[channelId].payer;
 
     return (
       <tr className="peerInfo" key={channelId}>
@@ -51,10 +52,9 @@ class ChannelsList extends React.Component<UploadInfoProps> {
         <td className="peer-id">{peerAccount}</td>
         <td className="uploaded">
           {uploaded && prettier(uploaded)}
-          &nbsp;
-          {peerType === 'seeder' ? `up` : `down`}
+          {pseType === 'seeder' ? ` up` : ` down`}
         </td>
-        {peerType === 'seeder' ? (
+        {pseType === 'seeder' ? (
           <td className="earned">{Number(channels[channelId].beneficiaryBalance)} wei</td>
         ) : (
           <td className="paid">-{Number(channels[channelId].beneficiaryBalance)} wei</td>
@@ -75,7 +75,7 @@ class ChannelsList extends React.Component<UploadInfoProps> {
                   id,
                   this.props.channels,
                   this.props.wires,
-                  this.props.peerType
+                  this.props.pseType
                 )
               )}
           </tbody>

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -45,7 +45,7 @@ class ChannelsList extends React.Component<UploadInfoProps> {
     const peerAccount = wire ? wire.paidStreamingExtension.peerAccount : 'unknown';
 
     return (
-      <tr className="peerInfo" key={peerAccount}>
+      <tr className="peerInfo" key={channelId}>
         <td>{channelButton}</td>
         <td className="channel-id">{channelId}</td>
         <td className="peer-id">{peerAccount}</td>

--- a/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.tsx
@@ -58,7 +58,7 @@ const DownloadInfo: React.FC<DownloadInfoProps> = ({
       <ChannelsList
         wires={torrent.wires}
         channels={_.pickBy(channelCache, ({channelId}) => myLeechingChannelIds.includes(channelId))}
-        peerType={'leecher'}
+        pseType={'leecher'}
       />
     </>
   );

--- a/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.tsx
+++ b/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.tsx
@@ -38,7 +38,7 @@ const UploadInfo: React.FC<UploadInfoProps> = ({
       <ChannelsList
         wires={torrent.wires}
         channels={_.pickBy(channelCache, ({channelId}) => mySeedingChannelIds.includes(channelId))}
-        peerType={'seeder'}
+        pseType={'seeder'}
       />
     </>
   );


### PR DESCRIPTION
Reflects fact that I can start uploading at any point after I start leeching, and in particular *before* I become a seeder. A seeder is someone who has the whole file.

With the existing condition in place, there's no evidence of the channels that I open to allow peers to download from me (unless I happen to be a seeder).

<img width="707" alt="Screenshot 2020-03-12 at 11 42 55" src="https://user-images.githubusercontent.com/1833419/76518662-7240c080-6457-11ea-8065-2df4242f8874.png">
