### PR TITLE
[w3t] Patch un-enabled provider on w3t

### DIFF
--- a/packages/channel-client/tests/fakes/fake-channel-provider.ts
+++ b/packages/channel-client/tests/fakes/fake-channel-provider.ts
@@ -47,6 +47,14 @@ export class FakeChannelProvider implements ChannelProviderInterface {
   opponentAddress: Record<ChannelId, string> = {};
   latestState: Record<ChannelId, ChannelResult> = {};
 
+  constructor(alreadyEnabled = true) {
+    if (alreadyEnabled) {
+      this.signingAddress = this.getAddress();
+      this.selectedAddress = '0xEthereumSelectedAddress';
+      this.walletVersion = 'FakeChannelProvider@VersionTBD';
+    }
+  }
+
   async mountWalletComponent(url?: string): Promise<void> {
     this.url = url || '';
   }
@@ -128,7 +136,7 @@ export class FakeChannelProvider implements ChannelProviderInterface {
     }
   }
 
-  private async getAddress(): Promise<string> {
+  private getAddress(): string {
     if (this.internalAddress === undefined) {
       throw Error('No address has been set yet');
     }

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -70,8 +70,10 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
   }
 
   async enable() {
-    log('Enabling Channel Provider...');
+    log('Mounting Wallet to App...');
     await window.channelProvider.mountWalletComponent(process.env.REACT_APP_WALLET_URL);
+    log('Enabling Channel Provider...');
+    await window.channelProvider.enable();
     log('Enabling WebTorrentPaidStreamingClient...');
     this.pseAccount = this.paymentChannelClient.mySigningAddress;
     log('set pseAccount to sc-wallet signing address');

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -56,10 +56,11 @@ function sanitizeMessageForFirebase(message) {
 // A Whimsical diagram explaining the functionality of Web3Torrent: https://whimsical.com/Sq6whAwa8aTjbwMRJc7vPU
 export default class WebTorrentPaidStreamingClient extends WebTorrent {
   peersList: PeersByTorrent;
-  pseAccount: string;
   torrents: PaidStreamingTorrent[] = [];
-  outcomeAddress: string;
   paymentChannelClient: PaymentChannelClient;
+
+  pseAccount: string;
+  outcomeAddress: string;
 
   constructor(opts: WebTorrent.Options & Partial<PaidStreamingExtensionOptions> = {}) {
     super(opts);


### PR DESCRIPTION
Fix error not noticed in tests due to `tic-tac-toe` error overtaking it... merged too recklessly.