### PR TITLE
Add budgets to create-and-fund workflow.

### DIFF
--- a/packages/xstate-wallet/package.json
+++ b/packages/xstate-wallet/package.json
@@ -9,6 +9,7 @@
     "@statechannels/wire-format": "0.0.1",
     "@xstate/react": "0.8.1",
     "ethers": "4.0.45",
+    "async-lock": "1.2.2",
     "eventemitter3": "4.0.0",
     "filter-async-rxjs-pipe": "0.1.5",
     "guid-typescript": "1.0.9",

--- a/packages/xstate-wallet/src/serde/app-messages/serialize.ts
+++ b/packages/xstate-wallet/src/serde/app-messages/serialize.ts
@@ -9,19 +9,25 @@ import {
   AllocationItem,
   SimpleAllocation,
   SiteBudget,
-  BudgetItem
+  BudgetItem,
+  AssetBudget
 } from '../../store/types';
 import {tokenAddress} from '../../constants';
 import {AddressZero} from 'ethers/constants';
+import {checkThat, exists} from '../../utils';
 
 export function serializeSiteBudget(budget: SiteBudget): AppSiteBudget {
-  const budgets = Object.keys(budget.forAsset).map(assetHolderAddress => ({
-    token: tokenAddress(assetHolderAddress) || AddressZero,
-    pending: serializeBudgetItem(budget.forAsset[assetHolderAddress].pending),
-    free: serializeBudgetItem(budget.forAsset[assetHolderAddress].free),
-    inUse: serializeBudgetItem(budget.forAsset[assetHolderAddress].inUse),
-    direct: serializeBudgetItem(budget.forAsset[assetHolderAddress].direct)
-  }));
+  const budgets = Object.keys(budget.forAsset).map(assetHolderAddress => {
+    const assetBudget = checkThat<AssetBudget>(budget.forAsset[assetHolderAddress], exists);
+
+    return {
+      token: tokenAddress(assetHolderAddress) || AddressZero,
+      pending: serializeBudgetItem(assetBudget.pending),
+      free: serializeBudgetItem(assetBudget.free),
+      inUse: serializeBudgetItem(assetBudget.inUse),
+      direct: serializeBudgetItem(assetBudget.direct)
+    };
+  });
 
   return {
     site: budget.site,

--- a/packages/xstate-wallet/src/store/channel-store-entry.ts
+++ b/packages/xstate-wallet/src/store/channel-store-entry.ts
@@ -12,4 +12,5 @@ export interface ChannelStoreEntry {
   readonly channelConstants: ChannelConstants;
   readonly funding?: Funding;
   readonly states: State[];
+  readonly applicationSite?: string;
 }

--- a/packages/xstate-wallet/src/store/index.ts
+++ b/packages/xstate-wallet/src/store/index.ts
@@ -1,5 +1,8 @@
 export {Store} from './store';
 
 export enum Errors {
-  channelLocked = 'Channel is locked'
+  channelLocked = 'Channel is locked',
+  noBudget = 'No budget exists for this site',
+  budgetInsufficient = 'Budget insufficient to reserve funds',
+  amountUnauthorized = 'Amount unauthorized in current budget'
 }

--- a/packages/xstate-wallet/src/store/memory-channel-storage.ts
+++ b/packages/xstate-wallet/src/store/memory-channel-storage.ts
@@ -11,7 +11,8 @@ export class MemoryChannelStoreEntry implements ChannelStoreEntry {
     public readonly myIndex: number,
     private stateVariables: Record<string, StateVariables> = {},
     private signatures: Record<string, string[] | undefined> = {},
-    public funding: Funding | undefined = undefined
+    public funding: Funding | undefined = undefined,
+    public readonly applicationSite?: string
   ) {
     this.channelConstants = _.pick(
       constants,

--- a/packages/xstate-wallet/src/store/memory-store.ts
+++ b/packages/xstate-wallet/src/store/memory-store.ts
@@ -91,7 +91,7 @@ export class MemoryStore implements Store {
   private _privateKeys: Record<string, string | undefined> = {};
   protected _ledgers: Record<string, string> = {};
   protected _channelLocks: Record<string, Guid | undefined> = {};
-  private _budgets: Record<string, SiteBudget> = {};
+  private _budgets: Record<string, SiteBudget | undefined> = {};
 
   constructor(privateKeys?: string[], chain?: Chain) {
     // TODO: We shouldn't default to a fake chain
@@ -113,7 +113,9 @@ export class MemoryStore implements Store {
   }
 
   public getBudget(site: string): Promise<SiteBudget> {
-    return Promise.resolve(this._budgets[site]);
+    const currentBudget = this._budgets[site];
+    if (!currentBudget) throw new Error(Errors.noBudget);
+    return Promise.resolve(currentBudget);
   }
 
   public updateOrCreateBudget(budget: SiteBudget): Promise<void> {

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -1,6 +1,6 @@
 import {Observable} from 'rxjs';
 import {BigNumber} from 'ethers/utils';
-import {Participant, StateVariables, Objective, Message, SiteBudget} from './types';
+import {Participant, StateVariables, Objective, Message, SiteBudget, BudgetItem} from './types';
 import {ChannelStoreEntry} from './channel-store-entry';
 import {Chain} from '../chain';
 import {Funding, ChannelLock} from './memory-store';
@@ -31,6 +31,7 @@ export interface Store {
   addObjective(objective: Objective): void;
   getBudget: (site: string) => Promise<SiteBudget | undefined>;
   updateOrCreateBudget: (budget: SiteBudget) => Promise<void>;
+  reserveFunds(site: string, assetHolderAddress: string, amount: BudgetItem): Promise<SiteBudget>;
 
   chain: Chain;
 }

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -29,7 +29,7 @@ export interface Store {
 
   setFunding(channelId: string, funding: Funding): Promise<void>;
   addObjective(objective: Objective): void;
-  getBudget: (site: string) => Promise<SiteBudget | undefined>;
+  getBudget: (site: string) => Promise<SiteBudget>;
   updateOrCreateBudget: (budget: SiteBudget) => Promise<void>;
   reserveFunds(site: string, assetHolderAddress: string, amount: BudgetItem): Promise<SiteBudget>;
 

--- a/packages/xstate-wallet/src/store/types.ts
+++ b/packages/xstate-wallet/src/store/types.ts
@@ -2,7 +2,7 @@ import {BigNumber} from 'ethers/utils';
 export interface SiteBudget {
   site: string;
   hubAddress: string;
-  forAsset: Record<string, AssetBudget>;
+  forAsset: Record<string, AssetBudget | undefined>;
 }
 export interface BudgetItem {
   playerAmount: BigNumber;
@@ -10,9 +10,9 @@ export interface BudgetItem {
 }
 export interface AssetBudget {
   assetHolderAddress: string;
-  pending: BudgetItem;
-  free: BudgetItem;
-  inUse: BudgetItem;
+  pending: BudgetItem; // Approved by user, but not yet funded
+  free: BudgetItem; // Funded, and ready to be allocated
+  inUse: BudgetItem; // Funded, but currently allocated
   direct: BudgetItem;
 }
 export interface Participant {
@@ -20,7 +20,6 @@ export interface Participant {
   signingAddress: string;
   destination: string;
 }
-// signers
 
 export interface StateVariables {
   outcome: Outcome;

--- a/packages/xstate-wallet/src/ui/selectors.ts
+++ b/packages/xstate-wallet/src/ui/selectors.ts
@@ -60,7 +60,8 @@ export function getApplicationOpenProgress(applicationWorkflowState: AppWorkflow
 export function getAmountsFromPendingBudget(
   budget: SiteBudget
 ): {playerAmount: BigNumber; hubAmount: BigNumber} {
-  const {pending} = budget.forAsset[ETH_ASSET_HOLDER_ADDRESS];
+  const pending = budget.forAsset[ETH_ASSET_HOLDER_ADDRESS]?.pending;
+  if (!pending) throw new Error('No eth budget found');
   const {playerAmount, hubAmount} = pending;
   return {playerAmount, hubAmount};
 }

--- a/packages/xstate-wallet/src/utils/budget-utils.ts
+++ b/packages/xstate-wallet/src/utils/budget-utils.ts
@@ -1,0 +1,31 @@
+import {BudgetItem, SiteBudget} from '../store/types';
+import {HUB_ADDRESS, ETH_ASSET_HOLDER_ADDRESS} from '../constants';
+import {bigNumberify} from 'ethers/utils';
+import _ from 'lodash';
+
+export function ethBudget(
+  site: string,
+  opts: {
+    free?: BudgetItem;
+    inUse?: BudgetItem;
+    pending?: BudgetItem;
+    direct?: BudgetItem;
+  }
+): SiteBudget {
+  return {
+    site,
+    hubAddress: HUB_ADDRESS,
+    forAsset: {
+      [ETH_ASSET_HOLDER_ADDRESS]: _.assign(
+        {
+          assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS,
+          free: {playerAmount: bigNumberify(0), hubAmount: bigNumberify(0)},
+          inUse: {playerAmount: bigNumberify(0), hubAmount: bigNumberify(0)},
+          pending: {playerAmount: bigNumberify(0), hubAmount: bigNumberify(0)},
+          direct: {playerAmount: bigNumberify(0), hubAmount: bigNumberify(0)}
+        },
+        opts
+      )
+    }
+  };
+}

--- a/packages/xstate-wallet/src/workflows/approve-budget-and-fund.ts
+++ b/packages/xstate-wallet/src/workflows/approve-budget-and-fund.ts
@@ -25,6 +25,7 @@ import {ETH_ASSET_HOLDER_ADDRESS} from '../constants';
 import {simpleEthAllocation} from '../utils/outcome';
 import {bigNumberify} from 'ethers/utils';
 import _ from 'lodash';
+import {checkThat, exists} from '../utils';
 interface UserApproves {
   type: 'USER_APPROVES_BUDGET';
 }
@@ -177,7 +178,7 @@ function convertPendingBudgetToAllocation({
   if (Object.keys(budget.forAsset).length !== 1) {
     throw new Error('Cannot handle mixed budget');
   }
-  const ethBudget = budget.forAsset[ETH_ASSET_HOLDER_ADDRESS];
+  const ethBudget = checkThat<AssetBudget>(budget.forAsset[ETH_ASSET_HOLDER_ADDRESS], exists);
   const playerItem: AllocationItem = {
     destination: player.destination,
     amount: ethBudget.pending.playerAmount

--- a/packages/xstate-wallet/src/workflows/tests/store.ts
+++ b/packages/xstate-wallet/src/workflows/tests/store.ts
@@ -6,16 +6,24 @@ import {Guid} from 'guid-typescript';
 
 export class TestStore extends MemoryStore {
   public _channelLocks: Record<string, Guid>;
-  public createEntry(signedState: SignedState, funding?: Funding): MemoryChannelStoreEntry {
+  public createEntry(
+    signedState: SignedState,
+    opts?: {
+      funding?: Funding;
+      applicationSite?: string;
+    }
+  ): MemoryChannelStoreEntry {
     const myIndex = signedState.participants
       .map(p => p.signingAddress)
       .findIndex(a => a === this.getAddress());
+    const {funding, applicationSite} = opts || {};
     const entry = new MemoryChannelStoreEntry(
       signedState,
       myIndex,
       {[hashState(signedState)]: signedState},
       {[hashState(signedState)]: signedState.signatures},
-      funding
+      funding,
+      applicationSite
     );
     this._channels[entry.channelId] = entry;
 

--- a/packages/xstate-wallet/src/workflows/tests/virtual-defunding.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/virtual-defunding.test.ts
@@ -148,16 +148,16 @@ let bStore: TestStore;
 beforeEach(() => {
   aStore = new TestStore([wallet1.privateKey]);
 
-  aStore.createEntry(ledger1State, {type: 'Direct'});
-  aStore.createEntry(guarantor1State, {type: 'Indirect', ledgerId: ledger1Id});
-  aStore.createEntry(jointState, {type: 'Guarantee', guarantorChannelId: guarantor1Id});
-  aStore.createEntry(targetState, {type: 'Virtual', jointChannelId});
+  aStore.createEntry(ledger1State, {funding: {type: 'Direct'}});
+  aStore.createEntry(guarantor1State, {funding: {type: 'Indirect', ledgerId: ledger1Id}});
+  aStore.createEntry(jointState, {funding: {type: 'Guarantee', guarantorChannelId: guarantor1Id}});
+  aStore.createEntry(targetState, {funding: {type: 'Virtual', jointChannelId}});
 
   bStore = new TestStore([wallet2.privateKey]);
-  bStore.createEntry(ledger2State, {type: 'Direct'});
-  bStore.createEntry(guarantor2State, {type: 'Indirect', ledgerId: ledger2Id});
-  bStore.createEntry(jointState, {type: 'Guarantee', guarantorChannelId: guarantor2Id});
-  bStore.createEntry(targetState, {type: 'Virtual', jointChannelId});
+  bStore.createEntry(ledger2State, {funding: {type: 'Direct'}});
+  bStore.createEntry(guarantor2State, {funding: {type: 'Indirect', ledgerId: ledger2Id}});
+  bStore.createEntry(jointState, {funding: {type: 'Guarantee', guarantorChannelId: guarantor2Id}});
+  bStore.createEntry(targetState, {funding: {type: 'Virtual', jointChannelId}});
 });
 
 test('virtual defunding with a simple hub', async () => {
@@ -190,14 +190,16 @@ test('virtual defunding with a simple hub', async () => {
 test('virtual defunding with a proper hub', async () => {
   const hubStore = new TestStore([wallet3.privateKey]);
 
-  hubStore.createEntry(ledger1State, {type: 'Direct'});
+  hubStore.createEntry(ledger1State, {funding: {type: 'Direct'}});
   hubStore.createEntry(jointState, {
-    type: 'Guarantees',
-    guarantorChannelIds: [guarantor1Id, guarantor2Id]
+    funding: {
+      type: 'Guarantees',
+      guarantorChannelIds: [guarantor1Id, guarantor2Id]
+    }
   });
-  hubStore.createEntry(guarantor1State, {type: 'Indirect', ledgerId: ledger1Id});
-  hubStore.createEntry(ledger2State, {type: 'Direct'});
-  hubStore.createEntry(guarantor2State, {type: 'Indirect', ledgerId: ledger2Id});
+  hubStore.createEntry(guarantor1State, {funding: {type: 'Indirect', ledgerId: ledger1Id}});
+  hubStore.createEntry(ledger2State, {funding: {type: 'Direct'}});
+  hubStore.createEntry(guarantor2State, {funding: {type: 'Indirect', ledgerId: ledger2Id}});
 
   const aService = interpret(VirtualDefundingAsLeaf.machine(aStore).withContext(context));
   const bService = interpret(VirtualDefundingAsLeaf.machine(bStore).withContext(context));


### PR DESCRIPTION
This adds a state `reservingFunds` before invoking the virtual-funding machine. This state invokes `reserveFunds`, which calls a new store method `reserveFunds`.