### PR TITLE
simple-hub: add hub participantId

### DIFF
--- a/packages/simple-hub/readme.md
+++ b/packages/simple-hub/readme.md
@@ -20,11 +20,11 @@ $ yarn hub:watch (will rebuild app on file change)
 
 ### Establishing a virtual channel between clients through the hub
 
-**NOTE**: Running this package makes a connection to a shared external Firebase database. So, to avoid colliding with other developers also running this package, set the environment variable `HUB_PARTICIPANT_PK` to one that is likely not being used by any other developer for local development purposes.
+**NOTE**: Running this package makes a connection to a shared external Firebase database. So, to avoid colliding with other developers also running this package, set the environment variable `HUB_PARTICIPANT_ID` to one that is likely not being used by any other developer for local development purposes.
 
 To connect to the `hub` from the browser `wallet`, the `hub` and the browser `wallet` need to:
 
-- Share the state-channel address of the hub. A good way to do so is to create a `.env.development.local` in the monorepo root with `HUB_PARTICIPANT_ADDRESS` and `HUB_PARTICIPANT_PK` defined.
+- Share the state-channel address of the hub. A good way to do so is to create a `.env.development.local` in the monorepo root with `HUB_CHANNEL_PK`defined.
 - Point to the same local Ganache server. Configure your `.env` files accordingly. This should work without any modifications.
 - Point to the same shared local Ganache server. This should work without any modifications. To see which ports are being used by the `hub` and `wallet`, and to verify they are the same, you can reference the `GANACHE_PORT` environment variable which by default is set in `.env` of each package.
 - Point to the same contract addresses on Ganache. This will be the case if the hub and the client wallet point to the same Ganache server.

--- a/packages/simple-hub/src/constants.ts
+++ b/packages/simple-hub/src/constants.ts
@@ -2,12 +2,14 @@ import {ethers} from 'ethers';
 
 export const cFirebasePrefix = process.env.FIREBASE_PREFIX || 'default-prefix';
 
-export const cHubParticipantPK =
-  process.env.HUB_PARTICIPANT_PK ||
+export const cHubChannelPK =
+  process.env.HUB_CHANNEL_PK ||
   '0x1b427b7ab88e2e10674b5aa92bb63c0ca26aa0b5a858e1d17295db6ad91c049b';
-export const cHubParticipantAddress = new ethers.Wallet(cHubParticipantPK).address;
+export const cHubChannelSigningAddress = new ethers.Wallet(cHubChannelPK).address;
 
 // This account is provided eth in @statechannels/devtools/utils/startGanache.js
 export const cHubChainPK =
   process.env.HUB_CHAIN_PK || '0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8';
 export const cHubChainAddress = new ethers.Wallet(cHubChainPK).address;
+
+export const cHubParticipantId = process.env.HUB_PARTICIPANT_ID || 'firebase.simple-hub';

--- a/packages/simple-hub/src/message/firebase-relay.ts
+++ b/packages/simple-hub/src/message/firebase-relay.ts
@@ -1,6 +1,6 @@
 import * as firebase from 'firebase';
 
-import {cHubParticipantAddress, cFirebasePrefix} from '../constants';
+import {cFirebasePrefix, cHubParticipantId} from '../constants';
 import {logger} from '../logger';
 import {Message} from '@statechannels/wire-format';
 import {fromEvent, Observable} from 'rxjs';
