### PR TITLE
[web3t] Detect public wifi / firewall / lack of internet

### DIFF
--- a/packages/web3torrent/src/App.tsx
+++ b/packages/web3torrent/src/App.tsx
@@ -1,4 +1,5 @@
 import ConnectionBanner from '@rimble/connection-banner';
+import {Flash} from 'rimble-ui';
 import {createBrowserHistory} from 'history';
 import React from 'react';
 import {Route, Router, Switch} from 'react-router-dom';
@@ -16,7 +17,8 @@ class App extends React.Component {
   state = {
     currentNetwork:
       'ethereum' in window && window.ethereum.chainId && parseInt(window.ethereum.chainId, 16),
-    requiredNetwork: Number(process.env.REACT_APP_CHAIN_NETWORK_ID)
+    requiredNetwork: Number(process.env.REACT_APP_CHAIN_NETWORK_ID),
+    canTorrent: true
   };
 
   static contextType = WebTorrentContext;
@@ -26,14 +28,21 @@ class App extends React.Component {
       window.ethereum.on('networkChanged', chainId => {
         this.setState({...this.state, currentNetwork: parseInt(chainId, 16)});
       });
-    await this.context.enable(); // get sc signing address and use it
+    await this.context.enable();
+    this.setState({...this.state, canTorrent: await this.context.testTorrentingCapability(3000)});
   }
 
   render() {
-    const {currentNetwork, requiredNetwork} = this.state;
+    const {currentNetwork, requiredNetwork, canTorrent} = this.state;
     return (
       <Router history={history}>
         <main>
+          {!canTorrent && (
+            <Flash my={3} variant="warning">
+              Looks like you do not have an internet connection or are behind a firewall.
+              Web3Torrent may not work on some public wifi networks.
+            </Flash>
+          )}
           <ConnectionBanner
             currentNetwork={currentNetwork}
             requiredNetwork={requiredNetwork}

--- a/packages/web3torrent/src/App.tsx
+++ b/packages/web3torrent/src/App.tsx
@@ -38,7 +38,7 @@ class App extends React.Component {
       <Router history={history}>
         <main>
           {!canTorrent && (
-            <Flash my={3} variant="warning">
+            <Flash variant="danger">
               Looks like you do not have an internet connection or are behind a firewall.
               Web3Torrent may not work on some public wifi networks.
             </Flash>

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -59,8 +59,6 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     log('got ethereum address');
     log('ACCOUNT ID: ', this.pseAccount);
     log('THIS address: ', this.outcomeAddress);
-    const canTorrent = await this.testTorrentingCapability(3000);
-    console.log(canTorrent ? 'Can Torrent!' : 'Cannot torrent');
   }
 
   async testTorrentingCapability(timeOut: number) {

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -62,6 +62,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
   }
 
   async testTorrentingCapability(timeOut: number) {
+    log('Testing torrenting capability...');
     const gotAWire = new Promise(resolve => {
       super.add(mockTorrents[0].magnetURI, (torrent: Torrent) => {
         torrent.once('wire', wire => {

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -17,6 +17,7 @@ import {
 import {utils} from 'ethers';
 import {ChannelState, PaymentChannelClient} from '../clients/payment-channel-client';
 import {Message, ChannelResult} from '@statechannels/channel-client';
+import {mockTorrents} from '../constants';
 
 const bigNumberify = utils.bigNumberify;
 const log = debug('web3torrent:library');
@@ -58,6 +59,23 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     log('got ethereum address');
     log('ACCOUNT ID: ', this.pseAccount);
     log('THIS address: ', this.outcomeAddress);
+    const canTorrent = await this.testTorrentingCapability(3000);
+    console.log(canTorrent ? 'Can Torrent!' : 'Cannot torrent');
+  }
+
+  async testTorrentingCapability(timeOut: number) {
+    const gotAWire = new Promise(resolve => {
+      super.add(mockTorrents[0].magnetURI, (torrent: Torrent) => {
+        torrent.once('wire', wire => {
+          this.remove(torrent.infoHash);
+          resolve(true);
+        });
+      });
+    });
+    const timer = new Promise(function(resolve, reject) {
+      setTimeout(resolve, timeOut);
+    });
+    return Promise.race([gotAWire, timer]);
   }
 
   seed(


### PR DESCRIPTION
The simple idea is to try and download the example torrent used on the webtorrent.io homepage when we enable the `WebTorrentPaidStreamingClient`. As soon as we get a WIRE event, cancel and raise a success flag. If this doesn't resolve in 3 seconds, raise a failure flag. 

We can hook this into another `ConnectionBanner` type component that informs the user: "Looks like you are behind a firewall or do not have an internet connection".

I tested this with my home WiFI on/off. 

TODO 
- test on public wifi / with typical firewall or blocked ports
- is a WIRE event enough of a signal that things should work?

Closes #1129 