### PR TITLE
[TTT] Fix type import errors

### DIFF
--- a/packages/rps/package.json
+++ b/packages/rps/package.json
@@ -67,6 +67,7 @@
     "@babel/runtime": "7.8.3",
     "@sentry/browser": "5.12.1",
     "@statechannels/channel-provider": "*",
+    "@statechannels/client-api-schema": "0.0.1",
     "@statechannels/devtools": "0.1.21",
     "@statechannels/jest-gas-reporter": "0.0.2",
     "@storybook/react": "5.3.9",

--- a/packages/tic-tac-toe/app/services/ttt-channel-client.ts
+++ b/packages/tic-tac-toe/app/services/ttt-channel-client.ts
@@ -1,10 +1,10 @@
 import Service from '@ember/service';
 import {
   ChannelResult,
-  Message,
   ChannelClientInterface,
   UnsubscribeFunction
 } from '@statechannels/channel-client';
+import {Message} from '@statechannels/client-api-schema';
 import {AppData, encodeAppData, decodeAppData} from '../core/app-data';
 import {ChannelState} from '../core/channel-state';
 import ENV from '@statechannels/tic-tac-toe/config/environment';

--- a/packages/tic-tac-toe/package.json
+++ b/packages/tic-tac-toe/package.json
@@ -80,6 +80,7 @@
     "@types/webpack-dev-server": "3.9.0",
     "@types/webpack-manifest-plugin": "2.1.0",
     "@types/yargs": "15.0.2",
+    "@statechannels/client-api-schema": "0.0.1",
     "babel-eslint": "10.0.3",
     "babel-loader": "8.0.6",
     "babel-polyfill": "6.26.0",


### PR DESCRIPTION
Fixes a type import error.
An import was moved in this PR and wasn't update for TTT.
https://github.com/statechannels/monorepo/pull/1264

This also adds `@statechannels/client-api-schema` as a devDependency of RPS and TTT as they both import from this package.