### PR TITLE
[web3t] Introduce prettyPrintWei() function

### DIFF
--- a/packages/web3torrent/src/components/share-list/ShareList.test.tsx
+++ b/packages/web3torrent/src/components/share-list/ShareList.test.tsx
@@ -6,7 +6,7 @@ import {MemoryRouter as Router} from 'react-router-dom';
 import {mockTorrents} from '../../constants';
 import {RoutePath} from '../../routes';
 import {ShareList, ShareListProps} from './ShareList';
-import {calculateWei} from '../../utils/calculateWei';
+import {calculateWei, prettyPrintWei} from '../../utils/calculateWei';
 import prettier from 'prettier-bytes';
 
 function setup(withNoTorrents = false) {
@@ -47,7 +47,9 @@ describe('<ShareList />', () => {
     expect(firstFileData.childAt(1).text()).toBe(prettier(props.torrents[0].length));
     expect(firstFileData.childAt(2).text()).toBe(props.torrents[0].numPeers + 'S');
     expect(firstFileData.childAt(3).text()).toBe(props.torrents[0].numPeers + 'P');
-    expect(firstFileData.childAt(4).text()).toBe(calculateWei(props.torrents[0].length));
+    expect(firstFileData.childAt(4).text()).toBe(
+      prettyPrintWei(calculateWei(props.torrents[0].length))
+    );
     expect(firstFileData.childAt(5).find('button')).not.toBeNull();
   });
 

--- a/packages/web3torrent/src/components/share-list/share-file/ShareFile.tsx
+++ b/packages/web3torrent/src/components/share-list/share-file/ShareFile.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {Torrent} from '../../../types';
 import {FormButton} from '../../form';
 import './ShareFile.scss';
-import {calculateWei} from '../../../utils/calculateWei';
+import {prettyPrintWei, calculateWei} from '../../../utils/calculateWei';
 import prettier from 'prettier-bytes';
 
 export type ShareFileProps = {file: Partial<Torrent>; goTo: (name: string) => void};
@@ -14,7 +14,7 @@ const ShareFile: React.FC<ShareFileProps> = ({file, goTo}: ShareFileProps) => {
       <td className="other-cell">{prettier(file.length)}</td>
       <td className="other-cell">{file.numPeers}S</td>
       <td className="other-cell">{file.numPeers}P</td>
-      <td className="other-cell">{calculateWei(file.length)}</td>
+      <td className="other-cell">{prettyPrintWei(calculateWei(file.length))}</td>
       <td className="button-cell">
         <FormButton name="download" onClick={() => goTo(file.magnetURI || file.name || '')}>
           Download

--- a/packages/web3torrent/src/components/torrent-info/TorrentInfo.tsx
+++ b/packages/web3torrent/src/components/torrent-info/TorrentInfo.tsx
@@ -6,7 +6,7 @@ import {DownloadLink} from './download-link/DownloadLink';
 import {MagnetLinkButton} from './magnet-link-button/MagnetLinkButton';
 import './TorrentInfo.scss';
 import {UploadInfo} from './upload-info/UploadInfo';
-import {calculateWei} from '../../utils/calculateWei';
+import {calculateWei, prettyPrintWei} from '../../utils/calculateWei';
 import {ChannelState} from '../../clients/payment-channel-client';
 
 export type TorrentInfoProps = {
@@ -32,7 +32,7 @@ const TorrentInfo: React.FC<TorrentInfoProps> = ({
           </span>
           {torrent.status && <span className="fileStatus">{torrent.status}</span>}
           <span className="fileCost">
-            Cost {torrent.length ? calculateWei(torrent.length) : 'unknown'}
+            Cost {torrent.length ? prettyPrintWei(calculateWei(torrent.length)) : 'unknown'}
           </span>
           {torrent.magnetURI && <MagnetLinkButton />}
         </div>

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -5,6 +5,8 @@ import {ChannelState} from '../../../clients/payment-channel-client';
 import {PaidStreamingWire} from '../../../library/types';
 import './ChannelsList.scss';
 import {WebTorrentContext} from '../../../clients/web3torrent-client';
+import {prettyPrintWei} from '../../../utils/calculateWei';
+import {utils} from 'ethers';
 
 export type UploadInfoProps = {
   wires: PaidStreamingWire[];
@@ -62,9 +64,13 @@ class ChannelsList extends React.Component<UploadInfoProps> {
           {participantType === 'beneficiary' ? ` up` : ` down`}
         </td>
         {participantType === 'beneficiary' ? (
-          <td className="earned">{Number(channels[channelId].beneficiaryBalance)} wei</td>
+          <td className="earned">
+            {prettyPrintWei(utils.bigNumberify(channels[channelId].beneficiaryBalance))}
+          </td>
         ) : (
-          <td className="paid">-{Number(channels[channelId].beneficiaryBalance)} wei</td>
+          <td className="paid">
+            -{prettyPrintWei(utils.bigNumberify(channels[channelId].beneficiaryBalance))}
+          </td>
         )}
       </tr>
     );

--- a/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.tsx
@@ -8,6 +8,7 @@ import {ProgressBar} from './progress-bar/ProgressBar';
 import {ChannelState} from '../../../clients/payment-channel-client';
 import {utils} from 'ethers';
 import {ChannelsList} from '../channels-list/ChannelsList';
+import {prettyPrintWei} from '../../../utils/calculateWei';
 
 const bigNumberify = utils.bigNumberify;
 
@@ -27,8 +28,7 @@ const DownloadInfo: React.FC<DownloadInfoProps> = ({
   );
   const totalSpent = myPayingChannelIds
     .map(id => channelCache[id].beneficiaryBalance)
-    .reduce((a, b) => bigNumberify(a).add(bigNumberify(b)), bigNumberify(0))
-    .toNumber();
+    .reduce((a, b) => bigNumberify(a).add(bigNumberify(b)), bigNumberify(0));
   return (
     <>
       <section className="downloadingInfo">
@@ -45,7 +45,7 @@ const DownloadInfo: React.FC<DownloadInfoProps> = ({
           false
         )}
         <p>
-          Total Spent: <span className="total-spent">{totalSpent} wei</span>
+          Total Spent: <span className="total-spent">{prettyPrintWei(totalSpent)}</span>
         </p>
         <p>
           {torrent.parsedTimeRemaining}.{' '}

--- a/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.test.tsx
+++ b/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.test.tsx
@@ -6,7 +6,7 @@ import {TorrentPeers} from '../../../library/types';
 import {Torrent} from '../../../types';
 import {createMockTorrent, createMockTorrentPeers, testSelector} from '../../../utils/test-utils';
 import {UploadInfo, UploadInfoProps} from './UploadInfo';
-import {calculateWei} from '../../../utils/calculateWei';
+import {calculateWei, prettyPrintWei} from '../../../utils/calculateWei';
 
 Enzyme.configure({adapter: new Adapter()});
 
@@ -102,7 +102,7 @@ describe.skip('<UploadInfo />', () => {
 
       expect(leecherIdElement.text()).toEqual(`#${peerId}...`);
       expect(leecherDownloadedElement.text()).toEqual(prettier(uploaded));
-      expect(leecherPaid.text()).toEqual(`$${calculateWei(uploaded)}`);
+      expect(leecherPaid.text()).toEqual(`$${prettyPrintWei(calculateWei(uploaded))}`);
     }
   );
 });

--- a/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.tsx
+++ b/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.tsx
@@ -5,6 +5,7 @@ import './UploadInfo.scss';
 import {ChannelState} from '../../../clients/payment-channel-client';
 import {utils} from 'ethers';
 import {ChannelsList} from '../channels-list/ChannelsList';
+import {prettyPrintWei} from '../../../utils/calculateWei';
 
 const bigNumberify = utils.bigNumberify;
 
@@ -24,13 +25,12 @@ const UploadInfo: React.FC<UploadInfoProps> = ({
   );
   const totalReceived = myReceivingChannelIds
     .map(id => channelCache[id].beneficiaryBalance)
-    .reduce((a, b) => bigNumberify(a).add(bigNumberify(b)), bigNumberify(0))
-    .toNumber();
+    .reduce((a, b) => bigNumberify(a).add(bigNumberify(b)), bigNumberify(0));
   return (
     <>
       <section className="uploadingInfo">
         <p>
-          Total Received: <strong>{totalReceived}</strong> wei
+          Total Received: <strong>{prettyPrintWei(totalReceived)}</strong>
           <br />
           <strong data-test-selector="numPeers">{torrent.numPeers}</strong> Peers connected
         </p>

--- a/packages/web3torrent/src/utils/calculateWei.ts
+++ b/packages/web3torrent/src/utils/calculateWei.ts
@@ -1,10 +1,31 @@
 import {WEI_PER_BYTE} from '../library/web3torrent-lib';
+import {utils} from 'ethers';
 
 export const calculateWei = (fileSize: number | string) => {
-  if (isNaN(Number(fileSize))) return 'unknown';
-  return (
-    WEI_PER_BYTE.mul(fileSize)
-      .toNumber()
-      .toString() + ' wei'
-  );
+  if (!isNaN(Number(fileSize))) {
+    return WEI_PER_BYTE.mul(fileSize);
+  } else return utils.bigNumberify(NaN);
+};
+
+export const prettyPrintWei = (wei: utils.BigNumber): string => {
+  const names = ['kwei', 'Mwei', 'Gwei', 'szabo', 'finney', 'ether'];
+  const decimals = [3, 6, 9, 12, 15, 18];
+  if (!wei) {
+    return 'unknown';
+  } else {
+    let formattedString = utils.formatUnits(wei, 'wei') + ' ' + 'wei';
+    decimals.forEach((decimal, index, array) => {
+      if (wei.gte(utils.bigNumberify(10).pow(decimal))) {
+        formattedString =
+          wei
+            .div(utils.bigNumberify(10).pow(decimal))
+            .toNumber()
+            .toFixed(1)
+            .toString() +
+          ' ' +
+          names[index];
+      }
+    });
+    return formattedString;
+  }
 };

--- a/packages/web3torrent/src/utils/calculateWei.ts
+++ b/packages/web3torrent/src/utils/calculateWei.ts
@@ -8,20 +8,21 @@ export const calculateWei = (fileSize: number | string) => {
 };
 
 export const prettyPrintWei = (wei: utils.BigNumber): string => {
-  const names = ['kwei', 'Mwei', 'Gwei', 'szabo', 'finney', 'ether'];
-  const decimals = [3, 6, 9, 12, 15, 18];
+  const names = ['wei', 'kwei', 'Mwei', 'Gwei', 'szabo', 'finney', 'ether'];
+  const decimals = [0, 3, 6, 9, 12, 15, 18];
   if (!wei) {
     return 'unknown';
   } else {
-    let formattedString = utils.formatUnits(wei, 'wei') + ' ' + 'wei';
+    let formattedString;
     decimals.forEach((decimal, index, array) => {
       if (wei.gte(utils.bigNumberify(10).pow(decimal))) {
         formattedString =
+          wei.div(utils.bigNumberify(10).pow(decimal)).toNumber() +
+          '.' +
           wei
-            .div(utils.bigNumberify(10).pow(decimal))
-            .toNumber()
-            .toFixed(1)
-            .toString() +
+            .mod(utils.bigNumberify(10).pow(decimal))
+            .div(utils.bigNumberify(10).pow(decimal - 1)) // TODO: this doesn't do rounding properly
+            .toNumber() +
           ' ' +
           names[index];
       }

--- a/packages/web3torrent/src/utils/prettyPrintWei.test.ts
+++ b/packages/web3torrent/src/utils/prettyPrintWei.test.ts
@@ -1,16 +1,18 @@
 import {bigNumberify} from 'ethers/utils';
 import {prettyPrintWei} from './calculateWei';
 
+// Note this test is aware of the incorrect rounding: 1599 -> 1.5kwei
 describe('Pretty printing wei', () => {
-  it('can pretty print a kwei', () => {
-    expect(prettyPrintWei(bigNumberify(1e3))).toEqual('1.0 kwei');
-  });
-
-  it('can pretty print 10 kwei', () => {
-    expect(prettyPrintWei(bigNumberify(1e4))).toEqual('10.0 kwei');
-  });
-
-  it('can pretty print 18 kwei', () => {
-    expect(prettyPrintWei(bigNumberify(18e3))).toEqual('18.0 kwei');
+  it.each`
+    input         | output
+    ${18}         | ${'18.0 wei'}
+    ${1001}       | ${'1.0 kwei'}
+    ${1599}       | ${'1.5 kwei'}
+    ${1234567}    | ${'1.2 Mwei'}
+    ${12345678}   | ${'12.3 Mwei'}
+    ${123456789}  | ${'123.4 Mwei'}
+    ${1234567890} | ${'1.2 Gwei'}
+  `('prettyPrintWei(bigNumberify($input)) = $output', ({input, output}) => {
+    expect(prettyPrintWei(bigNumberify(input))).toEqual(output);
   });
 });

--- a/packages/web3torrent/src/utils/prettyPrintWei.test.ts
+++ b/packages/web3torrent/src/utils/prettyPrintWei.test.ts
@@ -1,0 +1,16 @@
+import {bigNumberify} from 'ethers/utils';
+import {prettyPrintWei} from './calculateWei';
+
+describe('Pretty printing wei', () => {
+  it('can pretty print a kwei', () => {
+    expect(prettyPrintWei(bigNumberify(1e3))).toEqual('1.0 kwei');
+  });
+
+  it('can pretty print 10 kwei', () => {
+    expect(prettyPrintWei(bigNumberify(1e4))).toEqual('10.0 kwei');
+  });
+
+  it('can pretty print 18 kwei', () => {
+    expect(prettyPrintWei(bigNumberify(18e3))).toEqual('18.0 kwei');
+  });
+});


### PR DESCRIPTION
This is an experiment and I'm not 100% sure if we want to do it:
<img width="833" alt="Screenshot 2020-03-13 at 15 21 56" src="https://user-images.githubusercontent.com/1833419/76634886-772c6f80-653e-11ea-91c9-3deb206052d1.png">


Downsides: 

- increased "change blindness" (not so easy to see you are actually making payments when the numbers are big)
- rounding is not done correctly (not a big deal and definitely fixable with a bit more work). 