@@ -36,7 +36,7 @@ function getMessagesRef() {
 
 export function fbListen(responseForMessage: (message: Message) => Message[]) {
   log.info('firebase-relay: listen');
-  const hubRef = getMessagesRef().child(cHubParticipantAddress);
+  const hubRef = getMessagesRef().child(cHubParticipantId);
 
   const childAddedObservable: Observable<FirebaseEvent> = fromEvent(hubRef, 'child_added');
 

--- a/packages/simple-hub/src/wallet/index.ts
+++ b/packages/simple-hub/src/wallet/index.ts
@@ -1,6 +1,6 @@
 import {Message as WireMessage} from '@statechannels/wire-format';
 import * as R from 'ramda';
-import {cHubParticipantPK, cHubParticipantAddress} from '../constants';
+import {cHubChannelPK, cHubChannelSigningAddress} from '../constants';
 import {
   deserializeMessage,
   serializeMessage,
@@ -11,7 +11,7 @@ import {
 } from './xstate-wallet-internals';
 
 function containsHub(participant: Participant): boolean {
-  return participant.signingAddress === cHubParticipantAddress;
+  return participant.signingAddress === cHubChannelSigningAddress;
 }
 const notContainsHub = R.compose(R.not, containsHub);
 
@@ -28,7 +28,7 @@ export function respondToMessage(wireMessage: WireMessage): WireMessage[] {
     state => state.participants.filter(containsHub).length
   );
   const signedStates = statesWithHub.map(state => {
-    const ourSignature = signState(state, cHubParticipantPK);
+    const ourSignature = signState(state, cHubChannelPK);
     const signatures = R.append(ourSignature, state.signatures);
     return {...state, signatures};
   });

--- a/packages/simple-hub/src/wallet/test-helpers/index.ts
+++ b/packages/simple-hub/src/wallet/test-helpers/index.ts
@@ -9,7 +9,7 @@ import {
 } from '../xstate-wallet-internals';
 import {bigNumberify} from 'ethers/utils';
 import {ethers} from 'ethers';
-import {cHubParticipantPK, cHubParticipantAddress} from '../../constants';
+import {cHubChannelPK, cHubChannelSigningAddress, cHubParticipantId} from '../../constants';
 import {AddressZero} from 'ethers/constants';
 
 import * as R from 'ramda';
@@ -29,9 +29,9 @@ const first: Participant = {
 };
 
 const hub: Participant = {
-  signingAddress: cHubParticipantAddress,
+  signingAddress: cHubChannelSigningAddress,
   destination: '0x0000000000000000000000000000000000000000000000000000000000000002',
-  participantId: 'hub'
+  participantId: cHubParticipantId
 };
 
 const second: Participant = {
@@ -90,10 +90,7 @@ export const ledgerStateIncoming: SignedState = {
 
 export const ledgerStateResponse: SignedState = {
   ...ledgerState,
-  signatures: [
-    signState(ledgerState, wallet1.privateKey),
-    signState(ledgerState, cHubParticipantPK)
-  ]
+  signatures: [signState(ledgerState, wallet1.privateKey), signState(ledgerState, cHubChannelPK)]
 };
 
 const ledgerState3 = firstState(outcome3, channel3);
@@ -104,10 +101,7 @@ export const ledgerStateIncoming3: SignedState = {
 
 export const ledgerStateResponse3: SignedState = {
   ...ledgerState3,
-  signatures: [
-    signState(ledgerState3, wallet1.privateKey),
-    signState(ledgerState3, cHubParticipantPK)
-  ]
+  signatures: [signState(ledgerState3, wallet1.privateKey), signState(ledgerState3, cHubChannelPK)]
 };
 
 const ledgerState3_2: State = {...ledgerState3, turnNum: bigNumberify(1)};
@@ -120,6 +114,6 @@ export const ledgerStateResponse3_2: SignedState = {
   ...ledgerState3_2,
   signatures: [
     signState(ledgerState3_2, wallet1.privateKey),
-    signState(ledgerState3_2, cHubParticipantPK)
+    signState(ledgerState3_2, cHubChannelPK)
   ]
 };


### PR DESCRIPTION
And rename constants/environment variables.
- `HUB_CHANNEL_PK`/`cHubChannelPK`: state channel private key for supporting states.
- `cHubChannelSigningAddress`: state channel public key. Never hardcoded.
- `HUB_CHAIN_PK`/`cHubChainPK`: ethereum private key used for chain transaction signing.
- `cHubChainAddress`: ethereum address. Never hardcoded.
- `HUB_PARTICIPANT_ID`/`cHubParticipantId`: state channel messaging address.