### PR TITLE
[web3t] Fix downloaded = 0 in the UI

### DIFF
--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -41,9 +41,16 @@ class ChannelsList extends React.Component<UploadInfoProps> {
         wire.paidStreamingExtension.pseChannelId === channelId
     );
 
-    const transferred = pseType === 'seeder' ? wire.uploaded : wire.downloaded;
-    const peerAccount =
-      pseType === 'leecher' ? channels[channelId].beneficiary : channels[channelId].payer;
+    let transferred: string;
+    let peerAccount: string;
+    if (wire) {
+      transferred = pseType === 'seeder' ? prettier(wire.uploaded) : prettier(wire.downloaded);
+      peerAccount =
+        pseType === 'leecher' ? channels[channelId].beneficiary : channels[channelId].payer;
+    } else {
+      transferred = 'NOWIRE';
+      peerAccount = 'NOWIRE';
+    }
 
     return (
       <tr className="peerInfo" key={channelId}>
@@ -51,7 +58,7 @@ class ChannelsList extends React.Component<UploadInfoProps> {
         <td className="channel-id">{channelId}</td>
         <td className="peer-id">{peerAccount}</td>
         <td className="uploaded">
-          {prettier(transferred)}
+          {transferred}
           {pseType === 'seeder' ? ` up` : ` down`}
         </td>
         {pseType === 'seeder' ? (

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -41,7 +41,7 @@ class ChannelsList extends React.Component<UploadInfoProps> {
         wire.paidStreamingExtension.pseChannelId === channelId
     );
 
-    const uploaded = wire ? wire.uploaded : 0;
+    const transferred = pseType === 'seeder' ? wire.uploaded : wire.downloaded;
     const peerAccount =
       pseType === 'leecher' ? channels[channelId].beneficiary : channels[channelId].payer;
 
@@ -51,7 +51,7 @@ class ChannelsList extends React.Component<UploadInfoProps> {
         <td className="channel-id">{channelId}</td>
         <td className="peer-id">{peerAccount}</td>
         <td className="uploaded">
-          {uploaded && prettier(uploaded)}
+          {prettier(transferred)}
           {pseType === 'seeder' ? ` up` : ` down`}
         </td>
         {pseType === 'seeder' ? (

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -55,6 +55,7 @@ export type PaidStreamingWire = Omit<Wire, 'requests'> &
     extended: (name: 'paidStreamingExtension', data: Buffer) => void;
 
     uploaded: number;
+    downloaded: number;
 
     // TODO: Remove after merging https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38469.
     setTimeout(ms: number, unref?: boolean): void;


### PR DESCRIPTION
Currently the `DownloadInfo` component does not display the number of bytes downloaded. 

This was because 

1. TypesScript was telling me that `downloaded` was not a property on my `wire` (when actually it is). 
2. I had thought that perhaps `uploaded` would be the same as `downloaded` on a wire. But it's a duplex connection so I guess my `uploaded` is your `downloaded`. Fine. 



