### PR TITLE
[web3torrent] Fix possible race condition

### DIFF
--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -183,7 +183,7 @@ export class PaymentChannelClient {
       ) {
         resolve();
       } else {
-        this.channelClient.onChannelProposed(channelResult => {
+        this.channelClient.onChannelUpdated(channelResult => {
           const channelState = convertToChannelState(channelResult);
           channelState.channelId === channelId &&
             this.isAcceptanceOfMyPayment(channelState) &&

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -23,8 +23,8 @@ export interface ChannelState {
 }
 
 enum Index {
-  Leecher = 0,
-  Seeder = 1
+  Payer = 0,
+  Beneficiary = 1
 }
 
 // This class wraps the channel client converting the
@@ -187,7 +187,7 @@ export class PaymentChannelClient {
         state &&
         state.status === 'running' &&
         state.payer === this.mySigningAddress &&
-        state.turnNum.mod(2).eq(Index.Leecher);
+        state.turnNum.mod(2).eq(Index.Payer);
 
       const currentState = this.channelCache[channelId];
       if (readyToPay(currentState)) resolve(currentState);

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -177,7 +177,10 @@ export class PaymentChannelClient {
   // payer may use this method to make payments (if they have sufficient funds)
   async makePayment(channelId: string, amount: string) {
     const channelReady = new Promise(resolve => {
-      if (this.isAcceptanceOfMyPayment(this.channelCache[channelId])) {
+      if (
+        this.channelCache[channelId] &&
+        this.isAcceptanceOfMyPayment(this.channelCache[channelId])
+      ) {
         resolve();
       } else {
         this.channelClient.onChannelProposed(channelResult => {

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -268,7 +268,6 @@ export class PaymentChannelClient {
   }
 
   isAcceptanceOfMyPayment(channelState: ChannelState): boolean {
-    // doesn't guarantee that my balance increased
     if (channelState.payer === this.mySigningAddress) {
       return channelState.status === 'running' && channelState.turnNum.mod(2).eq(0);
     }

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -177,12 +177,16 @@ export class PaymentChannelClient {
   // payer may use this method to make payments (if they have sufficient funds)
   async makePayment(channelId: string, amount: string) {
     const channelReady = new Promise(resolve => {
-      this.channelClient.onChannelProposed(channelResult => {
-        const channelState = convertToChannelState(channelResult);
-        channelState.channelId === channelId &&
-          this.isAcceptanceOfMyPayment(channelState) &&
-          resolve();
-      });
+      if (this.isAcceptanceOfMyPayment(this.channelCache[channelId])) {
+        resolve();
+      } else {
+        this.channelClient.onChannelProposed(channelResult => {
+          const channelState = convertToChannelState(channelResult);
+          channelState.channelId === channelId &&
+            this.isAcceptanceOfMyPayment(channelState) &&
+            resolve();
+        });
+      }
     });
 
     await channelReady; // deals with race conditions where I am prompted to pay but did not receive previous acceptance yet

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -4,6 +4,7 @@ import {FakeChannelProvider} from '@statechannels/channel-client';
 import {ChannelClient} from '@statechannels/channel-client';
 import {ChannelStatus, Message} from '@statechannels/client-api-schema';
 import {SiteBudget} from '@statechannels/client-api-schema';
+import {SINGLE_ASSET_PAYMENT_CONTRACT_ADDRESS} from '../constants';
 
 const bigNumberify = utils.bigNumberify;
 const FINAL_SETUP_STATE = utils.bigNumberify(3); // for a 2 party ForceMove channel
@@ -41,7 +42,7 @@ if (process.env.REACT_APP_FAKE_CHANNEL_PROVIDER === 'true') {
 // The beneficiary proposes the channel, but accepts payments
 // The payer joins the channel, and makes payments
 export class PaymentChannelClient {
-  channelCache: Record<string, ChannelState> = {};
+  channelCache: Record<string, ChannelState | undefined> = {};
 
   get mySigningAddress(): string | undefined {
     return this.channelClient.signingAddress;
@@ -82,8 +83,8 @@ export class PaymentChannelClient {
       beneficiaryBalance,
       payerBalance
     );
-    const appDefinition = process.env.REACT_APP_SINGLE_ASSET_PAYMENT_CONTRACT_ADDRESS;
 
+    const appDefinition = SINGLE_ASSET_PAYMENT_CONTRACT_ADDRESS;
     const channelResult = await this.channelClient.createChannel(
       participants,
       allocations,
@@ -238,7 +239,7 @@ export class PaymentChannelClient {
 
   amProposer(channelIdOrChannelState: string | ChannelState): boolean {
     if (typeof channelIdOrChannelState === 'string') {
-      return this.channelCache[channelIdOrChannelState].beneficiary === this.mySigningAddress;
+      return this.channelCache[channelIdOrChannelState]?.beneficiary === this.mySigningAddress;
     } else {
       return channelIdOrChannelState.beneficiary === this.mySigningAddress;
     }

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -1,7 +1,6 @@
 import {Status, Torrent} from './types';
 import {ChannelState} from './clients/payment-channel-client';
 import {bigNumberify} from 'ethers/utils';
-import {AddressZero} from 'ethers/constants';
 
 export const WEI_PER_BYTE = bigNumberify(1); // cost per byte
 export const BUFFER_REFILL_RATE = bigNumberify(2e4); // number of bytes the leecher wishes to increase the buffer by

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -1,6 +1,7 @@
 import {Status, Torrent} from './types';
 import {ChannelState} from './clients/payment-channel-client';
 import {bigNumberify} from 'ethers/utils';
+import {AddressZero} from 'ethers/constants';
 
 export const WEI_PER_BYTE = bigNumberify(1); // cost per byte
 export const BUFFER_REFILL_RATE = bigNumberify(2e4); // number of bytes the leecher wishes to increase the buffer by
@@ -119,3 +120,12 @@ export const mockChannels: Array<Partial<ChannelState>> = [
     beneficiaryBalance: bigNumberify(mockBalance * 2).toString()
   }
 ];
+
+let SINGLE_ASSET_PAYMENT_CONTRACT_ADDRESS: string;
+if (process.env.REACT_APP_SINGLE_ASSET_PAYMENT_CONTRACT_ADDRESS) {
+  SINGLE_ASSET_PAYMENT_CONTRACT_ADDRESS =
+    process.env.REACT_APP_SINGLE_ASSET_PAYMENT_CONTRACT_ADDRESS;
+} else {
+  throw new Error('Contract address not defined');
+}
+export {SINGLE_ASSET_PAYMENT_CONTRACT_ADDRESS};

--- a/packages/web3torrent/src/library/testing/setup.js
+++ b/packages/web3torrent/src/library/testing/setup.js
@@ -1,4 +1,6 @@
 process.env.REACT_APP_FAKE_CHANNEL_PROVIDER = 'true';
+process.env.REACT_APP_SINGLE_ASSET_PAYMENT_CONTRACT_ADDRESS =
+  '0x430869383d611bBB1ce7Ca207024E7901bC26b40'; // some dummy value to prevent 'not defined' errors
 
 module.exports = () => {
   const {Server} = require('bittorrent-tracker');

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -96,8 +96,6 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
       this.paymentChannelClient.pushMessage(message);
     });
 
-    console.log(process.env);
-
     if (AUTO_FUND_LEDGER) {
       // TODO: This is a temporary measure while we don't have any budgeting built out.
       // We automatically call approveBudgetAndFund.

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -111,10 +111,6 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
       );
       console.log(`Budget approved: ${JSON.stringify(success)}`);
     }
-
-    // Cache the site budget so we have data to render in the budget UI.
-    // We don't need to do this when we wire up xstate-wallet and the approveBudgetAndFund function.
-    await this.paymentChannelClient.getBudget(window.location.hostname);
   }
 
   async disable() {

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -64,15 +64,11 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
   async enable() {
     await this.paymentChannelClient.enable();
 
-    log('set pseAccount to sc-wallet signing address');
     this.pseAccount = this.paymentChannelClient.mySigningAddress;
-
-    log('set outcomeAddress to sc-wallet web3 wallet address');
+    log('set pseAccount to sc-wallet signing address: ' + this.pseAccount);
     this.outcomeAddress = this.paymentChannelClient.myEthereumSelectedAddress;
+    log('set outcomeAddress to sc-wallet web3 wallet address: ' + this.outcomeAddress);
 
-    log('got ethereum address');
-    log('ACCOUNT ID: ', this.pseAccount);
-    log('THIS address: ', this.outcomeAddress);
     this.tracker.getAnnounceOpts = () => ({pseAccount: this.pseAccount});
 
     // Hub messaging

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -319,14 +319,18 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     });
 
     this.paymentChannelClient.onChannelUpdated(async (channelState: ChannelState) => {
-      if (channelState.channelId === wire.paidStreamingExtension.pseChannelId) {
+      if (
+        channelState.channelId === wire.paidStreamingExtension.pseChannelId ||
+        channelState.channelId === wire.paidStreamingExtension.peerChannelId
+      ) {
         // filter to updates for the channel on this wire
-        log(`State received with turnNum ${channelState.turnNum}`);
+        log(`Channel updated to turnNum ${channelState.turnNum}`);
         if (this.paymentChannelClient.shouldSendSpacerState(channelState)) {
           // send "spacer" state
           await this.paymentChannelClient.acceptChannelUpdate(
             this.paymentChannelClient.channelCache[channelState.channelId]
           );
+          log('sent space state, now sending STOP');
           wire.paidStreamingExtension.stop(); // prompt peer for a payment
         } else if (this.paymentChannelClient.isPaymentToMe(channelState)) {
           log(

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -330,7 +330,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
           await this.paymentChannelClient.acceptChannelUpdate(
             this.paymentChannelClient.channelCache[channelState.channelId]
           );
-          log('sent space state, now sending STOP');
+          log('sent spacer state, now sending STOP');
           wire.paidStreamingExtension.stop(); // prompt peer for a payment
         } else if (this.paymentChannelClient.isPaymentToMe(channelState)) {
           log(

--- a/packages/web3torrent/tsconfig.json
+++ b/packages/web3torrent/tsconfig.json
@@ -12,7 +12,8 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "strictNullChecks": true
   },
   "include": ["**/*.ts", "**/*.tsx"]
 }

--- a/packages/web3torrent/tsconfig.json
+++ b/packages/web3torrent/tsconfig.json
@@ -12,8 +12,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "esModuleInterop": true,
-    "strictNullChecks": true
+    "esModuleInterop": true
   },
   "include": ["**/*.ts", "**/*.tsx"]
 }

--- a/packages/xstate-wallet/.env
+++ b/packages/xstate-wallet/.env
@@ -29,8 +29,7 @@ TEST_ASSET_HOLDER2_ADDRESS = 0x0000000000000000000000000000000000000000
 
 # TODO: This should be something the wallet/user decides not a .env variable. 
 # For now this allows integration tests to test ledger funding
-USE_VIRTUAL_FUNDING=TRUE
+
 
 # This allows indexed-db storage to be disabled when running the wallet in the browser
 # which may be useful for testing purposes
-USE_INDEXED_DB = TRUE

--- a/packages/xstate-wallet/.env
+++ b/packages/xstate-wallet/.env
@@ -29,7 +29,8 @@ TEST_ASSET_HOLDER2_ADDRESS = 0x0000000000000000000000000000000000000000
 
 # TODO: This should be something the wallet/user decides not a .env variable. 
 # For now this allows integration tests to test ledger funding
-
+USE_VIRTUAL_FUNDING=
 
 # This allows indexed-db storage to be disabled when running the wallet in the browser
 # which may be useful for testing purposes
+USE_INDEXED_DB=


### PR DESCRIPTION
When transitioning from the fake provider to a real wallet, channel updates are going to get significantly slower due to the burden of managing signatures. Meanwhile, web3torrent messages that do not involve the wallet will be relatively fast. 

This means that although the seeder will send the spacer state, *then* prompt the leecher to make a payment, the leecher may well respond to the prompt before the channel has been updated in their client. 