### PR TITLE
Handle duplicate Join Channel

### DIFF
--- a/packages/xstate-wallet/src/ui/selectors.ts
+++ b/packages/xstate-wallet/src/ui/selectors.ts
@@ -26,8 +26,20 @@ export function getConfirmCreateChannelState(
 
 // TODO:Ideally this should be a type guard
 export function isConfirmCreateChannel(applicationWorkflowState: AppWorkflowState): boolean {
+  // TODO: This is fragile and should be revisited at some point
+  const joinInConfirmCreateChannel =
+    getApplicationStateValue(applicationWorkflowState) === 'confirmJoinChannelWorkflow' &&
+    applicationWorkflowState.value['confirmJoinChannelWorkflow'] &&
+    applicationWorkflowState.value['confirmJoinChannelWorkflow']['confirmChannelCreation'] ===
+      'invokeCreateChannelConfirmation';
+  console.log(JSON.stringify(applicationWorkflowState.value));
+  console.log('joinInConfirmCreateChannel ', joinInConfirmCreateChannel);
+  if (joinInConfirmCreateChannel) {
+    console.log(getConfirmCreateChannelState(applicationWorkflowState));
+  }
+
   return (
-    getApplicationStateValue(applicationWorkflowState) === 'confirmJoinChannelWorkflow' ||
+    joinInConfirmCreateChannel ||
     getApplicationStateValue(applicationWorkflowState) === 'confirmCreateChannelWorkflow'
   );
 }

--- a/packages/xstate-wallet/src/ui/selectors.ts
+++ b/packages/xstate-wallet/src/ui/selectors.ts
@@ -32,11 +32,6 @@ export function isConfirmCreateChannel(applicationWorkflowState: AppWorkflowStat
     applicationWorkflowState.value['confirmJoinChannelWorkflow'] &&
     applicationWorkflowState.value['confirmJoinChannelWorkflow']['confirmChannelCreation'] ===
       'invokeCreateChannelConfirmation';
-  console.log(JSON.stringify(applicationWorkflowState.value));
-  console.log('joinInConfirmCreateChannel ', joinInConfirmCreateChannel);
-  if (joinInConfirmCreateChannel) {
-    console.log(getConfirmCreateChannelState(applicationWorkflowState));
-  }
 
   return (
     joinInConfirmCreateChannel ||


### PR DESCRIPTION
Fixes #1235 

Currently `rps` will call `JoinChannel` any time it receives a `ChannelUpdated` event. Right now it seems that we're sending out multiple `ChannelUpdated` events (possibly related to #1237)

The `xstate-wallet` ends up creating multiple workflows for each `JoinChannel` request, ending up with multiple `Application` workflows running, causing issues with the UI.

To safeguard this I've added deterministic workflowIds for some of the events so we can detect the duplicate call and avoid starting a workflow.

Longer term:
-`RPS` should probably be more careful about making duplicate calls 
- The `xstate-wallet` should not be sending out duplicate `ChannelUpdated` events (this might be resolved by #1237?)