### PR TITLE
[monorepo] Include build-storybook in build:ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ junit.xml
 **/gas.json
 **/gas.md
 **/*.gas.md
+**/storybook
 
 
 ganache-deployments.json

--- a/packages/rps/package.json
+++ b/packages/rps/package.json
@@ -184,8 +184,9 @@
   },
   "scripts": {
     "build": "run-s build:typescript build:webpack",
-    "build:ci": "run-s build:typescript contracts:compile",
+    "build:ci": "run-s build:typescript contracts:compile build:storybook",
     "build:netlify": "NODE_ENV=production yarn build:webpack",
+    "build:storybook": "build-storybook -c .storybook -o storybook",
     "build:typescript": "npx tsc -b",
     "build:webpack": "CI=false node scripts/build.js",
     "contracts:compile": "node ./bin/compile.js",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -168,8 +168,9 @@
   },
   "scripts": {
     "build": "run-s build:typescript build:webpack",
-    "build:ci": "yarn build:typescript",
+    "build:ci": "yarn build:typescript build:storybook",
     "build:netlify": "NODE_ENV=production yarn build:webpack",
+    "build:storybook": "build-storybook -c .storybook -o storybook",
     "build:typescript": "npx tsc -b",
     "build:webpack": "CI=false node scripts/build.js",
     "lint:check": "eslint \"src/**/*.{js,ts,tsx}\" --cache",

--- a/packages/web3torrent/package.json
+++ b/packages/web3torrent/package.json
@@ -116,8 +116,9 @@
   },
   "scripts": {
     "build": "react-scripts build",
-    "build:ci": "run-s contracts:compile build",
+    "build:ci": "run-s contracts:compile build build:storybook",
     "build:typescript": "tsc -b .",
+    "build:storybook": "build-storybook -c .storybook -s ./public -o storybook",
     "contracts:compile": "node ./bin/compile.js",
     "eject": "react-scripts eject",
     "eslint:check": "eslint \"**/*.{js,ts,tsx}\" --cache --max-warnings=0",

--- a/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.stories.tsx
+++ b/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.stories.tsx
@@ -1,5 +1,5 @@
 import {withActions} from '@storybook/addon-actions';
-import {number, withKnobs} from '@storybook/addon-knobs';
+import {withKnobs} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import React from 'react';
 import '../../../App.scss';

--- a/packages/xstate-wallet/package.json
+++ b/packages/xstate-wallet/package.json
@@ -62,8 +62,9 @@
   "private": true,
   "scripts": {
     "build": "npx webpack --config ./webpack-build.config.js",
-    "build:ci": "yarn build",
+    "build:ci": "run-s build build:storybook",
     "build:netlify": "NODE_ENV=production yarn build",
+    "build:storybook": "build-storybook -c .storybook -o storybook",
     "generateConfigs": "yarn run ts-node bin/generateConfigs.ts",
     "lint:check": "eslint . --ext .ts --cache",
     "lint:write": "eslint . --ext .ts --fix",


### PR DESCRIPTION
Motivation: save developer time by preventing us from breaking storybook

TODO Fix all of the broken storybooks

I ran into this issue in `web3torrent`:
https://github.com/webpack-contrib/mini-css-extract-plugin/issues/73

(start-storybook works, build-storybook does not)