### PR TITLE
xstate-wallet: add launch config for attaching to chrome

### DIFF
--- a/packages/xstate-wallet/.vscode/launch.json
+++ b/packages/xstate-wallet/.vscode/launch.json
@@ -18,7 +18,6 @@
         "webpack:///./~/*": "${webRoot}/node_modules/*"
       }
     },
-
     {
       "name": "Jest Current",
       "type": "node",
@@ -44,6 +43,14 @@
       "processId": "${command:PickProcess}",
       "skipFiles": ["<node_internals>/**"],
       "sourceMaps": true
+    },
+    {
+      "name": "Attach to running wallet",
+      "type": "chrome",
+      "request": "attach",
+      "port": 9222,
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}"
     }
   ]
 }


### PR DESCRIPTION
Great reference doc: [https://github.com/microsoft/vscode-chrome-debug](https://github.com/microsoft/vscode-chrome-debug)

- Launch chrome via `/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222 --user-data-dir=[PATH TO DIR STORING CHROME USER DATA]/chrome-debug`. Reading [this](https://github.com/microsoft/vscode-chrome-debug#cannot-connect-to-the-target-connect-econnrefused-1270019222) will clarify the command.
- Run *Attach to running wallet* in VSCode.
- Set breakpoints to your heart's content.