### PR TITLE
[web3t] Fix messaging bug

### DIFF
--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -179,28 +179,35 @@ export class PaymentChannelClient {
 
   // payer may use this method to make payments (if they have sufficient funds)
   async makePayment(channelId: string, amount: string) {
-    const {
-      beneficiary,
-      payer,
-      beneficiaryBalance,
-      payerBalance,
-      beneficiaryOutcomeAddress,
-      payerOutcomeAddress
-    } = this.channelCache[channelId];
-    if (bigNumberify(payerBalance).gte(amount)) {
-      await this.updateChannel(
-        channelId,
+    if (
+      this.channelCache[channelId] &&
+      this.channelCache[channelId].payer === this.mySigningAddress
+    ) {
+      const {
         beneficiary,
         payer,
-        bigNumberify(beneficiaryBalance)
-          .add(amount)
-          .toString(),
-        bigNumberify(payerBalance)
-          .sub(amount)
-          .toString(),
+        beneficiaryBalance,
+        payerBalance,
         beneficiaryOutcomeAddress,
         payerOutcomeAddress
-      );
+      } = this.channelCache[channelId];
+      if (bigNumberify(payerBalance).gte(amount)) {
+        await this.updateChannel(
+          channelId,
+          beneficiary,
+          payer,
+          bigNumberify(beneficiaryBalance)
+            .add(amount)
+            .toString(),
+          bigNumberify(payerBalance)
+            .sub(amount)
+            .toString(),
+          beneficiaryOutcomeAddress,
+          payerOutcomeAddress
+        );
+      }
+    } else {
+      console.error('Cannot make a payment in a channel that you did not join');
     }
   }
   // beneficiary may use this method to accept payments

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -127,7 +127,7 @@ export type PeerByTorrent = {
   wire: PaidStreamingWire | PeerWire;
   allowed: boolean;
   buffer: string;
-  credit: string;
+  beneficiaryBalance: string;
   channelId: string;
 };
 

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -322,7 +322,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
       switch (command) {
         case PaidStreamingExtensionNotices.STOP: // synonymous with a prompt for a payment
           if (!torrent.done) {
-            const channelId = wire.paidStreamingExtension.peerChannelId;
+            const channelId = data;
             await this.paymentChannelClient.makePayment(
               channelId,
               WEI_PER_BYTE.mul(BUFFER_REFILL_RATE).toString()

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -35,6 +35,8 @@ export const BUFFER_REFILL_RATE = bigNumberify(2e4); // number of credits / piec
 export const INITIAL_SEEDER_BALANCE = bigNumberify(0); // needs to be zero so that depositing works correctly (unidirectional payment channel)
 export const INITIAL_LEECHER_BALANCE = bigNumberify(BUFFER_REFILL_RATE.mul(100)); // e.g. gwei = 1e9 = nano-ETH
 
+const HUB_ADDRESS = 'TODO';
+
 // A Whimsical diagram explaining the functionality of Web3Torrent: https://whimsical.com/Sq6whAwa8aTjbwMRJc7vPU
 export default class WebTorrentPaidStreamingClient extends WebTorrent {
   peersList: PeersByTorrent;
@@ -59,6 +61,17 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     log('got ethereum address');
     log('ACCOUNT ID: ', this.pseAccount);
     log('THIS address: ', this.outcomeAddress);
+
+    // Hub messaging
+    this.paymentChannelClient.onMessageQueued((message: Message) => {
+      if (message.recipient === HUB_ADDRESS) {
+        // pipe to firebase.
+      }
+    });
+    // TODO
+    // onFirebaseMessageReceived(message:Message) => {
+    //   await this.paymentChannelClient.pushMessage(message);
+    // }
   }
 
   async testTorrentingCapability(timeOut: number) {
@@ -224,7 +237,9 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
 
     // If the wallet queues a message, send it across the wire
     this.paymentChannelClient.onMessageQueued((message: Message) => {
-      wire.paidStreamingExtension.sendMessage(JSON.stringify(message));
+      if (message.recipient === wire.paidStreamingExtension.peerAccount) {
+        wire.paidStreamingExtension.sendMessage(JSON.stringify(message));
+      }
     });
 
     // If a channel is proposed, join it

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -326,11 +326,10 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
             await this.paymentChannelClient.makePayment(
               channelId,
               WEI_PER_BYTE.mul(BUFFER_REFILL_RATE).toString()
+            ); // if I have run out of money,
+            log(
+              `attempted to make payment for channel ${channelId}, beneficiaryBalance: ${this.paymentChannelClient.channelCache[channelId].beneficiaryBalance}`
             );
-            const newSeederBalance = bigNumberify(
-              this.paymentChannelClient.channelCache[channelId].beneficiaryBalance
-            );
-            log(`payment made for channel ${channelId}, newSeederBalance: ${newSeederBalance}`);
           }
           break;
         case PaidStreamingExtensionNotices.START:

--- a/packages/web3torrent/src/utils/test-utils.ts
+++ b/packages/web3torrent/src/utils/test-utils.ts
@@ -26,7 +26,7 @@ export function createMockTorrentPeers(): TorrentPeers {
       wire: {
         uploaded: 4225
       },
-      credit: '50',
+      beneficiaryBalance: '50',
       channelId: '0x0000000000000000000000000000001231927371',
       buffer: '50'
     },
@@ -34,7 +34,7 @@ export function createMockTorrentPeers(): TorrentPeers {
       id: '5589113806923374',
       allowed: true,
       buffer: '50',
-      credit: '50',
+      beneficiaryBalance: '50',
       wire: {
         uploaded: 52923
       },


### PR DESCRIPTION
Currently 

(1) I will send all `onChannelUpdated` messages messages down all wires, and
(2)The `PaymentChannelClient` will happily cache states for unknown channels.

This PR fixes both 1 and 2.

It also includes some TODOs for hub messaging (soon to be implemented)