### PR TITLE
[xstate-wallet] Validate messages in + out

### DIFF
--- a/packages/xstate-wallet/src/integration-tests/approve-budget.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/approve-budget.test.ts
@@ -6,7 +6,7 @@ import {FundLedger} from '../store/types';
 import {checkThat} from '../utils';
 import {isSimpleEthAllocation} from '../utils/outcome';
 
-import {bigNumberify} from 'ethers/utils';
+import {bigNumberify, hexZeroPad} from 'ethers/utils';
 import {ApproveBudgetAndFundResponse} from '@statechannels/client-api-schema/src';
 
 jest.setTimeout(30000);
@@ -69,11 +69,11 @@ it('allows for a wallet to approve a budget and fund with the hub', async () => 
   const allocation = checkThat(ledgerEntry.supported.outcome, isSimpleEthAllocation);
   expect(allocation.allocationItems).toContainEqual({
     destination: hub.destination,
-    amount: bigNumberify('0x5')
+    amount: bigNumberify(hexZeroPad('0x5', 32))
   });
   expect(allocation.allocationItems).toContainEqual({
     destination: playerA.destination,
-    amount: bigNumberify('0x5')
+    amount: bigNumberify(hexZeroPad('0x5', 32))
   });
   // Check that the funds are reflected on chain
   const chainInfo = await playerA.store.chain.getChainInfo(ledgerEntry.channelId);

--- a/packages/xstate-wallet/src/integration-tests/close-withdraw.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/close-withdraw.test.ts
@@ -30,12 +30,16 @@ it('allows for a wallet to close the ledger channel with the hub and withdraw', 
   ]);
   hookUpMessaging(playerA, hub);
 
-  const ledgerChannel = await playerA.store.createChannel([playerA, hub], CHALLENGE_DURATION, {
-    outcome,
-    turnNum: bigNumberify(20),
-    isFinal: false,
-    appData: '0x0'
-  });
+  const ledgerChannel = await playerA.store.createChannel(
+    [playerA.participant, hub.participant],
+    CHALLENGE_DURATION,
+    {
+      outcome,
+      turnNum: bigNumberify(20),
+      isFinal: false,
+      appData: '0x0'
+    }
+  );
 
   await playerA.store.setLedger(ledgerChannel.channelId);
   await hub.store

--- a/packages/xstate-wallet/src/integration-tests/closing.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/closing.test.ts
@@ -1,6 +1,6 @@
 import {FakeChain} from '../chain';
 import {Player, hookUpMessaging, generateCloseRequest} from './helpers';
-import {bigNumberify} from 'ethers/utils';
+import {bigNumberify, hexZeroPad} from 'ethers/utils';
 import waitForExpect from 'wait-for-expect';
 import {simpleEthAllocation} from '../utils/outcome';
 import {State, SignedState} from '../store/types';
