### PR TITLE
[web3t] Clarify logic around "spacer" state

### DIFF
--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -198,7 +198,7 @@ export class PaymentChannelClient {
     }
   }
   // beneficiary may use this method to accept payments
-  async acceptPayment(channelState: ChannelState) {
+  async acceptChannelUpdate(channelState: ChannelState) {
     const {
       channelId,
       beneficiary,

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -6,6 +6,8 @@ import {ChannelStatus} from '@statechannels/client-api-schema';
 import {SiteBudget} from '@statechannels/client-api-schema';
 
 const bigNumberify = utils.bigNumberify;
+const FINAL_SETUP_STATE = 3; // for a 2 party ForceMove channel
+
 export interface ChannelState {
   channelId: string;
   turnNum: string;
@@ -233,7 +235,7 @@ export class PaymentChannelClient {
 
   shouldSendSpacerState(channelState: ChannelState): boolean {
     const turnNum = Number(channelState.turnNum);
-    return turnNum === 3 ? true : false;
+    return turnNum === FINAL_SETUP_STATE ? true : false;
   }
 
   async pushMessage(message: Message<ChannelResult>) {

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -231,6 +231,11 @@ export class PaymentChannelClient {
     return false; // only beneficiary may receive payments
   }
 
+  shouldSendSpacerState(channelState: ChannelState): boolean {
+    const turnNum = Number(channelState.turnNum);
+    return turnNum === 3 ? true : false;
+  }
+
   async pushMessage(message: Message<ChannelResult>) {
     await this.channelClient.pushMessage(message);
     return convertToChannelState(message.data);

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -222,7 +222,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
         return;
       }
       log(`State received with turnNum ${channelState.turnNum}`);
-      if (Number(channelState.turnNum) === 3) {
+      if (this.paymentChannelClient.shouldSendSpacerState(channelState)) {
         // send "spacer" state
         await this.paymentChannelClient.acceptChannelUpdate(
           this.paymentChannelClient.channelCache[channelState.channelId]

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -26,13 +26,13 @@ export type TorrentCallback = (torrent: Torrent) => any;
 export * from './types';
 
 export const WEI_PER_BYTE = bigNumberify(1); // cost per credit / piece
-export const BUFFER_REFILL_RATE = bigNumberify(80000); // number of credits / pieces the leecher wishes to increase the buffer by
+export const BUFFER_REFILL_RATE = bigNumberify(2e4); // number of credits / pieces the leecher wishes to increase the buffer by
 // These variables control the amount of (micro)trust the leecher must invest in the seeder
 // As well as the overall performance hit of integrating payments into webtorrent.
 // A high BUFFER_REFILL_RATE increases the need for trust, but decreases the number of additional messages and therefore latency
 // It can also cause a payment to go above the leecher's balance / capabilities
 export const INITIAL_SEEDER_BALANCE = bigNumberify(0); // needs to be zero so that depositing works correctly (unidirectional payment channel)
-export const INITIAL_LEECHER_BALANCE = bigNumberify(2e9); // e.g. gwei = 1e9 = nano-ETH
+export const INITIAL_LEECHER_BALANCE = bigNumberify(BUFFER_REFILL_RATE.mul(100)); // e.g. gwei = 1e9 = nano-ETH
 
 // A Whimsical diagram explaining the functionality of Web3Torrent: https://whimsical.com/Sq6whAwa8aTjbwMRJc7vPU
 export default class WebTorrentPaidStreamingClient extends WebTorrent {
@@ -100,7 +100,6 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
 
   blockPeer(torrentInfoHash: string, wire: PaidStreamingWire, peerAccount: string) {
     this.peersList[torrentInfoHash][peerAccount].allowed = false;
-    wire.paidStreamingExtension.stop();
     this.emit(ClientEvents.PEER_STATUS_CHANGED, {
       torrentPeers: this.peersList[torrentInfoHash],
       torrentInfoHash,
@@ -180,6 +179,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
           response(false);
           log('> BLOCKED: ' + index, 'BUFFER: ' + knownPeerAccount.buffer);
           this.blockPeer(torrent.infoHash, wire, peerAccount); // As soon as buffer is empty, block
+          wire.paidStreamingExtension.stop(); // prompt peer for a payment
         } else {
           this.peersList[torrent.infoHash][peerAccount] = {
             id: peerAccount,
@@ -213,21 +213,32 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     // If a channel is proposed, join it
     this.paymentChannelClient.onChannelProposed(async (channelState: ChannelState) => {
       await this.paymentChannelClient.joinChannel(channelState.channelId);
+      log(`Joined channel ${channelState.channelId}`);
     });
 
     this.paymentChannelClient.onChannelUpdated(async (channelState: ChannelState) => {
+      if (channelState.channelId !== wire.paidStreamingExtension.pseChannelId) {
+        // filter to updates for the channel on this wire
+        return;
+      }
       log(`State received with turnNum ${channelState.turnNum}`);
+      if (Number(channelState.turnNum) === 3) {
+        // send "spacer" state
+        await this.paymentChannelClient.acceptChannelUpdate(
+          this.paymentChannelClient.channelCache[channelState.channelId]
+        );
+        wire.paidStreamingExtension.stop(); // prompt peer for a payment
+        return;
+      }
       if (
-        (channelState.channelId === wire.paidStreamingExtension.pseChannelId && // must narrow to *this* wire
-          this.paymentChannelClient.isPaymentToMe(channelState)) ||
-        Number(channelState.turnNum) === 3
+        this.paymentChannelClient.isPaymentToMe(channelState)
         // returns true for the second postFS if I am the beneficiary
         // (I need to countersign this state in order for the first payment to be sent)
       ) {
         log(
           `Accepting payment, refilling buffer and unblocking ${wire.paidStreamingExtension.peerAccount}`
         );
-        await this.paymentChannelClient.acceptPayment(
+        await this.paymentChannelClient.acceptChannelUpdate(
           this.paymentChannelClient.channelCache[channelState.channelId]
         );
         await this.refillBuffer(
@@ -237,24 +248,27 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
         );
         this.unblockPeer(torrent.infoHash, wire, wire.paidStreamingExtension.peerAccount);
         // TODO: only unblock if the buffer is large enough
+        return;
       }
     });
   }
 
-  protected async refillBuffer(infoHash: string, peerId: string, channelId: string) {
+  protected refillBuffer(infoHash: string, peerId: string, channelId: string) {
+    if (!this.peersList[infoHash][peerId]) {
+      log(`Received payment from ${peerId} in channel ${channelId} but peer not known!`);
+    }
     log(`querying channel client for updated balance`);
     const newSeederBalance = bigNumberify(
       this.paymentChannelClient.channelCache[channelId].beneficiaryBalance
     );
     // infer payment using update balance and previously stored balance
     const payment = bigNumberify(
-      this.peersList[infoHash][peerId]
-        ? newSeederBalance.sub(bigNumberify(this.peersList[infoHash][peerId].seederBalance))
-        : 0
+      newSeederBalance.sub(bigNumberify(this.peersList[infoHash][peerId].seederBalance))
     );
     // store new balance
+
     this.peersList[infoHash][peerId].seederBalance = newSeederBalance.toString();
-    // convert payment into number of pieces
+    // convert payment into buffer units (bytes)
     this.peersList[infoHash][peerId].buffer = bigNumberify(this.peersList[infoHash][peerId].buffer)
       .add(payment.div(WEI_PER_BYTE)) // This must remain an integer as long as our check above uses .isZero()
       // ethers BigNumbers are always integers
@@ -263,25 +277,6 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     log(
       `newSeederBalance: ${newSeederBalance} wei; payment: ${payment} wei;, buffer for peer: ${this.peersList[infoHash][peerId].buffer} bytes`
     );
-  }
-
-  protected async transferFunds(wire: PaidStreamingWire) {
-    const channelId = wire.paidStreamingExtension.peerChannelId;
-
-    if (
-      this.paymentChannelClient.channelCache[channelId] &&
-      this.paymentChannelClient.channelCache[channelId].status === 'running' &&
-      bigNumberify(this.paymentChannelClient.channelCache[channelId].turnNum).gt(3)
-    ) {
-      await this.paymentChannelClient.makePayment(
-        channelId,
-        WEI_PER_BYTE.mul(BUFFER_REFILL_RATE).toString()
-      );
-      const newSeederBalance = bigNumberify(
-        this.paymentChannelClient.channelCache[channelId].beneficiaryBalance
-      );
-      log(`payment made for channel ${channelId}, newSeederBalance: ${newSeederBalance}`);
-    }
   }
 
   protected setupTorrent(torrent: PaidStreamingTorrent) {
@@ -299,9 +294,17 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
       log(`< ${command} received from ${wire.peerExtendedHandshake.pseAccount}`, data);
       let message: Message<ChannelResult>;
       switch (command) {
-        case PaidStreamingExtensionNotices.STOP:
+        case PaidStreamingExtensionNotices.STOP: // synonymous with a prompt for a payment
           if (!torrent.done) {
-            await this.transferFunds(wire);
+            const channelId = wire.paidStreamingExtension.peerChannelId;
+            await this.paymentChannelClient.makePayment(
+              channelId,
+              WEI_PER_BYTE.mul(BUFFER_REFILL_RATE).toString()
+            );
+            const newSeederBalance = bigNumberify(
+              this.paymentChannelClient.channelCache[channelId].beneficiaryBalance
+            );
+            log(`payment made for channel ${channelId}, newSeederBalance: ${newSeederBalance}`);
           }
           break;
         case PaidStreamingExtensionNotices.START:

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -230,11 +230,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
         wire.paidStreamingExtension.stop(); // prompt peer for a payment
         return;
       }
-      if (
-        this.paymentChannelClient.isPaymentToMe(channelState)
-        // returns true for the second postFS if I am the beneficiary
-        // (I need to countersign this state in order for the first payment to be sent)
-      ) {
+      if (this.paymentChannelClient.isPaymentToMe(channelState)) {
         log(
           `Accepting payment, refilling buffer and unblocking ${wire.paidStreamingExtension.peerAccount}`
         );
@@ -255,7 +251,9 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
 
   protected refillBuffer(infoHash: string, peerId: string, channelId: string) {
     if (!this.peersList[infoHash][peerId]) {
-      log(`Received payment from ${peerId} in channel ${channelId} but peer not known!`);
+      throw new Error(
+        `Received payment from ${peerId} in channel ${channelId} but peer not known!`
+      );
     }
     log(`querying channel client for updated balance`);
     const newSeederBalance = bigNumberify(


### PR DESCRIPTION
The "spacer state" is the state channel update with `turnNum = 4`. 

It's awkward to handle, but an important inevitable consequence of the following choices: 

- unidirectional ForceMove payment channel with beneficiary in slot `0`
- vanilla ForceMove turn-taking

At the state channel layer, we should have the following sequence, with uploader as `0` and downloader as `1`:
```
0: createChannel, turnNum = 0
1: joinChannel() turnNum = 1
0: turnNum = 2
1: turnNum = 3 <<-- fake provider updates straight to here on joinChannel()
0: acceptChannelUpdate(), turnNum = 4 <<--- "spacer state"
1: makePayment(), turnNum = 5
0: acceptChannelUpdate(), turnNum = 6
...
1: makePayment(), turnNum = 2n+3
0: acceptChannelUpdate(), turnNum = 2n+4
```

According to this PR, in the web3torrent code, we do not prompt the downloader to make a payment (i.e. send him a STOP message) until we have sent the spacer state. That way, no special logic is required on the downloader's client: they can always respond to this prompt with a payment. 

(Previously we had a bit of a hacky solution where we would treat `turnNum=3` as a payment -- which it isn't -- and accepting this payment triggered the spacer state to be sent. We were also skipping payments on the downloader's client until we received the spacer state).

Closes #1178 .