### PR TITLE
simple-hub: isolate wire message and participant broadcast logic

### DIFF
--- a/packages/simple-hub/src/blockchain/eth-asset-holder.ts
+++ b/packages/simple-hub/src/blockchain/eth-asset-holder.ts
@@ -36,8 +36,6 @@ export class Blockchain {
     Blockchain.ethAssetHolder = Blockchain.ethAssetHolder || newAssetHolder;
     return Blockchain.ethAssetHolder;
   }
-
-  private;
 }
 
 export async function createEthAssetHolder() {

--- a/packages/simple-hub/src/message/__test__/firebase-relay.test.ts
+++ b/packages/simple-hub/src/message/__test__/firebase-relay.test.ts
@@ -1,0 +1,59 @@
+import {Message} from '@statechannels/wire-format';
+import {serializeMessage} from '@statechannels/xstate-wallet/lib/src/serde/wire-format/serialize';
+import {
+  participants,
+  ledgerStateResponse,
+  ledgerStateResponse3,
+  ledgerStateResponse3_2
+} from '../../wallet/test-helpers';
+import {messagesToSend} from '../firebase-relay';
+
+describe('broadcast to 1 participant', () => {
+  it('Echo message with signature', () => {
+    const messageToSend = {signedStates: [ledgerStateResponse]};
+    const wireMessageToSend = messagesToSend(messageToSend);
+    const expectedWireMessageToSend = serializeMessage(
+      {signedStates: [ledgerStateResponse]},
+      participants[0].participantId,
+      participants[1].participantId
+    );
+    expect(wireMessageToSend).toMatchObject<Message[]>([expectedWireMessageToSend]);
+  });
+
+  it('Echo message with signature with 3 participants', () => {
+    const messageToSend = {signedStates: [ledgerStateResponse3]};
+    const response = messagesToSend(messageToSend);
+    const expectedWireMessageToSend = [
+      serializeMessage(
+        {signedStates: [ledgerStateResponse3]},
+        participants[0].participantId,
+        participants[1].participantId
+      ),
+      serializeMessage(
+        {signedStates: [ledgerStateResponse3]},
+        participants[2].participantId,
+        participants[1].participantId
+      )
+    ];
+    expect(response).toMatchObject<Message[]>(expectedWireMessageToSend);
+  });
+
+  it('Echo message with signature with 3 participants, 2 states', () => {
+    const message = {signedStates: [ledgerStateResponse3, ledgerStateResponse3_2]};
+    const wireMessagesToSend = messagesToSend(message);
+
+    const expectedWireMessageToSend = [
+      serializeMessage(
+        {signedStates: [ledgerStateResponse3, ledgerStateResponse3_2]},
+        participants[0].participantId,
+        participants[1].participantId
+      ),
+      serializeMessage(
+        {signedStates: [ledgerStateResponse3, ledgerStateResponse3_2]},
+        participants[2].participantId,
+        participants[1].participantId
+      )
+    ];
+    expect(wireMessagesToSend).toMatchObject<Message[]>(expectedWireMessageToSend);
+  });
+});

--- a/packages/simple-hub/src/utils.ts
+++ b/packages/simple-hub/src/utils.ts
@@ -1,0 +1,8 @@
+import {Participant} from './wallet/xstate-wallet-internals';
+import {cHubChannelSigningAddress} from './constants';
+import * as R from 'ramda';
+
+export function containsHub(participant: Participant): boolean {
+  return participant.signingAddress === cHubChannelSigningAddress;
+}
+export const notContainsHub = R.compose(R.not, containsHub);

--- a/packages/simple-hub/src/wallet/__test__/respond-to-message.test.ts
+++ b/packages/simple-hub/src/wallet/__test__/respond-to-message.test.ts
@@ -1,73 +1,32 @@
 import {respondToMessage} from '../respond-to-message';
-import {Message} from '@statechannels/wire-format';
-import {serializeMessage} from '@statechannels/xstate-wallet/lib/src/serde/wire-format/serialize';
 import {
   ledgerStateIncoming,
-  participants,
   ledgerStateResponse,
   ledgerStateIncoming3,
   ledgerStateResponse3,
   ledgerStateIncoming3_2,
   ledgerStateResponse3_2
 } from '../test-helpers';
+import {Message} from '../xstate-wallet-internals';
 
 describe('ledger state', () => {
   it('Echo message with signature', () => {
-    const ledgerMessage = serializeMessage(
-      {signedStates: [ledgerStateIncoming]},
-      participants[1].participantId,
-      participants[0].participantId
-    );
-    const response = respondToMessage(ledgerMessage);
-    const expectedResponse = serializeMessage(
-      {signedStates: [ledgerStateResponse]},
-      participants[0].participantId,
-      participants[1].participantId
-    );
-    expect(response).toMatchObject<Message[]>([expectedResponse]);
+    const response = respondToMessage({signedStates: [ledgerStateIncoming]});
+    const expectedResponse = {signedStates: [ledgerStateResponse]};
+    expect(response).toMatchObject<Message>(expectedResponse);
   });
 
   it('Echo message with signature with 3 participants', () => {
-    const ledgerMessage = serializeMessage(
-      {signedStates: [ledgerStateIncoming3]},
-      participants[1].participantId,
-      participants[0].participantId
-    );
+    const ledgerMessage = {signedStates: [ledgerStateIncoming3]};
     const response = respondToMessage(ledgerMessage);
-    const expectedResponses = [
-      serializeMessage(
-        {signedStates: [ledgerStateResponse3]},
-        participants[0].participantId,
-        participants[1].participantId
-      ),
-      serializeMessage(
-        {signedStates: [ledgerStateResponse3]},
-        participants[2].participantId,
-        participants[1].participantId
-      )
-    ];
-    expect(response).toMatchObject<Message[]>(expectedResponses);
+    const expectedResponse = {signedStates: [ledgerStateResponse3]};
+    expect(response).toMatchObject<Message>(expectedResponse);
   });
 
   it('Echo message with signature with 3 participants, 2 states', () => {
-    const ledgerMessage = serializeMessage(
-      {signedStates: [ledgerStateIncoming3, ledgerStateIncoming3_2]},
-      participants[1].participantId,
-      participants[0].participantId
-    );
+    const ledgerMessage = {signedStates: [ledgerStateIncoming3, ledgerStateIncoming3_2]};
     const response = respondToMessage(ledgerMessage);
-    const expectedResponses = [
-      serializeMessage(
-        {signedStates: [ledgerStateResponse3, ledgerStateResponse3_2]},
-        participants[0].participantId,
-        participants[1].participantId
-      ),
-      serializeMessage(
-        {signedStates: [ledgerStateResponse3, ledgerStateResponse3_2]},
-        participants[2].participantId,
-        participants[1].participantId
-      )
-    ];
-    expect(response).toMatchObject<Message[]>(expectedResponses);
+    const expectedResponse = {signedStates: [ledgerStateResponse3, ledgerStateResponse3_2]};
+    expect(response).toMatchObject<Message>(expectedResponse);
   });
 });

--- a/packages/simple-hub/src/wallet/respond-to-message.ts
+++ b/packages/simple-hub/src/wallet/respond-to-message.ts
@@ -1,29 +1,9 @@
-import {Message as WireMessage} from '@statechannels/wire-format';
 import * as R from 'ramda';
-import {cHubChannelPK, cHubChannelSigningAddress} from '../constants';
-import {
-  deserializeMessage,
-  serializeMessage,
-  SignedState,
-  Message,
-  Participant,
-  signState
-} from './xstate-wallet-internals';
+import {cHubChannelPK} from '../constants';
+import {Message, signState} from './xstate-wallet-internals';
+import {containsHub} from '../utils';
 
-function containsHub(participant: Participant): boolean {
-  return participant.signingAddress === cHubChannelSigningAddress;
-}
-const notContainsHub = R.compose(R.not, containsHub);
-
-function broadcastRecipients(states: SignedState[]): Participant[] {
-  const allParticipantsWithDups = states
-    .map(state => state.participants)
-    .reduce((participantsSoFar, participants) => participantsSoFar.concat(participants), []);
-  return R.intersection(allParticipantsWithDups, allParticipantsWithDups).filter(notContainsHub);
-}
-
-export function respondToMessage(wireMessage: WireMessage): WireMessage[] {
-  const message = deserializeMessage(wireMessage);
+export function respondToMessage(message: Message): Message {
   const statesWithHub = message.signedStates.filter(
     state => state.participants.filter(containsHub).length
   );
@@ -32,9 +12,5 @@ export function respondToMessage(wireMessage: WireMessage): WireMessage[] {
     const signatures = R.append(ourSignature, state.signatures);
     return {...state, signatures};
   });
-  const ourMessage: Message = {signedStates, objectives: message.objectives};
-
-  return broadcastRecipients(signedStates).map(participant =>
-    serializeMessage(ourMessage, participant.participantId, wireMessage.recipient)
-  );
+  return {signedStates, objectives: message.objectives};
 }


### PR DESCRIPTION
This PR is preparation work needed for the upcoming deposit work. With this PR:
- `firebase-relay` exports an observable that can be used to listen for firebase wire messages.
- `server` is responsible for subscribing to the observable and managing subscription side effects.
- `firebase-relay` is responsible for converting a wallet message to a list of serialized wire messages with correct recipients.