### PR TITLE
[web3t] Add start:shared-ganache script to web3t

### DIFF
--- a/packages/web3torrent/package.json
+++ b/packages/web3torrent/package.json
@@ -132,6 +132,7 @@
     "prettier:write": "prettier --write '**/*.{scss,json}' --ignore-path '.eslintignore'",
     "start": "node scripts/start.js",
     "start:alt": "PORT=3333 node scripts/start.js",
+    "start:shared-ganache": "NODE_ENV=development npx start-shared-ganache",
     "storybook": "start-storybook -s ./public -p 4568",
     "test": "TRACKER_URL=http://localhost:4242/announce react-scripts test",
     "test:ci": "CI=true yarn test --runInBand --ci --all --forceExit",


### PR DESCRIPTION
Brings it into line with our other apps -- it is necessary to run this command before `yarn start`