### PR TITLE
web3torrent: handle dropped wires

### DIFF
--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -5,7 +5,7 @@ import {ChannelState} from '../../../clients/payment-channel-client';
 import {PaidStreamingWire} from '../../../library/types';
 import './ChannelsList.scss';
 import {WebTorrentContext} from '../../../clients/web3torrent-client';
-import {prettyPrintWei} from '../../../utils/calculateWei';
+import {prettyPrintWei, prettyPrintBytes} from '../../../utils/calculateWei';
 import {utils} from 'ethers';
 
 export type UploadInfoProps = {
@@ -27,10 +27,11 @@ class ChannelsList extends React.Component<UploadInfoProps> {
     participantType: 'payer' | 'beneficiary'
   ) {
     let channelButton;
+    const channel = channels[channelId];
 
-    if (channels[channelId].status === 'closing') {
+    if (channel.status === 'closing') {
       channelButton = <button disabled>Closing ...</button>;
-    } else if (channels[channelId].status === 'closed') {
+    } else if (channel.status === 'closed') {
       channelButton = <button disabled>Closed</button>;
     } else {
       channelButton = <button disabled>Running</button>;
@@ -43,14 +44,13 @@ class ChannelsList extends React.Component<UploadInfoProps> {
     );
 
     let transferred: string;
-    let peerAccount: string;
+    const peerAccount = channel[participantType];
     if (wire) {
       transferred =
         participantType === 'beneficiary' ? prettier(wire.uploaded) : prettier(wire.downloaded);
-      peerAccount = channels[channelId][participantType];
     } else {
-      transferred = 'NOWIRE';
-      peerAccount = 'NOWIRE';
+      // Use the beneficiery balance as an approximate of the file size, when wire is dropped.
+      transferred = prettyPrintBytes(utils.bigNumberify(channel.beneficiaryBalance));
     }
 
     return (
@@ -64,11 +64,11 @@ class ChannelsList extends React.Component<UploadInfoProps> {
         </td>
         {participantType === 'beneficiary' ? (
           <td className="earned">
-            {prettyPrintWei(utils.bigNumberify(channels[channelId].beneficiaryBalance))}
+            {prettyPrintWei(utils.bigNumberify(channel.beneficiaryBalance))}
           </td>
         ) : (
           <td className="paid">
-            -{prettyPrintWei(utils.bigNumberify(channels[channelId].beneficiaryBalance))}
+            -{prettyPrintWei(utils.bigNumberify(channel.beneficiaryBalance))}
           </td>
         )}
       </tr>

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -370,9 +370,19 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
             await this.paymentChannelClient.makePayment(
               channelId,
               WEI_PER_BYTE.mul(BUFFER_REFILL_RATE).toString()
-            ); // if I have run out of money,
+            );
+
+            let balance: string;
+            const channel = this.paymentChannelClient.channelCache[channelId];
+
+            if (channel) {
+              balance = channel.beneficiaryBalance;
+            } else {
+              balance = 'unknown';
+            }
+
             log(
-              `attempted to make payment for channel ${channelId}, beneficiaryBalance: ${this.paymentChannelClient.channelCache[channelId].beneficiaryBalance}`
+              `attempted to make payment for channel ${channelId}, beneficiaryBalance: ${balance}`
             );
           }
           break;

--- a/packages/web3torrent/src/utils/calculateWei.ts
+++ b/packages/web3torrent/src/utils/calculateWei.ts
@@ -1,10 +1,16 @@
 import {WEI_PER_BYTE} from '../library/web3torrent-lib';
 import {utils} from 'ethers';
+import prettier from 'prettier-bytes';
 
 export const calculateWei = (fileSize: number | string) => {
   if (!isNaN(Number(fileSize))) {
     return WEI_PER_BYTE.mul(fileSize);
   } else return utils.bigNumberify(NaN);
+};
+
+export const prettyPrintBytes = (wei: utils.BigNumber): string => {
+  const bytes = wei.div(WEI_PER_BYTE);
+  return prettier(bytes.toNumber());
 };
 
 export const prettyPrintWei = (wei: utils.BigNumber): string => {


### PR DESCRIPTION
Fix: https://github.com/statechannels/monorepo/issues/1215

Added a fix to fall back to channel cache to calculate the download size.

Also put in a fix to handle a random crash when the channel cache is not available.

WIP: When leechers cancels the download, wire is dropped but the channel is still running.