### PR TITLE
[channel-provider/client] Add types to ChannelProvider events

### DIFF
--- a/packages/channel-client/jest.config.js
+++ b/packages/channel-client/jest.config.js
@@ -4,5 +4,6 @@ module.exports = {
       tsConfig: './tsconfig.json'
     }
   },
-  preset: 'ts-jest'
+  preset: 'ts-jest',
+  testMatch: ['**/__tests__/**/*.ts?(x)', '**/?(*.)+(spec|test).ts?(x)']
 };

--- a/packages/channel-client/src/channel-client.ts
+++ b/packages/channel-client/src/channel-client.ts
@@ -1,6 +1,6 @@
 import {ChannelProviderInterface} from '@statechannels/channel-provider';
 
-import {ChannelClientInterface, UnsubscribeFunction, Message} from './types';
+import {ChannelClientInterface, UnsubscribeFunction} from './types';
 import {
   PushMessageResult,
   ChannelResult,
@@ -9,7 +9,9 @@ import {
   SiteBudget,
   ChannelUpdatedNotification,
   ChannelProposedNotification,
-  BudgetUpdatedNotification
+  BudgetUpdatedNotification,
+  Message,
+  MessageQueuedNotification
 } from '@statechannels/client-api-schema';
 
 type TokenAllocations = Allocation[];
@@ -17,32 +19,45 @@ type TokenAllocations = Allocation[];
 export class ChannelClient implements ChannelClientInterface {
   constructor(private readonly provider: ChannelProviderInterface) {}
 
-  onMessageQueued(callback: (message: Message) => void): UnsubscribeFunction {
-    this.provider.on('MessageQueued', callback);
-    return this.provider.off.bind(this, 'MessageQueued', callback);
+  onMessageQueued(
+    callback: (result: MessageQueuedNotification['params']) => void
+  ): UnsubscribeFunction {
+    const listenerFn = (result: MessageQueuedNotification['params']): void => callback(result);
+    this.provider.on('MessageQueued', listenerFn);
+    return (): void => {
+      this.provider.off('MessageQueued', listenerFn);
+    };
   }
 
-  onChannelUpdated(callback: (result: ChannelResult) => void): UnsubscribeFunction {
-    this.provider.on('ChannelUpdated', (result: ChannelUpdatedNotification) =>
-      callback(result.params)
-    );
-    return this.provider.off.bind(this, 'ChannelUpdated', callback);
+  onChannelUpdated(
+    callback: (result: ChannelUpdatedNotification['params']) => void
+  ): UnsubscribeFunction {
+    const listenerFn = (result: ChannelUpdatedNotification['params']): void => callback(result);
+    this.provider.on('ChannelUpdated', listenerFn);
+    return (): void => {
+      this.provider.off('ChannelUpdated', listenerFn);
+    };
   }
 
-  onChannelProposed(callback: (result: ChannelResult) => void): UnsubscribeFunction {
-    this.provider.on('ChannelProposed', (result: ChannelProposedNotification) =>
-      callback(result.params)
-    );
-    return this.provider.off.bind(this, 'ChannelProposed', callback);
+  onChannelProposed(
+    callback: (result: ChannelProposedNotification['params']) => void
+  ): UnsubscribeFunction {
+    const listenerFn = (result: ChannelProposedNotification['params']): void => callback(result);
+    this.provider.on('ChannelProposed', listenerFn);
+    return (): void => {
+      this.provider.off('ChannelProposed', listenerFn);
+    };
   }
 
-  onBudgetUpdated(callback: (result: SiteBudget) => void): UnsubscribeFunction {
-    this.provider.on('BudgetUpdated', (result: BudgetUpdatedNotification) =>
-      callback(result.params)
-    );
-    return this.provider.off.bind(this, 'BudgetUpdated', callback);
+  onBudgetpdated(
+    callback: (result: BudgetUpdatedNotification['params']) => void
+  ): UnsubscribeFunction {
+    const listenerFn = (result: BudgetUpdatedNotification['params']): void => callback(result);
+    this.provider.on('BudgetUpdated', listenerFn);
+    return (): void => {
+      this.provider.off('BudgetUpdated', listenerFn);
+    };
   }
-
   async createChannel(
     participants: Participant[],
     allocations: TokenAllocations,

--- a/packages/channel-client/src/channel-client.ts
+++ b/packages/channel-client/src/channel-client.ts
@@ -16,7 +16,7 @@ import {
 
 type TokenAllocations = Allocation[];
 
-export class ChannelClient implements ChannelClientInterface {
+export class ChannelClient implements ChannelClientInterface<ChannelResult> {
   constructor(private readonly provider: ChannelProviderInterface) {}
 
   onMessageQueued(

--- a/packages/channel-client/src/channel-client.ts
+++ b/packages/channel-client/src/channel-client.ts
@@ -6,7 +6,10 @@ import {
   ChannelResult,
   Allocation,
   Participant,
-  SiteBudget
+  SiteBudget,
+  ChannelUpdatedNotification,
+  ChannelProposedNotification,
+  BudgetUpdatedNotification
 } from '@statechannels/client-api-schema';
 
 type TokenAllocations = Allocation[];
@@ -20,17 +23,23 @@ export class ChannelClient implements ChannelClientInterface {
   }
 
   onChannelUpdated(callback: (result: ChannelResult) => void): UnsubscribeFunction {
-    this.provider.on('ChannelUpdated', result => callback(result.params));
+    this.provider.on('ChannelUpdated', (result: ChannelUpdatedNotification) =>
+      callback(result.params)
+    );
     return this.provider.off.bind(this, 'ChannelUpdated', callback);
   }
 
   onChannelProposed(callback: (result: ChannelResult) => void): UnsubscribeFunction {
-    this.provider.on('ChannelProposed', result => callback(result.params));
+    this.provider.on('ChannelProposed', (result: ChannelProposedNotification) =>
+      callback(result.params)
+    );
     return this.provider.off.bind(this, 'ChannelProposed', callback);
   }
 
   onBudgetUpdated(callback: (result: SiteBudget) => void): UnsubscribeFunction {
-    this.provider.on('BudgetUpdated', result => callback(result.params));
+    this.provider.on('BudgetUpdated', (result: BudgetUpdatedNotification) =>
+      callback(result.params)
+    );
     return this.provider.off.bind(this, 'BudgetUpdated', callback);
   }
 

--- a/packages/channel-client/src/channel-client.ts
+++ b/packages/channel-client/src/channel-client.ts
@@ -22,40 +22,36 @@ export class ChannelClient implements ChannelClientInterface {
   onMessageQueued(
     callback: (result: MessageQueuedNotification['params']) => void
   ): UnsubscribeFunction {
-    const listenerFn = (result: MessageQueuedNotification['params']): void => callback(result);
-    this.provider.on('MessageQueued', listenerFn);
+    this.provider.on('MessageQueued', callback);
     return (): void => {
-      this.provider.off('MessageQueued', listenerFn);
+      this.provider.off('MessageQueued', callback);
     };
   }
 
   onChannelUpdated(
     callback: (result: ChannelUpdatedNotification['params']) => void
   ): UnsubscribeFunction {
-    const listenerFn = (result: ChannelUpdatedNotification['params']): void => callback(result);
-    this.provider.on('ChannelUpdated', listenerFn);
+    this.provider.on('ChannelUpdated', callback);
     return (): void => {
-      this.provider.off('ChannelUpdated', listenerFn);
+      this.provider.off('ChannelUpdated', callback);
     };
   }
 
   onChannelProposed(
     callback: (result: ChannelProposedNotification['params']) => void
   ): UnsubscribeFunction {
-    const listenerFn = (result: ChannelProposedNotification['params']): void => callback(result);
-    this.provider.on('ChannelProposed', listenerFn);
+    this.provider.on('ChannelProposed', callback);
     return (): void => {
-      this.provider.off('ChannelProposed', listenerFn);
+      this.provider.off('ChannelProposed', callback);
     };
   }
 
   onBudgetUpdated(
     callback: (result: BudgetUpdatedNotification['params']) => void
   ): UnsubscribeFunction {
-    const listenerFn = (result: BudgetUpdatedNotification['params']): void => callback(result);
-    this.provider.on('BudgetUpdated', listenerFn);
+    this.provider.on('BudgetUpdated', callback);
     return (): void => {
-      this.provider.off('BudgetUpdated', listenerFn);
+      this.provider.off('BudgetUpdated', callback);
     };
   }
   async createChannel(

--- a/packages/channel-client/src/channel-client.ts
+++ b/packages/channel-client/src/channel-client.ts
@@ -16,7 +16,7 @@ import {
 
 type TokenAllocations = Allocation[];
 
-export class ChannelClient implements ChannelClientInterface<ChannelResult> {
+export class ChannelClient implements ChannelClientInterface {
   constructor(private readonly provider: ChannelProviderInterface) {}
 
   onMessageQueued(

--- a/packages/channel-client/src/channel-client.ts
+++ b/packages/channel-client/src/channel-client.ts
@@ -11,10 +11,10 @@ import {
 
 type TokenAllocations = Allocation[];
 
-export class ChannelClient implements ChannelClientInterface<ChannelResult> {
+export class ChannelClient implements ChannelClientInterface {
   constructor(private readonly provider: ChannelProviderInterface) {}
 
-  onMessageQueued(callback: (message: Message<ChannelResult>) => void): UnsubscribeFunction {
+  onMessageQueued(callback: (message: Message) => void): UnsubscribeFunction {
     this.provider.on('MessageQueued', callback);
     return this.provider.off.bind(this, 'MessageQueued', callback);
   }
@@ -89,7 +89,7 @@ export class ChannelClient implements ChannelClientInterface<ChannelResult> {
     return this.provider.send({method: 'CloseChannel', params: {channelId}});
   }
 
-  async pushMessage(message: Message<ChannelResult>): Promise<PushMessageResult> {
+  async pushMessage(message: Message): Promise<PushMessageResult> {
     return this.provider.send({method: 'PushMessage', params: message});
   }
 

--- a/packages/channel-client/src/channel-client.ts
+++ b/packages/channel-client/src/channel-client.ts
@@ -49,7 +49,7 @@ export class ChannelClient implements ChannelClientInterface {
     };
   }
 
-  onBudgetpdated(
+  onBudgetUpdated(
     callback: (result: BudgetUpdatedNotification['params']) => void
   ): UnsubscribeFunction {
     const listenerFn = (result: BudgetUpdatedNotification['params']): void => callback(result);

--- a/packages/channel-client/src/index.ts
+++ b/packages/channel-client/src/index.ts
@@ -1,4 +1,4 @@
-export {ChannelClientInterface, UnsubscribeFunction, Message} from './types';
+export {ChannelClientInterface, UnsubscribeFunction} from './types';
 export {ChannelClient} from './channel-client';
 export {FakeChannelProvider} from '../tests/fakes/fake-channel-provider';
 export {ChannelResult} from '@statechannels/client-api-schema';

--- a/packages/channel-client/src/types.ts
+++ b/packages/channel-client/src/types.ts
@@ -3,15 +3,9 @@ import {
   ChannelResult,
   Participant,
   Allocation,
-  SiteBudget
+  SiteBudget,
+  Message
 } from '@statechannels/client-api-schema';
-
-export interface Message<T = object> {
-  recipient: string; // Identifier of user that the message should be relayed to
-  sender: string; // Identifier of user that the message is from
-  data: T; // Message payload. Format defined by wallet and opaque to app.
-  // But useful to be able to specify, for the purposes of the fake-client
-}
 
 export type UnsubscribeFunction = () => void;
 

--- a/packages/channel-client/src/types.ts
+++ b/packages/channel-client/src/types.ts
@@ -9,22 +9,19 @@ import {
 
 export type UnsubscribeFunction = () => void;
 
-// The message Payload is designed to be opaque to the app. However, it's useful
-// to be able to specify the Payload type for the FakeChannelClient, as we'll be
-// manipulating it within the client.
-export interface ChannelClientInterface<Payload = object> {
+export interface ChannelClientInterface {
   /*
     Queuing a message is meant for when the app receives messages from
     the wallet meant for the opponent's app (and hence the opponent's wallet).
   */
-  onMessageQueued: (callback: (message: Message<Payload>) => void) => UnsubscribeFunction;
+  onMessageQueued: (callback: (message: Message<object>) => void) => UnsubscribeFunction;
   onChannelUpdated: (callback: (result: ChannelResult) => void) => UnsubscribeFunction;
   onChannelProposed: (callback: (result: ChannelResult) => void) => UnsubscribeFunction;
   /*
     Pushing a message is meant for when the app receives a message from
     the opponent's app meant for the wallet.
   */
-  pushMessage: (message: Message<Payload>) => Promise<PushMessageResult>;
+  pushMessage: (message: Message<object>) => Promise<PushMessageResult>;
   createChannel: (
     participants: Participant[],
     allocations: Allocation[],

--- a/packages/channel-client/src/types.ts
+++ b/packages/channel-client/src/types.ts
@@ -14,14 +14,14 @@ export interface ChannelClientInterface {
     Queuing a message is meant for when the app receives messages from
     the wallet meant for the opponent's app (and hence the opponent's wallet).
   */
-  onMessageQueued: (callback: (message: Message<object>) => void) => UnsubscribeFunction;
+  onMessageQueued: (callback: (message: Message) => void) => UnsubscribeFunction;
   onChannelUpdated: (callback: (result: ChannelResult) => void) => UnsubscribeFunction;
   onChannelProposed: (callback: (result: ChannelResult) => void) => UnsubscribeFunction;
   /*
     Pushing a message is meant for when the app receives a message from
     the opponent's app meant for the wallet.
   */
-  pushMessage: (message: Message<object>) => Promise<PushMessageResult>;
+  pushMessage: (message: Message) => Promise<PushMessageResult>;
   createChannel: (
     participants: Participant[],
     allocations: Allocation[],
@@ -52,7 +52,7 @@ export interface ChannelClientInterface {
   closeAndWithdraw(hubAddress: string): Promise<SiteBudget | {}>;
 }
 export interface EventsWithArgs {
-  MessageQueued: [Message<ChannelResult>];
+  MessageQueued: [Message];
   ChannelUpdated: [ChannelResult];
   BudgetUpdated: [SiteBudget];
   // TODO: Is `ChannelResult` the right type to use here?

--- a/packages/channel-client/tests/channel-client.test.ts
+++ b/packages/channel-client/tests/channel-client.test.ts
@@ -103,11 +103,11 @@ describe('ChannelClient with FakeChannelProvider', () => {
     // pushed from B's app to B's wallet.
     // The de/queuing described above is effectively faked by explicitly passing
     // the messages between the clients.
-    clientA.onMessageQueued(async (message: Message<ChannelResult>) => {
+    clientA.onMessageQueued(async (message: Message) => {
       await clientB.pushMessage(message);
     });
 
-    clientB.onMessageQueued(async (message: Message<ChannelResult>) => {
+    clientB.onMessageQueued(async (message: Message) => {
       await clientA.pushMessage(message);
     });
 
@@ -117,7 +117,7 @@ describe('ChannelClient with FakeChannelProvider', () => {
   });
 
   describe('creates a channel', () => {
-    let proposalMessage: Message<ChannelResult>;
+    let proposalMessage: Message;
 
     it('client A produces the right channel result', async () => {
       const clientAChannelState = await clientA.createChannel(

--- a/packages/channel-client/tests/channel-client.test.ts
+++ b/packages/channel-client/tests/channel-client.test.ts
@@ -9,8 +9,8 @@ import {
   UPDATED_APP_DATA
 } from './constants';
 import {ChannelResultBuilder, buildParticipant, buildAllocation, setProviderStates} from './utils';
-import {Message, ChannelClient} from '../src';
-import {ChannelResult} from '@statechannels/client-api-schema';
+import {ChannelClient} from '../src';
+import {Message, ChannelResult} from '@statechannels/client-api-schema';
 import {EventsWithArgs} from '../src/types';
 import {calculateChannelId} from '../src/utils';
 import {FakeChannelProvider} from './fakes/fake-channel-provider';

--- a/packages/channel-client/tests/fake-channel-client.test.ts
+++ b/packages/channel-client/tests/fake-channel-client.test.ts
@@ -126,11 +126,11 @@ describe('FakeChannelClient', () => {
     // pushed from B's app to B's wallet.
     // The de/queuing described above is effectively faked by explicitly passing
     // the messages between the clients.
-    clientA.onMessageQueued(async (message: Message<ChannelResult>) => {
+    clientA.onMessageQueued(async (message: Message) => {
       await clientB.pushMessage(message);
     });
 
-    clientB.onMessageQueued(async (message: Message<ChannelResult>) => {
+    clientB.onMessageQueued(async (message: Message) => {
       await clientA.pushMessage(message);
     });
 
@@ -138,7 +138,7 @@ describe('FakeChannelClient', () => {
       clientBEventEmitter.emit('ChannelProposed', result);
     });
 
-    clientC.onMessageQueued(async (message: Message<ChannelResult>) => {
+    clientC.onMessageQueued(async (message: Message) => {
       await clientA.pushMessage(message);
     });
 

--- a/packages/channel-client/tests/fake-channel-client.test.ts
+++ b/packages/channel-client/tests/fake-channel-client.test.ts
@@ -148,7 +148,7 @@ describe('FakeChannelClient', () => {
   });
 
   describe('client A creates channels', () => {
-    let proposalMessageB: Message<ChannelResult>, proposalMessageC: Message<ChannelResult>;
+    let proposalMessageB: Message, proposalMessageC: Message;
 
     it('client A produces the right channel result', async () => {
       const clientChannelStateAB = await clientA.createChannel(

--- a/packages/channel-client/tests/fake-channel-client.test.ts
+++ b/packages/channel-client/tests/fake-channel-client.test.ts
@@ -10,8 +10,8 @@ import {
   UPDATED_APP_DATA
 } from './constants';
 import {ChannelResultBuilder, buildParticipant, buildAllocation, setProviderStates} from './utils';
-import {Message, ChannelClient} from '../src';
-import {ChannelResult} from '@statechannels/client-api-schema';
+import {ChannelClient} from '../src';
+import {Message, ChannelResult} from '@statechannels/client-api-schema';
 import {EventsWithArgs} from '../src/types';
 import {calculateChannelId} from '../src/utils';
 import {FakeChannelProvider} from './fakes/fake-channel-provider';

--- a/packages/channel-client/tests/fakes/fake-channel-provider.ts
+++ b/packages/channel-client/tests/fakes/fake-channel-provider.ts
@@ -1,7 +1,9 @@
 import {
   ChannelProviderInterface,
   MethodResponseType,
-  MethodRequestType
+  MethodRequestType,
+  OnType,
+  OffType
 } from '@statechannels/channel-provider';
 import log = require('loglevel');
 
@@ -86,9 +88,9 @@ export class FakeChannelProvider implements ChannelProviderInterface {
     }
   }
 
-  on = this.events.on;
+  on: OnType = (method, params) => this.events.on(method, params);
 
-  off = this.events.off;
+  off: OffType = (method, params) => this.events.off(method, params);
 
   // subscribe(): Promise<string> {
   //   return Promise.resolve('success');

--- a/packages/channel-client/tests/fakes/fake-channel-provider.ts
+++ b/packages/channel-client/tests/fakes/fake-channel-provider.ts
@@ -92,12 +92,12 @@ export class FakeChannelProvider implements ChannelProviderInterface {
 
   off: OffType = (method, params) => this.events.off(method, params);
 
-  // subscribe(): Promise<string> {
-  //   return Promise.resolve('success');
-  // }
-  // unsubscribe(): Promise<boolean> {
-  //   return Promise.resolve(true);
-  // }
+  subscribe(): Promise<string> {
+    return Promise.resolve('success');
+  }
+  unsubscribe(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
 
   setState(state: ChannelResult): void {
     this.latestState = {...this.latestState, [state.channelId]: state};

--- a/packages/channel-client/tests/fakes/fake-channel-provider.ts
+++ b/packages/channel-client/tests/fakes/fake-channel-provider.ts
@@ -3,7 +3,8 @@ import {
   MethodResponseType,
   MethodRequestType,
   OnType,
-  OffType
+  OffType,
+  EventType
 } from '@statechannels/channel-provider';
 import log = require('loglevel');
 
@@ -19,7 +20,6 @@ import {
   PushMessageResult,
   SiteBudget,
   UpdateChannelParams,
-  NotificationType,
   Message
 } from '@statechannels/client-api-schema';
 import {calculateChannelId} from '../../src/utils';
@@ -34,7 +34,7 @@ type ChannelId = string;
  coming from a non-fake `ChannelClient`.
  */
 export class FakeChannelProvider implements ChannelProviderInterface {
-  private events = new EventEmitter<NotificationType>();
+  private events = new EventEmitter<EventType>();
   protected url = '';
 
   playerIndex: Record<ChannelId, 0 | 1> = {};

--- a/packages/channel-provider/src/channel-provider.ts
+++ b/packages/channel-provider/src/channel-provider.ts
@@ -4,7 +4,9 @@ import {
   ChannelProviderInterface,
   isJsonRpcNotification,
   MethodRequestType,
-  MethodResponseType
+  MethodResponseType,
+  OnType,
+  OffType
 } from './types';
 import {UIService} from './ui-service';
 import {NotificationType} from '@statechannels/client-api-schema';
@@ -31,17 +33,12 @@ class ChannelProvider implements ChannelProviderInterface {
 
   async enable(url?: string) {
     window.addEventListener('message', this.onMessage.bind(this));
-
     if (url) {
       this.url = url;
     }
-
     this.ui.setUrl(this.url);
     this.messaging.setUrl(this.url);
-
     await this.ui.mount();
-
-    // this.events.emit('Connect');
   }
 
   async send(request: MethodRequestType): Promise<MethodResponseType[MethodRequestType['method']]> {
@@ -73,9 +70,9 @@ class ChannelProvider implements ChannelProviderInterface {
   //   return true;
   // }
 
-  on = this.events.on;
+  on: OnType = (method, params) => this.events.on(method, params);
 
-  off = this.events.off;
+  off: OffType = (method, params) => this.events.off(method, params);
 
   protected async onMessage(event: MessageEvent) {
     const message = event.data;

--- a/packages/channel-provider/src/channel-provider.ts
+++ b/packages/channel-provider/src/channel-provider.ts
@@ -6,20 +6,20 @@ import {
   MethodRequestType,
   MethodResponseType,
   OnType,
-  OffType
+  OffType,
+  EventType
 } from './types';
 import {UIService} from './ui-service';
-import {NotificationType} from '@statechannels/client-api-schema';
 
 class ChannelProvider implements ChannelProviderInterface {
-  protected readonly events: EventEmitter<NotificationType>;
+  protected readonly events: EventEmitter<EventType>;
   protected readonly ui: UIService;
   protected readonly messaging: MessagingService;
   // protected readonly subscriptions: {[T in keyof NotificationType]: string[]};
   protected url = '';
 
   constructor() {
-    this.events = new EventEmitter<NotificationType>();
+    this.events = new EventEmitter<EventType>();
     this.ui = new UIService();
     this.messaging = new MessagingService();
     // this.subscriptions = {
@@ -80,11 +80,11 @@ class ChannelProvider implements ChannelProviderInterface {
       return;
     }
 
-    if (isJsonRpcNotification<keyof NotificationType>(message)) {
+    if (isJsonRpcNotification<keyof EventType>(message)) {
       // this line asserts the type. Not currently safe
       const notificationMethod = message.method;
       const notificationParams = message.params;
-      if (message.method === ('UIUpdate' as keyof NotificationType)) {
+      if (message.method === 'UIUpdate') {
         // TODO expand event emitter type to included this, as well as the subscription id stuff
         this.ui.setVisibility(message.params.showWallet);
       }

--- a/packages/channel-provider/src/channel-provider.ts
+++ b/packages/channel-provider/src/channel-provider.ts
@@ -84,9 +84,10 @@ class ChannelProvider implements ChannelProviderInterface {
       // this line asserts the type. Not currently safe
       const notificationMethod = message.method;
       const notificationParams = message.params;
-      // if (eventName === 'UIUpdate') {
-      //   this.ui.setVisibility(message.params.showWallet);
-      // }
+      if (message.method === ('UIUpdate' as keyof NotificationType)) {
+        // TODO expand event emitter type to included this, as well as the subscription id stuff
+        this.ui.setVisibility(message.params.showWallet);
+      }
       this.events.emit(notificationMethod, notificationParams);
       // if (this.subscriptions[notificationMethod]) {
       //   this.subscriptions[notificationMethod].forEach(s => {

--- a/packages/channel-provider/src/channel-provider.ts
+++ b/packages/channel-provider/src/channel-provider.ts
@@ -1,5 +1,6 @@
 import EventEmitter from 'eventemitter3';
 import {MessagingService} from './messaging-service';
+import {Guid} from 'guid-typescript';
 import {
   ChannelProviderInterface,
   isJsonRpcNotification,
@@ -10,25 +11,28 @@ import {
   EventType
 } from './types';
 import {UIService} from './ui-service';
+import {NotificationType, Notification} from '@statechannels/client-api-schema';
 
 class ChannelProvider implements ChannelProviderInterface {
   protected readonly events: EventEmitter<EventType>;
   protected readonly ui: UIService;
   protected readonly messaging: MessagingService;
-  // protected readonly subscriptions: {[T in keyof NotificationType]: string[]};
+  protected readonly subscriptions: {
+    [T in keyof NotificationType]: string[];
+  } = {
+    ChannelProposed: [],
+    ChannelUpdated: [],
+    ChannelClosed: [],
+    BudgetUpdated: [],
+    MessageQueued: [],
+    UIUpdate: []
+  };
   protected url = '';
 
   constructor() {
     this.events = new EventEmitter<EventType>();
     this.ui = new UIService();
     this.messaging = new MessagingService();
-    // this.subscriptions = {
-    //   ChannelProposed: [],
-    //   ChannelUpdated: [],
-    //   ChannelClosed: [],
-    //   BudgetUpdated: [],
-    //   MessageQueued: []
-    // };
   }
 
   async enable(url?: string) {
@@ -52,23 +56,21 @@ class ChannelProvider implements ChannelProviderInterface {
     return response;
   }
 
-  // async subscribe(subscriptionType: string): Promise<string> {
-  //   const subscriptionId = Guid.create().toString();
-  //   if (!this.subscriptions[subscriptionType]) {
-  //     this.subscriptions[subscriptionType] = [];
-  //   }
-  //   this.subscriptions[subscriptionType].push(subscriptionId);
-  //   return subscriptionId;
-  // }
+  async subscribe(subscriptionType: Notification['method']): Promise<string> {
+    const subscriptionId = Guid.create().toString();
+    this.subscriptions[subscriptionType].push(subscriptionId);
+    return subscriptionId;
+  }
 
-  // async unsubscribe(subscriptionId: string): Promise<boolean> {
-  //   Object.keys(this.subscriptions).map(e => {
-  //     this.subscriptions[e] = this.subscriptions[e]
-  //       ? this.subscriptions[e].filter(s => s !== subscriptionId)
-  //       : [];
-  //   });
-  //   return true;
-  // }
+  async unsubscribe(subscriptionId: string): Promise<boolean> {
+    Object.keys(this.subscriptions).forEach(method => {
+      this.subscriptions[method as Notification['method']] = this.subscriptions[
+        method as Notification['method']
+      ].filter((id: string) => id != subscriptionId);
+    });
+
+    return true;
+  }
 
   on: OnType = (method, params) => this.events.on(method, params);
 
@@ -80,20 +82,18 @@ class ChannelProvider implements ChannelProviderInterface {
       return;
     }
 
-    if (isJsonRpcNotification<keyof EventType>(message)) {
+    if (isJsonRpcNotification<keyof NotificationType>(message)) {
       // this line asserts the type. Not currently safe
       const notificationMethod = message.method;
       const notificationParams = message.params;
-      if (message.method === 'UIUpdate') {
-        // TODO expand event emitter type to included this, as well as the subscription id stuff
-        this.ui.setVisibility(message.params.showWallet);
-      }
       this.events.emit(notificationMethod, notificationParams);
-      // if (this.subscriptions[notificationMethod]) {
-      //   this.subscriptions[notificationMethod].forEach(s => {
-      //     this.events.emit(s, notificationParams);
-      //   });
-      // }
+      if (notificationMethod === 'UIUpdate') {
+        this.ui.setVisibility(message.params.showWallet);
+      } else {
+        this.subscriptions[notificationMethod].forEach(id => {
+          this.events.emit(id, notificationParams);
+        });
+      }
     }
   }
 }

--- a/packages/channel-provider/src/channel-provider.ts
+++ b/packages/channel-provider/src/channel-provider.ts
@@ -82,8 +82,8 @@ class ChannelProvider implements ChannelProviderInterface {
       return;
     }
 
-    if (isJsonRpcNotification<keyof NotificationType>(message)) {
-      // this line asserts the type. Not currently safe
+    if (isJsonRpcNotification<keyof NotificationType, any>(message)) {
+      // TODO: use schema validations as better type guards
       const notificationMethod = message.method;
       const notificationParams = message.params;
       this.events.emit(notificationMethod, notificationParams);

--- a/packages/channel-provider/src/channel-provider.ts
+++ b/packages/channel-provider/src/channel-provider.ts
@@ -82,7 +82,7 @@ class ChannelProvider implements ChannelProviderInterface {
       return;
     }
 
-    if (isJsonRpcNotification<keyof NotificationType, any>(message)) {
+    if (isJsonRpcNotification<keyof NotificationType>(message)) {
       // TODO: use schema validations as better type guards
       const notificationMethod = message.method;
       const notificationParams = message.params;

--- a/packages/channel-provider/src/types.ts
+++ b/packages/channel-provider/src/types.ts
@@ -126,7 +126,10 @@ export type MethodRequestType =
   | Call<'GetBudget', GetBudgetRequest>
   | Call<'CloseAndWithdraw', any>;
 
-const eventEmitter = new EventEmitter<NotificationType>();
+export interface EventType extends NotificationType {
+  UIUpdate: [];
+}
+const eventEmitter = new EventEmitter<EventType>();
 export type OnType = typeof eventEmitter.on;
 export type OffType = typeof eventEmitter.off;
 

--- a/packages/channel-provider/src/types.ts
+++ b/packages/channel-provider/src/types.ts
@@ -1,4 +1,4 @@
-import {ListenerFn} from 'eventemitter3';
+import {ListenerFn, EventEmitter} from 'eventemitter3';
 import {
   Request as RequestParams,
   CreateChannelResponse,
@@ -24,7 +24,9 @@ import {
   GetBudgetResponse,
   GetBudgetRequest,
   ApproveBudgetAndFundResponse,
-  ApproveBudgetAndFundRequest
+  ApproveBudgetAndFundRequest,
+  NotificationType,
+  ChannelProposedNotification
 } from '@statechannels/client-api-schema';
 
 export interface JsonRpcRequest<MethodName = string, RequestParams = any> {
@@ -125,11 +127,12 @@ export type MethodRequestType =
   | Call<'GetBudget', GetBudgetRequest>
   | Call<'CloseAndWithdraw', any>;
 
+const eventEmitter = new EventEmitter<NotificationType>();
 export interface ChannelProviderInterface {
   enable(url?: string): Promise<void>;
   send(request: MethodRequestType): Promise<MethodResponseType[MethodRequestType['method']]>;
-  on(event: string, callback: ListenerFn): void;
-  off(event: string, callback?: ListenerFn): void;
+  on: typeof eventEmitter.on;
+  off: typeof eventEmitter.off;
   subscribe(subscriptionType: string, params?: any): Promise<string>;
   unsubscribe(subscriptionId: string): Promise<boolean>;
 }

--- a/packages/channel-provider/src/types.ts
+++ b/packages/channel-provider/src/types.ts
@@ -127,11 +127,14 @@ export type MethodRequestType =
   | Call<'CloseAndWithdraw', any>;
 
 const eventEmitter = new EventEmitter<NotificationType>();
+export type OnType = typeof eventEmitter.on;
+export type OffType = typeof eventEmitter.off;
+
 export interface ChannelProviderInterface {
   enable(url?: string): Promise<void>;
   send(request: MethodRequestType): Promise<MethodResponseType[MethodRequestType['method']]>;
-  on: typeof eventEmitter.on;
-  off: typeof eventEmitter.off;
+  on: OnType;
+  off: OffType;
   // subscribe(subscriptionType: string, params?: any): Promise<string>;
   // unsubscribe(subscriptionId: string): Promise<boolean>;
 }

--- a/packages/channel-provider/src/types.ts
+++ b/packages/channel-provider/src/types.ts
@@ -1,4 +1,4 @@
-import {ListenerFn, EventEmitter} from 'eventemitter3';
+import {EventEmitter} from 'eventemitter3';
 import {
   Request as RequestParams,
   CreateChannelResponse,
@@ -25,8 +25,7 @@ import {
   GetBudgetRequest,
   ApproveBudgetAndFundResponse,
   ApproveBudgetAndFundRequest,
-  NotificationType,
-  ChannelProposedNotification
+  NotificationType
 } from '@statechannels/client-api-schema';
 
 export interface JsonRpcRequest<MethodName = string, RequestParams = any> {
@@ -60,7 +59,7 @@ export interface JsonRpcNotification<NotificationName = string, NotificationPara
   params: NotificationParams;
 }
 
-export function isJsonRpcNotification(message: any): message is JsonRpcNotification {
+export function isJsonRpcNotification<T>(message: any): message is JsonRpcNotification<T, any> {
   return 'method' in message && !('id' in message);
 }
 
@@ -133,6 +132,6 @@ export interface ChannelProviderInterface {
   send(request: MethodRequestType): Promise<MethodResponseType[MethodRequestType['method']]>;
   on: typeof eventEmitter.on;
   off: typeof eventEmitter.off;
-  subscribe(subscriptionType: string, params?: any): Promise<string>;
-  unsubscribe(subscriptionId: string): Promise<boolean>;
+  // subscribe(subscriptionType: string, params?: any): Promise<string>;
+  // unsubscribe(subscriptionId: string): Promise<boolean>;
 }

--- a/packages/channel-provider/src/types.ts
+++ b/packages/channel-provider/src/types.ts
@@ -127,7 +127,7 @@ export type MethodRequestType =
   | Call<'CloseAndWithdraw', any>;
 
 export interface EventType extends NotificationType {
-  UIUpdate: [];
+  [id: string]: [unknown]; // guid
 }
 const eventEmitter = new EventEmitter<EventType>();
 export type OnType = typeof eventEmitter.on;
@@ -138,6 +138,6 @@ export interface ChannelProviderInterface {
   send(request: MethodRequestType): Promise<MethodResponseType[MethodRequestType['method']]>;
   on: OnType;
   off: OffType;
-  // subscribe(subscriptionType: string, params?: any): Promise<string>;
-  // unsubscribe(subscriptionId: string): Promise<boolean>;
+  subscribe(subscriptionType: string, params?: any): Promise<string>;
+  unsubscribe(subscriptionId: string): Promise<boolean>;
 }

--- a/packages/channel-provider/tests/channel-provider.test.ts
+++ b/packages/channel-provider/tests/channel-provider.test.ts
@@ -1,16 +1,16 @@
-import {channelProvider} from '../src/channel-provider';
+// import {channelProvider} from '../src/channel-provider';
 
-describe('ChannelProvider', () => {
-  it('can be enabled', () => {
-    const onMessageSpy = jest.spyOn(window, 'addEventListener');
+// describe('ChannelProvider', () => {
+//   it('can be enabled', () => {
+//     const onMessageSpy = jest.spyOn(window, 'addEventListener');
 
-    return new Promise(done => {
-      channelProvider.on('Connect', () => {
-        expect(onMessageSpy).toHaveBeenCalled();
-        done();
-      });
+//     return new Promise(done => {
+//       channelProvider.on('Connect', () => {
+//         expect(onMessageSpy).toHaveBeenCalled();
+//         done();
+//       });
 
-      channelProvider.enable();
-    });
-  });
-});
+//       channelProvider.enable();
+//     });
+//   });
+// });

--- a/packages/channel-provider/tests/channel-provider.test.ts
+++ b/packages/channel-provider/tests/channel-provider.test.ts
@@ -1,16 +1,11 @@
-// import {channelProvider} from '../src/channel-provider';
+import {channelProvider} from '../src/channel-provider';
 
-// describe('ChannelProvider', () => {
-//   it('can be enabled', () => {
-//     const onMessageSpy = jest.spyOn(window, 'addEventListener');
+describe('ChannelProvider', () => {
+  it('can be enabled', () => {
+    const onMessageSpy = jest.spyOn(window, 'addEventListener');
 
-//     return new Promise(done => {
-//       channelProvider.on('Connect', () => {
-//         expect(onMessageSpy).toHaveBeenCalled();
-//         done();
-//       });
+    channelProvider.enable('www.test.com');
 
-//       channelProvider.enable();
-//     });
-//   });
-// });
+    expect(onMessageSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -1046,6 +1046,25 @@
         }
       ]
     },
+    "NotificationType": {
+      "additionalProperties": false,
+      "properties": {
+        "ChannelProposed": {
+          "items": [
+            {
+              "$ref": "#/definitions/ChannelResult"
+            }
+          ],
+          "maxItems": 1,
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "ChannelProposed"
+      ],
+      "type": "object"
+    },
     "Participant": {
       "additionalProperties": false,
       "properties": {

--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -1043,6 +1043,9 @@
         },
         {
           "$ref": "#/definitions/MessageQueuedNotification"
+        },
+        {
+          "$ref": "#/definitions/UiNotification"
         }
       ]
     },
@@ -1339,6 +1342,41 @@
         "free",
         "inUse",
         "direct"
+      ],
+      "type": "object"
+    },
+    "UiNotification": {
+      "additionalProperties": false,
+      "properties": {
+        "jsonrpc": {
+          "enum": [
+            "2.0"
+          ],
+          "type": "string"
+        },
+        "method": {
+          "enum": [
+            "UIUpdate"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": false,
+          "properties": {
+            "showWallet": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "showWallet"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
       ],
       "type": "object"
     },

--- a/packages/client-api-schema/src/types.ts
+++ b/packages/client-api-schema/src/types.ts
@@ -190,12 +190,28 @@ export type ChannelClosingNotification = JsonRpcNotification<'ChannelClosed', Ch
 export type MessageQueuedNotification = JsonRpcNotification<'MessageQueued', Message>;
 export type BudgetUpdatedNotification = JsonRpcNotification<'BudgetUpdated', SiteBudget>;
 
+// these notifications come *from* the wallet, which is not how JSON-RPC works
 export type Notification =
   | ChannelProposedNotification
   | ChannelUpdatedNotification
   | ChannelClosingNotification
   | BudgetUpdatedNotification
   | MessageQueuedNotification;
+
+type FilterByMethod<T, Method> = T extends {method: Method} ? T : never;
+
+export type NotificationType = {
+  [T in Notification['method']]: [FilterByMethod<Notification, T>['params']];
+};
+
+// export interface NotificationType {
+//   // TODO this more safely
+//   ChannelProposed: [ChannelProposedNotification['params']];
+//   ChannelUpdated: [ChannelUpdatedNotification['params']];
+//   ChannelClosed: [ChannelClosingNotification['params']];
+//   BudgetUpdated: [BudgetUpdatedNotification['params']];
+//   MessageQueued: [MessageQueuedNotification['params']];
+// }
 
 export type Request =
   | GetAddressRequest

--- a/packages/client-api-schema/src/types.ts
+++ b/packages/client-api-schema/src/types.ts
@@ -204,15 +204,6 @@ export type NotificationType = {
   [T in Notification['method']]: [FilterByMethod<Notification, T>['params']];
 };
 
-// export interface NotificationType {
-//   // TODO this more safely
-//   ChannelProposed: [ChannelProposedNotification['params']];
-//   ChannelUpdated: [ChannelUpdatedNotification['params']];
-//   ChannelClosed: [ChannelClosingNotification['params']];
-//   BudgetUpdated: [BudgetUpdatedNotification['params']];
-//   MessageQueued: [MessageQueuedNotification['params']];
-// }
-
 export type Request =
   | GetAddressRequest
   | GetEthereumSelectedAddressRequest

--- a/packages/client-api-schema/src/types.ts
+++ b/packages/client-api-schema/src/types.ts
@@ -190,13 +190,17 @@ export type ChannelClosingNotification = JsonRpcNotification<'ChannelClosed', Ch
 export type MessageQueuedNotification = JsonRpcNotification<'MessageQueued', Message>;
 export type BudgetUpdatedNotification = JsonRpcNotification<'BudgetUpdated', SiteBudget>;
 
-// these notifications come *from* the wallet, which is not how JSON-RPC works
+export type UiNotification = JsonRpcNotification<'UIUpdate', {showWallet: boolean}>;
+// these notifications come *from* the wallet, which is not strictly how JSON-RPC should work
+// (since we treat the wallet as the 'server')
+
 export type Notification =
   | ChannelProposedNotification
   | ChannelUpdatedNotification
   | ChannelClosingNotification
   | BudgetUpdatedNotification
-  | MessageQueuedNotification;
+  | MessageQueuedNotification
+  | UiNotification;
 
 type FilterByMethod<T, Method> = T extends {method: Method} ? T : never;
 

--- a/packages/client-api-schema/src/types.ts
+++ b/packages/client-api-schema/src/types.ts
@@ -184,15 +184,14 @@ export type CloseAndWithdrawParams = {site: string; player: Participant; hub: Pa
 export type CloseAndWithdrawRequest = JsonRpcRequest<'CloseAndWithdraw', CloseAndWithdrawParams>;
 export type CloseAndWithdrawResponse = JsonRpcResponse<{success: boolean}>;
 // Notifications
+// these notifications come *from* the wallet, which is not strictly how JSON-RPC should work
+// (since we treat the wallet as the 'server')
 export type ChannelProposedNotification = JsonRpcNotification<'ChannelProposed', ChannelResult>;
 export type ChannelUpdatedNotification = JsonRpcNotification<'ChannelUpdated', ChannelResult>;
 export type ChannelClosingNotification = JsonRpcNotification<'ChannelClosed', ChannelResult>;
 export type MessageQueuedNotification = JsonRpcNotification<'MessageQueued', Message>;
 export type BudgetUpdatedNotification = JsonRpcNotification<'BudgetUpdated', SiteBudget>;
-
 export type UiNotification = JsonRpcNotification<'UIUpdate', {showWallet: boolean}>;
-// these notifications come *from* the wallet, which is not strictly how JSON-RPC should work
-// (since we treat the wallet as the 'server')
 
 export type Notification =
   | ChannelProposedNotification

--- a/packages/client-api-schema/src/types.ts
+++ b/packages/client-api-schema/src/types.ts
@@ -62,12 +62,10 @@ export interface Allocation {
 
 export type Allocations = Allocation[]; // included for backwards compatibility
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface Message<T = any> {
+export interface Message {
   recipient: string; // Identifier of user that the message should be relayed to
   sender: string; // Identifier of user that the message is from
-  data: T; // Message payload. Format defined by wallet and opaque to app.
-  // But useful to be able to specify, for the purposes of the fake-client
+  data: unknown; // Message payload. Format defined by wallet and opaque to app.
 }
 
 export interface Funds {

--- a/packages/rps/src/redux/message-service/firebase-inbox-listener.ts
+++ b/packages/rps/src/redux/message-service/firebase-inbox-listener.ts
@@ -2,9 +2,9 @@ import {take, call, apply} from 'redux-saga/effects';
 
 import {default as firebase, reduxSagaFirebase} from '../../gateways/firebase';
 import {RPSChannelClient} from '../../utils/rps-channel-client';
-import {Message} from '@statechannels/channel-client';
 import {buffers} from 'redux-saga';
 import {FIREBASE_PREFIX} from '../../constants';
+import {Message} from '@statechannels/client-api-schema';
 
 export function* firebaseInboxListener(client: RPSChannelClient, address: string) {
   const channel = yield call(

--- a/packages/rps/src/utils/rps-channel-client.ts
+++ b/packages/rps/src/utils/rps-channel-client.ts
@@ -1,7 +1,8 @@
 import {AppData, ChannelState, encodeAppData, decodeAppData} from '../core';
-import {ChannelResult, Message, ChannelClientInterface} from '@statechannels/channel-client';
+import {ChannelResult, ChannelClientInterface} from '@statechannels/channel-client';
 import {RPS_ADDRESS} from '../constants';
 import {bigNumberify} from 'ethers/utils';
+import {Message} from '@statechannels/client-api-schema';
 
 // This class wraps the channel client converting the request/response formats to those used in the app
 

--- a/packages/wallet/src/redux/sagas/messaging/message-handler.ts
+++ b/packages/wallet/src/redux/sagas/messaging/message-handler.ts
@@ -211,16 +211,17 @@ function* handlePushMessage(payload: RequestObject) {
   // TODO: We need to handle the case where we receive an invalid wallet message
   const {id} = payload;
   const message = payload.params as PushMessageParams;
+  const messageData = message.data as any;
   if (isRelayableAction(message.data)) {
     yield put(message.data);
     yield fork(messageSender, outgoingMessageActions.pushMessageResponse({id}));
   } else {
-    switch (message.data.type) {
+    switch (messageData.type) {
       case "Channel.Updated":
         yield put(
           actions.application.opponentStateReceived({
             processId: APPLICATION_PROCESS_ID,
-            signedState: message.data.signedState
+            signedState: messageData.signedState
           })
         );
         yield fork(messageSender, outgoingMessageActions.pushMessageResponse({id}));
@@ -228,7 +229,7 @@ function* handlePushMessage(payload: RequestObject) {
         yield fork(
           messageSender,
           outgoingMessageActions.channelUpdatedEvent({
-            channelId: getChannelId(message.data.signedState.state.channel)
+            channelId: getChannelId(messageData.signedState.state.channel)
           })
         );
 
@@ -237,26 +238,26 @@ function* handlePushMessage(payload: RequestObject) {
         yield put(
           actions.application.opponentStateReceived({
             processId: APPLICATION_PROCESS_ID,
-            signedState: message.data.signedState
+            signedState: messageData.signedState
           })
         );
 
         yield put(
           fundingRequested({
-            channelId: getChannelId(message.data.signedState.state.channel),
+            channelId: getChannelId(messageData.signedState.state.channel),
             playerIndex: TwoPartyPlayerIndex.A
           })
         );
         yield fork(
           messageSender,
           outgoingMessageActions.channelUpdatedEvent({
-            channelId: getChannelId(message.data.signedState.state.channel)
+            channelId: getChannelId(messageData.signedState.state.channel)
           })
         );
         yield fork(messageSender, outgoingMessageActions.pushMessageResponse({id}));
         break;
       case "Channel.Open":
-        const {signedState, participants} = message.data;
+        const {signedState, participants} = messageData;
         // The channel gets initialized and the state will be pushed into the app protocol
         // If the client doesn't want to join the channel then we dispose of these on that API call
         // Since only our wallet can progress the app protocol from this point by signing the next state
@@ -304,7 +305,7 @@ function* handlePushMessage(payload: RequestObject) {
         );
         break;
       default:
-        console.error(`Could not handle message data with type ${message.data.type}`);
+        console.error(`Could not handle message data with type ${messageData.type}`);
     }
   }
 }

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -110,7 +110,6 @@ export class PaymentChannelClient {
   // Accepts an payment-channel-friendly callback, performs the necessary encoding, and subscribes to the channelClient with an appropriate, API-compliant callback
   onChannelUpdated(web3tCallback: (channelState: ChannelState) => any) {
     function callback(channelResult: ChannelResult): any {
-      console.log('on channel updated' + JSON.stringify(channelResult));
       web3tCallback(convertToChannelState(channelResult));
     }
     const unsubChannelUpdated = this.channelClient.onChannelUpdated(callback);
@@ -291,7 +290,6 @@ export const paymentChannelClient = new PaymentChannelClient(
 );
 
 const convertToChannelState = (channelResult: ChannelResult): ChannelState => {
-  console.log('trying to convert' + JSON.stringify(channelResult) + 'to a channel state');
   const {
     turnNum,
     channelId,

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -235,9 +235,14 @@ export class PaymentChannelClient {
     );
   }
 
-  amProposer(channelId: string): boolean {
-    return this.channelCache[channelId].beneficiary === this.mySigningAddress;
+  amProposer(channelIdOrChannelState: string | ChannelState): boolean {
+    if (typeof channelIdOrChannelState === 'string') {
+      return this.channelCache[channelIdOrChannelState].beneficiary === this.mySigningAddress;
+    } else {
+      return channelIdOrChannelState.beneficiary === this.mySigningAddress;
+    }
   }
+
   isPaymentToMe(channelState: ChannelState): boolean {
     // doesn't guarantee that my balance increased
     if (channelState.beneficiary === this.mySigningAddress) {

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -257,7 +257,6 @@ export class PaymentChannelClient {
 
   async pushMessage(message: Message) {
     await this.channelClient.pushMessage(message);
-    return convertToChannelState(message.data);
   }
 
   async approveBudgetAndFund(

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -1,8 +1,8 @@
-import {ChannelResult, Message, ChannelClientInterface} from '@statechannels/channel-client';
+import {ChannelResult, ChannelClientInterface} from '@statechannels/channel-client';
 import {utils, constants} from 'ethers';
 import {FakeChannelProvider} from '@statechannels/channel-client';
 import {ChannelClient} from '@statechannels/channel-client';
-import {ChannelStatus} from '@statechannels/client-api-schema';
+import {ChannelStatus, Message} from '@statechannels/client-api-schema';
 import {SiteBudget} from '@statechannels/client-api-schema';
 
 const bigNumberify = utils.bigNumberify;

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -255,7 +255,7 @@ export class PaymentChannelClient {
     return channelState.turnNum.eq(FINAL_SETUP_STATE) ? true : false;
   }
 
-  async pushMessage(message: Message<ChannelResult>) {
+  async pushMessage(message: Message) {
     await this.channelClient.pushMessage(message);
     return convertToChannelState(message.data);
   }

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -110,6 +110,7 @@ export class PaymentChannelClient {
   // Accepts an payment-channel-friendly callback, performs the necessary encoding, and subscribes to the channelClient with an appropriate, API-compliant callback
   onChannelUpdated(web3tCallback: (channelState: ChannelState) => any) {
     function callback(channelResult: ChannelResult): any {
+      console.log('on channel updated' + JSON.stringify(channelResult));
       web3tCallback(convertToChannelState(channelResult));
     }
     const unsubChannelUpdated = this.channelClient.onChannelUpdated(callback);
@@ -290,6 +291,7 @@ export const paymentChannelClient = new PaymentChannelClient(
 );
 
 const convertToChannelState = (channelResult: ChannelResult): ChannelState => {
+  console.log('trying to convert' + JSON.stringify(channelResult) + 'to a channel state');
   const {
     turnNum,
     channelId,

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -294,7 +294,8 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     // If a channel is proposed, join it
     this.paymentChannelClient.onChannelProposed(async (channelState: ChannelState) => {
       log(channelState);
-      if (!this.paymentChannelClient.amProposer(channelState.channelId)) {
+      if (!this.paymentChannelClient.amProposer(channelState)) {
+        // do not pass a channelId, since this is the first we heard about this channel and it won't be cached
         // only join if counterparty proposed
         await this.paymentChannelClient.joinChannel(channelState.channelId);
         log(`Joined channel ${channelState.channelId}`);

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -281,11 +281,11 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
 
     // If the wallet queues a message, send it across the wire
     this.paymentChannelClient.onMessageQueued((message: Message | any) => {
+      log('message queued event' + JSON.stringify(message));
       // TODO remove any
       if ('params' in message) {
         message = message.params; // peel off jsonrpc headers
       } // else there are no headers with the fake provider
-      log('message queued event' + JSON.stringify(message));
       if (message.recipient === wire.paidStreamingExtension.peerAccount) {
         wire.paidStreamingExtension.sendMessage(JSON.stringify(message));
       }
@@ -293,7 +293,6 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
 
     // If a channel is proposed, join it
     this.paymentChannelClient.onChannelProposed(async (channelState: ChannelState) => {
-      log(channelState);
       if (!this.paymentChannelClient.amProposer(channelState)) {
         // do not pass a channelId, since this is the first we heard about this channel and it won't be cached
         // only join if counterparty proposed

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -16,10 +16,11 @@ import {
 } from './types';
 import {utils} from 'ethers';
 import {ChannelState, PaymentChannelClient} from '../clients/payment-channel-client';
-import {Message, ChannelResult} from '@statechannels/channel-client';
+import {ChannelResult} from '@statechannels/channel-client';
 import {mockTorrents} from '../constants';
 import * as firebase from 'firebase/app';
 import 'firebase/database';
+import {Message} from '@statechannels/client-api-schema';
 
 const bigNumberify = utils.bigNumberify;
 const log = debug('web3torrent:library');

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -282,7 +282,6 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
 
     // If the wallet queues a message, send it across the wire
     this.paymentChannelClient.onMessageQueued((message: Message) => {
-      log('message queued event' + JSON.stringify(message));
       if (message.recipient === wire.paidStreamingExtension.peerAccount) {
         wire.paidStreamingExtension.sendMessage(JSON.stringify(message));
       }

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -367,7 +367,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
 
     torrent.on(TorrentEvents.NOTICE, async (wire, {command, data}) => {
       log(`< ${command} received from ${wire.peerExtendedHandshake.pseAccount}`, data);
-      let message: Message<ChannelResult>;
+      let message: Message;
       switch (command) {
         case PaidStreamingExtensionNotices.STOP: // synonymous with a prompt for a payment
           if (!torrent.done) {

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -16,7 +16,6 @@ import {
 } from './types';
 import {utils} from 'ethers';
 import {ChannelState, PaymentChannelClient} from '../clients/payment-channel-client';
-import {ChannelResult} from '@statechannels/channel-client';
 import {mockTorrents} from '../constants';
 import * as firebase from 'firebase/app';
 import 'firebase/database';

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -281,12 +281,8 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     );
 
     // If the wallet queues a message, send it across the wire
-    this.paymentChannelClient.onMessageQueued((message: Message | any) => {
+    this.paymentChannelClient.onMessageQueued((message: Message) => {
       log('message queued event' + JSON.stringify(message));
-      // TODO remove any
-      if ('params' in message) {
-        message = message.params; // peel off jsonrpc headers
-      } // else there are no headers with the fake provider
       if (message.recipient === wire.paidStreamingExtension.peerAccount) {
         wire.paidStreamingExtension.sendMessage(JSON.stringify(message));
       }


### PR DESCRIPTION
This work was spurred by seeing runtime errors due to unexpected types emitted from the provider, as well as discrepancy in types coming from fake vs real providers. 

I believe the second issue to be solved by this PR.

The first issue is not (and possibly cannot be) solved by tinkering with types in the provider. But we can probably diagnose the issue by doing validation of messages *from* the wallet against our schema (see #1266 ) . That work should be much easier given the greater clarity that (I hope) this PR brings to the various JSON RPC types. 