### PR TITLE
Remove build:netlify from packages with manual netlify deployment

### DIFF
--- a/packages/rps/package.json
+++ b/packages/rps/package.json
@@ -186,7 +186,6 @@
   "scripts": {
     "build": "run-s build:typescript build:webpack",
     "build:ci": "run-s build:typescript contracts:compile",
-    "build:netlify": "NODE_ENV=production yarn build:webpack",
     "build:typescript": "npx tsc -b",
     "build:webpack": "CI=false node scripts/build.js",
     "contracts:compile": "node ./bin/compile.js",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -169,7 +169,6 @@
   "scripts": {
     "build": "run-s build:typescript build:webpack",
     "build:ci": "yarn build:typescript",
-    "build:netlify": "NODE_ENV=production yarn build:webpack",
     "build:typescript": "npx tsc -b",
     "build:webpack": "CI=false node scripts/build.js",
     "lint:check": "eslint \"src/**/*.{js,ts,tsx}\" --cache",

--- a/packages/xstate-wallet/package.json
+++ b/packages/xstate-wallet/package.json
@@ -67,7 +67,6 @@
   "scripts": {
     "build": "npx webpack --config ./webpack-build.config.js",
     "build:ci": "yarn build",
-    "build:netlify": "NODE_ENV=production yarn build",
     "generateConfigs": "yarn run ts-node bin/generateConfigs.ts",
     "lint:check": "eslint . --ext .ts --cache",
     "lint:write": "eslint . --ext .ts --fix",


### PR DESCRIPTION
The upside of including `build:netlify` is that CI tests that all packages hosted on netlify can be built for netlify when the package changes and on all master CI runs. The downside is that we are seeing [out-of-memory errors](https://app.circleci.com/pipelines/github/statechannels/monorepo/4464/workflows/7f137d70-7283-49b9-a440-68e22a5ba936/jobs/16026) even with concurrency set to 2.