@@ -25,11 +25,11 @@ test('concludes on their turn', async () => {
   const outcome = simpleEthAllocation([
     {
       destination: playerA.destination,
-      amount: bigNumberify('0x06f05b59d3b20000')
+      amount: bigNumberify(hexZeroPad('0x06f05b59d3b20000', 32))
     },
     {
       destination: playerA.destination,
-      amount: bigNumberify('0x06f05b59d3b20000')
+      amount: bigNumberify(hexZeroPad('0x06f05b59d3b20000', 32))
     }
   ]);
 

--- a/packages/xstate-wallet/src/integration-tests/helpers.ts
+++ b/packages/xstate-wallet/src/integration-tests/helpers.ts
@@ -19,6 +19,7 @@ import * as CreateAndFundLedger from '../workflows/create-and-fund-ledger';
 import {Guid} from 'guid-typescript';
 import * as CloseLedgerAndWithdraw from '../workflows/close-ledger-and-withdraw';
 import {TestStore} from '../workflows/tests/store';
+import {hexZeroPad} from 'ethers/utils';
 
 export class Player {
   privateKey: string;
@@ -78,7 +79,7 @@ export class Player {
     return this.channelWallet.workflows[0]?.machine.state.value;
   }
   get destination() {
-    return '0x63e3fb11830c01ac7c9c64091c14bb6cbaac9ac7';
+    return hexZeroPad('0x63e3fb11830c01ac7c9c64091c14bb6cbaac9ac7', 32);
   }
   get participant(): Participant {
     return {

--- a/packages/xstate-wallet/src/messaging.ts
+++ b/packages/xstate-wallet/src/messaging.ts
@@ -132,7 +132,7 @@ export class MessagingService implements MessagingServiceInterface {
       const notification = {
         jsonrpc: '2.0',
         method: 'MessageQueued',
-        params: serializeMessage(message, recipient, sender)
+        params: validateMessage(serializeMessage(message, recipient, sender))
       } as Notification; // typescript can't handle this otherwise
       this.eventEmitter.emit('SendMessage', notification);
     });

--- a/packages/xstate-wallet/src/messaging.ts
+++ b/packages/xstate-wallet/src/messaging.ts
@@ -22,7 +22,7 @@ import * as jrs from 'jsonrpc-lite';
 
 import {fromEvent, Observable} from 'rxjs';
 import {ChannelStoreEntry} from './store/channel-store-entry';
-import {Message as WireMessage} from '@statechannels/wire-format';
+import {validateMessage} from '@statechannels/wire-format';
 import {unreachable} from './utils';
 import {isAllocation, Message, SiteBudget} from './store/types';
 import {serializeAllocation, serializeSiteBudget} from './serde/app-messages/serialize';
@@ -173,8 +173,7 @@ export class MessagingService implements MessagingServiceInterface {
         this.eventEmitter.emit('AppRequest', appRequest);
         break;
       case 'PushMessage':
-        // TODO: should verify message format here
-        const message = request.params as WireMessage;
+        const message = validateMessage(request.params);
         if (message.recipient !== (await this.store.getAddress())) {
           throw new Error(`Received message not addressed to us ${JSON.stringify(message)}`);
         }

--- a/packages/xstate-wallet/src/serde/wire-format/serde.test.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/serde.test.ts
@@ -20,5 +20,6 @@ it('works for a message', () => {
 });
 
 it('creates valid wire format', () => {
-  expect(() => validateState(serializeState(internalStateFormat))).not.toThrow();
+  const serializedState = serializeState(internalStateFormat);
+  expect(() => validateState(serializedState)).not.toThrow();
 });

--- a/packages/xstate-wallet/src/serde/wire-format/serialize.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/serialize.ts
@@ -7,6 +7,7 @@ import {
 } from '@statechannels/wire-format';
 import {SignedState, Outcome, AllocationItem, SimpleAllocation, Message} from '../../store/types';
 import {calculateChannelId} from '../../store/state-utils';
+import {BigNumber} from 'ethers/utils';
 
 export function serializeMessage(message: Message, recipient: string, sender: string): WireMessage {
   const signedStates = (message.signedStates || []).map(ss => {
@@ -20,15 +21,26 @@ export function serializeMessage(message: Message, recipient: string, sender: st
   };
 }
 
+function bigNumberToUint256(bigNumber: BigNumber): string {
+  return (
+    '0x' +
+    bigNumber
+      .toHexString()
+      .slice(2)
+      .padStart(64, '0')
+  );
+}
 export function serializeState(state: SignedState): SignedStateWire {
-  return {
+  const sswire = {
     ...state,
-    challengeDuration: state.challengeDuration.toHexString(),
-    channelNonce: state.channelNonce.toHexString(),
-    turnNum: state.turnNum.toHexString(),
+    challengeDuration: bigNumberToUint256(state.challengeDuration),
+    channelNonce: bigNumberToUint256(state.channelNonce),
+    turnNum: bigNumberToUint256(state.turnNum),
     outcome: serializeOutcome(state.outcome),
     channelId: calculateChannelId(state)
   };
+  console.log('serializing' + JSON.stringify(state) + ' to ' + JSON.stringify(sswire));
+  return sswire;
 }
 
 function serializeOutcome(outcome: Outcome): OutcomeWire {
@@ -52,5 +64,5 @@ function serializeSimpleAllocation(allocation: SimpleAllocation): AllocationWire
 
 function serializeAllocationItem(allocationItem: AllocationItem): AllocationItemWire {
   const {destination, amount} = allocationItem;
-  return {destination, amount: amount.toHexString()};
+  return {destination, amount: bigNumberToUint256(amount)};
 }

--- a/packages/xstate-wallet/src/serde/wire-format/serialize.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/serialize.ts
@@ -31,7 +31,7 @@ function bigNumberToUint256(bigNumber: BigNumber): string {
   );
 }
 export function serializeState(state: SignedState): SignedStateWire {
-  const sswire = {
+  return {
     ...state,
     challengeDuration: bigNumberToUint256(state.challengeDuration),
     channelNonce: bigNumberToUint256(state.channelNonce),
@@ -39,8 +39,6 @@ export function serializeState(state: SignedState): SignedStateWire {
     outcome: serializeOutcome(state.outcome),
     channelId: calculateChannelId(state)
   };
-  console.log('serializing' + JSON.stringify(state) + ' to ' + JSON.stringify(sswire));
-  return sswire;
 }
 
 function serializeOutcome(outcome: Outcome): OutcomeWire {

--- a/packages/xstate-wallet/src/serde/wire-format/serialize.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/serialize.ts
@@ -7,7 +7,7 @@ import {
 } from '@statechannels/wire-format';
 import {SignedState, Outcome, AllocationItem, SimpleAllocation, Message} from '../../store/types';
 import {calculateChannelId} from '../../store/state-utils';
-import {BigNumber} from 'ethers/utils';
+import {BigNumber, hexZeroPad, hexlify} from 'ethers/utils';
 
 export function serializeMessage(message: Message, recipient: string, sender: string): WireMessage {
   const signedStates = (message.signedStates || []).map(ss => {
@@ -22,15 +22,9 @@ export function serializeMessage(message: Message, recipient: string, sender: st
 }
 
 function bigNumberToUint256(bigNumber: BigNumber): string {
-  // our wire protocol calls for hex strings of this exact format
-  return (
-    '0x' +
-    bigNumber
-      .toHexString()
-      .slice(2)
-      .padStart(64, '0')
-  );
+  return hexZeroPad(hexlify(bigNumber), 32);
 }
+
 export function serializeState(state: SignedState): SignedStateWire {
   return {
     ...state,

--- a/packages/xstate-wallet/src/serde/wire-format/serialize.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/serialize.ts
@@ -22,6 +22,7 @@ export function serializeMessage(message: Message, recipient: string, sender: st
 }
 
 function bigNumberToUint256(bigNumber: BigNumber): string {
+  // our wire protocol calls for hex strings of this exact format
   return (
     '0x' +
     bigNumber

--- a/packages/xstate-wallet/src/store/channel-store-entry.ts
+++ b/packages/xstate-wallet/src/store/channel-store-entry.ts
@@ -8,7 +8,7 @@ export type ChannelStoredData = {
     challengeDuration: BigNumber | string;
     channelNonce: BigNumber | string;
   };
-  signatures: Record<string, string[] | undefined>;
+  signatures: Record<string, (string | undefined)[]>;
   funding: Funding | undefined;
   applicationSite: string | undefined;
   myIndex: number;


### PR DESCRIPTION
Currently tests will fail due to the increased checking that is being done.  Assuming the `wire-format` is correct, looks like there is some work to do ensuring messages end up being serialized in a way that is consistent with that. 