### PR TITLE
[channel - provider] Do not populateProviderProps() until enabled

### DIFF
--- a/packages/channel-provider/src/channel-provider.ts
+++ b/packages/channel-provider/src/channel-provider.ts
@@ -48,7 +48,6 @@ class ChannelProvider implements ChannelProviderInterface {
     this.messaging.setUrl(this.url);
     await this.ui.mount();
     console.info('Application successfully mounted Wallet iFrame inside DOM.');
-    await this.populateProviderProperties();
   }
 
   async enable() {


### PR DESCRIPTION
If I clear my metamask connections, then I get a metamask not enabled error:

![Screenshot 2020-03-24 at 10 34 23](https://user-images.githubusercontent.com/1833419/77417768-c3d53d80-6dbd-11ea-91be-a027e8132d4a.png)

We should only ever try to populate these properties once we have enabled ethereum in the wallet (in web3torrent we do this immediately afterwards anyway). 