### PR TITLE
Web3torrent: Add end-to-end tests with Puppeteer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,13 +214,12 @@ jobs:
           command: (cd packages/devtools && yarn run start:shared-ganache)
           background: true
       - run:
-          command: (cd packages/wallet && yarn run wait-on ../../.ganache-deployments && yarn run start:integration)
+          command: (cd packages/xstate-wallet && yarn run wait-on ../../.ganache-deployments && yarn start)
           background: true
       - run:
-          command: (cd packages/rps && yarn run wait-on ../../.ganache-deployments && yarn run start)
+          command: (cd packages/web3torrent && yarn run wait-on ../../.ganache-deployments && yarn start)
           background: true
-      - run: (cd packages/wallet && yarn run test:ci:integration)
-      - run: (cd packages/e2e-tests && USE_VIRTUAL_FUNDING=false yarn test)
+      - run: (cd packages/e2e-tests && openssl rand -out sample.txt -base64 $(( 2**20 * 3/4 * 4 )) && yarn test puppeteer/__tests__/web3torrent.test.ts)
       - upload_logs:
           file: integration-test-stats
       - upload_e2e_screenshots:
@@ -313,9 +312,9 @@ workflows:
           requires:
             - prepare
       # TODO: Enable once working with xstate wallet
-      #  - integration-test:
-      #      requires:
-      #        - prepare
+      - integration-test:
+          requires:
+            - prepare
       # TODO: Enable once the test runs reliably
       # - integration-test-with-hub:
       #    requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,12 +214,47 @@ jobs:
           command: (cd packages/devtools && yarn run start:shared-ganache)
           background: true
       - run:
+          command: (cd packages/wallet && yarn run wait-on ../../.ganache-deployments && yarn run start:integration)
+          background: true
+      - run:
+          command: (cd packages/rps && yarn run wait-on ../../.ganache-deployments && yarn run start)
+          background: true
+      - run: (cd packages/wallet && yarn run test:ci:integration)
+      - run: (cd packages/e2e-tests && USE_VIRTUAL_FUNDING=false yarn test)
+      - upload_logs:
+          file: integration-test-stats
+      - upload_e2e_screenshots:
+          job: integration-test
+
+  integration-test-web3torrent:
+    resource_class: medium
+    working_directory: /home/circleci/project
+    docker:
+      - image: circleci/node:10.16.3
+    environment:
+      FIREBASE_PREFIX: << pipeline.git.branch >>-1
+      USE_VIRTUAL_FUNDING: 'FALSE'
+      USE_GANACHE_DEPLOYMENT_CACHE: true
+      GANACHE_CACHE_FOLDER: ../../.ganache-deployments
+      GANACHE_PORT: 8547
+      NODE_ENV: test
+    steps:
+      - checkout
+      - puppeteer/install
+      - log_stats:
+          file: integration-test-stats
+      - attach_workspace:
+          at: /home/circleci/project
+      - run:
+          command: (cd packages/devtools && yarn run start:shared-ganache)
+          background: true
+      - run:
           command: (cd packages/xstate-wallet && yarn run wait-on ../../.ganache-deployments && yarn start)
           background: true
       - run:
           command: (cd packages/web3torrent && yarn run wait-on ../../.ganache-deployments && yarn start)
           background: true
-      - run: (cd packages/e2e-tests && openssl rand -out sample.txt -base64 $(( 2**20 * 3/4 * 4 )) && yarn test puppeteer/__tests__/web3torrent.test.ts)
+      - run: (cd packages/e2e-tests && yarn test puppeteer/__tests__/web3torrent.test.ts)
       - upload_logs:
           file: integration-test-stats
       - upload_e2e_screenshots:
@@ -312,14 +347,17 @@ workflows:
           requires:
             - prepare
       # TODO: Enable once working with xstate wallet
-      - integration-test:
-          requires:
-            - prepare
+      #  - integration-test:
+      #      requires:
+      #        - prepare
       # TODO: Enable once the test runs reliably
       # - integration-test-with-hub:
       #    requires:
       #      - prepare
       #      - integration-test
+      - integration-test-web3torrent:
+          requires:
+            - prepare
       - release-incremental:
           requires:
             - prepare

--- a/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
@@ -2,7 +2,7 @@
 import {Page, Browser} from 'puppeteer';
 import {configureEnvVariables, getEnvBool} from '@statechannels/devtools';
 
-import {setUpBrowser, loadWeb3App} from '../helpers';
+import {setUpBrowser, loadDapp} from '../helpers';
 import {
   login,
   aChallenges,
@@ -29,8 +29,12 @@ describe('completes game 1 (challenge by A, challenge by B, resign by B) and beg
     rpsTabA = (await browserA.pages())[0];
     rpsTabB = (await browserB.pages())[0];
 
-    await loadWeb3App(rpsTabA, 0);
-    await loadWeb3App(rpsTabB, 1);
+    await loadDapp(rpsTabA, 0);
+    await loadDapp(rpsTabB, 1);
+
+    const url = 'http://localhost:3000';
+    await rpsTabA.goto(url, {waitUntil: 'load'});
+    await rpsTabB.goto(url, {waitUntil: 'load'});
 
     await login(rpsTabA, rpsTabB);
   });

--- a/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/rps.test.ts
@@ -2,7 +2,7 @@
 import {Page, Browser} from 'puppeteer';
 import {configureEnvVariables, getEnvBool} from '@statechannels/devtools';
 
-import {setUpBrowser, loadRPSApp} from '../helpers';
+import {setUpBrowser, loadWeb3App} from '../helpers';
 import {
   login,
   aChallenges,
@@ -29,8 +29,8 @@ describe('completes game 1 (challenge by A, challenge by B, resign by B) and beg
     rpsTabA = (await browserA.pages())[0];
     rpsTabB = (await browserB.pages())[0];
 
-    await loadRPSApp(rpsTabA, 0);
-    await loadRPSApp(rpsTabB, 1);
+    await loadWeb3App(rpsTabA, 0);
+    await loadWeb3App(rpsTabB, 1);
 
     await login(rpsTabA, rpsTabB);
   });

--- a/packages/e2e-tests/puppeteer/__tests__/web3torrent.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/web3torrent.test.ts
@@ -57,6 +57,8 @@ describe('Supports torrenting among peers with channels', () => {
     await waitForClosingChannel(web3tTabB);
     await waitForClosingChannel(web3tTabA);
 
+    await web3tTabA.waitFor(1500);
+    await web3tTabB.waitFor(1500);
     console.log('Checking exchanged amount between downloader and uploader...');
     const earnedColumn = await web3tTabA.$('td.earned');
     const earned = await web3tTabA.evaluate(e => e.textContent, earnedColumn);

--- a/packages/e2e-tests/puppeteer/__tests__/web3torrent.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/web3torrent.test.ts
@@ -50,6 +50,7 @@ describe('Supports torrenting among peers with channels', () => {
     await waitAndOpenChannel(web3tTabA);
     await waitAndOpenChannel(web3tTabB);
 
+    // Let the download cointinue for some time
     await web3tTabB.waitFor(3000);
     console.log('B cancels download');
     await cancelDownload(web3tTabB);
@@ -57,8 +58,10 @@ describe('Supports torrenting among peers with channels', () => {
     await waitForClosingChannel(web3tTabB);
     await waitForClosingChannel(web3tTabA);
 
+    // Inject some delays. Otherwise puppeteer may read the stale amounts and fails.
     await web3tTabA.waitFor(1500);
     await web3tTabB.waitFor(1500);
+
     console.log('Checking exchanged amount between downloader and uploader...');
     const earnedColumn = await web3tTabA.$('td.earned');
     const earned = await web3tTabA.evaluate(e => e.textContent, earnedColumn);

--- a/packages/e2e-tests/puppeteer/__tests__/web3torrent.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/web3torrent.test.ts
@@ -54,5 +54,12 @@ describe('Supports torrenting among peers with channels', () => {
 
     await waitForClosingChannel(web3tTabB);
     await waitForClosingChannel(web3tTabA);
+
+    // Assert exchanged amount are the same on both sides
+    const earnedColumn = await web3tTabA.$('td.earned');
+    const earned = await web3tTabA.evaluate(e => e.textContent, earnedColumn);
+    const paidColumn = await web3tTabB.$('td.paid');
+    const paid = await web3tTabB.evaluate(e => e.textContent, paidColumn);
+    expect(paid).toEqual(`-${earned}`);
   });
 });

--- a/packages/e2e-tests/puppeteer/__tests__/web3torrent.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/web3torrent.test.ts
@@ -39,7 +39,7 @@ describe('Supports torrenting among peers with channels', () => {
   });
 
   it('allows peers to start torrenting', async () => {
-    console.log('A uploads a file...');
+    console.log('A uploads a file');
     const url = await uploadFile(web3tTabA);
 
     console.log('B starts downloading...');
@@ -49,13 +49,13 @@ describe('Supports torrenting among peers with channels', () => {
     await waitAndOpenChannel(web3tTabB);
 
     await web3tTabB.waitFor(3000);
-    console.log('B cancels download...');
+    console.log('B cancels download');
     await cancelDownload(web3tTabB);
 
     await waitForClosingChannel(web3tTabB);
     await waitForClosingChannel(web3tTabA);
 
-    // Assert exchanged amount are the same on both sides
+    console.log('Checking exchanged amount from downloader and uploader...');
     const earnedColumn = await web3tTabA.$('td.earned');
     const earned = await web3tTabA.evaluate(e => e.textContent, earnedColumn);
     const paidColumn = await web3tTabB.$('td.paid');

--- a/packages/e2e-tests/puppeteer/__tests__/web3torrent.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/web3torrent.test.ts
@@ -2,9 +2,9 @@
 import {Page, Browser} from 'puppeteer';
 import {configureEnvVariables, getEnvBool} from '@statechannels/devtools';
 
-import {setUpBrowser, loadWeb3App} from '../helpers';
+import {setUpBrowser, loadWeb3App, waitAndOpenChannel, waitForClosingChannel} from '../helpers';
 
-import {seederUploadsAFile, startDownload, cancelDownload} from '../scripts/web3torrent';
+import {uploadFile, startDownload, cancelDownload} from '../scripts/web3torrent';
 
 jest.setTimeout(200_000);
 
@@ -13,25 +13,20 @@ const HEADLESS = getEnvBool('HEADLESS');
 
 let browserA: Browser;
 let browserB: Browser;
-let browserC: Browser;
 let web3tTabA: Page;
 let web3tTabB: Page;
-let web3tTabC: Page;
 
-describe('Multiple downloaders', () => {
+describe('Supports torrenting among peers with channels', () => {
   beforeAll(async () => {
     // 100ms sloMo avoids some undiagnosed race conditions
     browserA = await setUpBrowser(HEADLESS, 100);
     browserB = await setUpBrowser(HEADLESS, 100);
-    browserC = await setUpBrowser(HEADLESS, 100);
 
     web3tTabA = (await browserA.pages())[0];
     web3tTabB = (await browserB.pages())[0];
-    web3tTabC = (await browserC.pages())[0];
 
-    await loadWeb3App(web3tTabA, 0);
-    await loadWeb3App(web3tTabB, 0);
-    await loadWeb3App(web3tTabC, 0);
+    await loadWeb3App(web3tTabA, 0, 'file/new', true);
+    await loadWeb3App(web3tTabB, 0, '', true);
   });
 
   afterAll(async () => {
@@ -41,23 +36,23 @@ describe('Multiple downloaders', () => {
     if (browserB) {
       await browserB.close();
     }
-    if (browserC) {
-      await browserC.close();
-    }
   });
 
-  it('allows multiple peers to start torrenting', async () => {
+  it('allows peers to start torrenting', async () => {
     console.log('A uploads a file...');
-    const url = await seederUploadsAFile(web3tTabA);
+    const url = await uploadFile(web3tTabA);
 
-    console.log('B and C start downloading...');
+    console.log('B starts downloading...');
     await startDownload(web3tTabB, url);
-    await startDownload(web3tTabC, url);
 
-    console.log('B and C cancel download...');
+    await waitAndOpenChannel(web3tTabA);
+    await waitAndOpenChannel(web3tTabB);
+
+    await web3tTabB.waitFor(3000);
+    console.log('B cancels download...');
     await cancelDownload(web3tTabB);
-    await cancelDownload(web3tTabC);
 
-    // Assert uploader earned equal to sum of spent by the downloaders
+    await waitForClosingChannel(web3tTabB);
+    await waitForClosingChannel(web3tTabA);
   });
 });

--- a/packages/e2e-tests/puppeteer/__tests__/web3torrent.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/web3torrent.test.ts
@@ -2,7 +2,7 @@
 import {Page, Browser} from 'puppeteer';
 import {configureEnvVariables, getEnvBool} from '@statechannels/devtools';
 
-import {setUpBrowser, loadWeb3App, waitAndOpenChannel, waitForClosingChannel} from '../helpers';
+import {setUpBrowser, loadDapp, waitAndOpenChannel, waitForClosingChannel} from '../helpers';
 
 import {uploadFile, startDownload, cancelDownload} from '../scripts/web3torrent';
 
@@ -25,8 +25,10 @@ describe('Supports torrenting among peers with channels', () => {
     web3tTabA = (await browserA.pages())[0];
     web3tTabB = (await browserB.pages())[0];
 
-    await loadWeb3App(web3tTabA, 0, 'file/new', true);
-    await loadWeb3App(web3tTabB, 0, '', true);
+    await loadDapp(web3tTabA, 0, true);
+    await loadDapp(web3tTabB, 0, true);
+
+    await web3tTabA.goto('http://localhost:3000/file/new', {waitUntil: 'load'});
   });
 
   afterAll(async () => {
@@ -55,7 +57,7 @@ describe('Supports torrenting among peers with channels', () => {
     await waitForClosingChannel(web3tTabB);
     await waitForClosingChannel(web3tTabA);
 
-    console.log('Checking exchanged amount from downloader and uploader...');
+    console.log('Checking exchanged amount between downloader and uploader...');
     const earnedColumn = await web3tTabA.$('td.earned');
     const earned = await web3tTabA.evaluate(e => e.textContent, earnedColumn);
     const paidColumn = await web3tTabB.$('td.paid');

--- a/packages/e2e-tests/puppeteer/__tests__/web3torrent.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/web3torrent.test.ts
@@ -1,0 +1,63 @@
+/* eslint-disable jest/expect-expect */
+import {Page, Browser} from 'puppeteer';
+import {configureEnvVariables, getEnvBool} from '@statechannels/devtools';
+
+import {setUpBrowser, loadWeb3App} from '../helpers';
+
+import {seederUploadsAFile, startDownload, cancelDownload} from '../scripts/web3torrent';
+
+jest.setTimeout(200_000);
+
+configureEnvVariables();
+const HEADLESS = getEnvBool('HEADLESS');
+
+let browserA: Browser;
+let browserB: Browser;
+let browserC: Browser;
+let web3tTabA: Page;
+let web3tTabB: Page;
+let web3tTabC: Page;
+
+describe('Multiple downloaders', () => {
+  beforeAll(async () => {
+    // 100ms sloMo avoids some undiagnosed race conditions
+    browserA = await setUpBrowser(HEADLESS, 100);
+    browserB = await setUpBrowser(HEADLESS, 100);
+    browserC = await setUpBrowser(HEADLESS, 100);
+
+    web3tTabA = (await browserA.pages())[0];
+    web3tTabB = (await browserB.pages())[0];
+    web3tTabC = (await browserC.pages())[0];
+
+    await loadWeb3App(web3tTabA, 0);
+    await loadWeb3App(web3tTabB, 0);
+    await loadWeb3App(web3tTabC, 0);
+  });
+
+  afterAll(async () => {
+    if (browserA) {
+      await browserA.close();
+    }
+    if (browserB) {
+      await browserB.close();
+    }
+    if (browserC) {
+      await browserC.close();
+    }
+  });
+
+  it('allows multiple peers to start torrenting', async () => {
+    console.log('A uploads a file...');
+    const url = await seederUploadsAFile(web3tTabA);
+
+    console.log('B and C start downloading...');
+    await startDownload(web3tTabB, url);
+    await startDownload(web3tTabC, url);
+
+    console.log('B and C cancel download...');
+    await cancelDownload(web3tTabB);
+    await cancelDownload(web3tTabC);
+
+    // Assert uploader earned equal to sum of spent by the downloaders
+  });
+});

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -3,7 +3,12 @@ import {Browser, Page, Frame, launch} from 'puppeteer';
 import * as fs from 'fs';
 import * as path from 'path';
 
-export async function loadWeb3App(page: Page, ganacheAccountIndex: number): Promise<void> {
+export async function loadWeb3App(
+  page: Page,
+  ganacheAccountIndex: number,
+  urlPath?: string,
+  ignoreConsoleError?: boolean
+): Promise<void> {
   // TODO: This is kinda ugly but it works
   // We need to instantiate a web3 for the wallet so we import the web 3 script
   // and then assign it on the window
@@ -24,14 +29,22 @@ export async function loadWeb3App(page: Page, ganacheAccountIndex: number): Prom
     window.ethereum.on = () => {};
   `);
 
-  await page.goto('http://localhost:3000/', {waitUntil: 'load'});
+  const base = 'http://localhost:3000/';
+
+  let url = base;
+
+  if (urlPath) {
+    url = `${base}${urlPath}`;
+  }
+
+  await page.goto(url, {waitUntil: 'load'});
 
   page.on('pageerror', error => {
     throw error;
   });
 
   page.on('console', msg => {
-    if (msg.type() === 'error') {
+    if (msg.type() === 'error' && !ignoreConsoleError) {
       throw new Error(`Error was logged into the console ${msg.text()}`);
     }
   });
@@ -91,4 +104,18 @@ export async function setUpBrowser(headless: boolean, slowMo?: number): Promise<
   });
 
   return browser;
+}
+
+export async function waitAndOpenChannel(page: Page): Promise<void> {
+  const createChannelButton =
+    'body > div:nth-child(3) > div > div > div:nth-child(2) > div > button';
+
+  const walletIFrame = page.frames()[1];
+  await waitForAndClickButton(page, walletIFrame, createChannelButton);
+}
+
+export async function waitForClosingChannel(page: Page): Promise<void> {
+  const closingText = 'body > div:nth-child(3) > div > div > div:nth-child(2) > h1';
+  const closingIframeB = page.frames()[1];
+  await closingIframeB.waitForSelector(closingText);
 }

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -3,7 +3,7 @@ import {Browser, Page, Frame, launch} from 'puppeteer';
 import * as fs from 'fs';
 import * as path from 'path';
 
-export async function loadRPSApp(page: Page, ganacheAccountIndex: number): Promise<void> {
+export async function loadWeb3App(page: Page, ganacheAccountIndex: number): Promise<void> {
   // TODO: This is kinda ugly but it works
   // We need to instantiate a web3 for the wallet so we import the web 3 script
   // and then assign it on the window

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -3,10 +3,9 @@ import {Browser, Page, Frame, launch} from 'puppeteer';
 import * as fs from 'fs';
 import * as path from 'path';
 
-export async function loadWeb3App(
+export async function loadDapp(
   page: Page,
   ganacheAccountIndex: number,
-  urlPath?: string,
   ignoreConsoleError?: boolean
 ): Promise<void> {
   // TODO: This is kinda ugly but it works
@@ -28,16 +27,6 @@ export async function loadWeb3App(
     window.ethereum.networkVersion = 9001;
     window.ethereum.on = () => {};
   `);
-
-  const base = 'http://localhost:3000/';
-
-  let url = base;
-
-  if (urlPath) {
-    url = `${base}${urlPath}`;
-  }
-
-  await page.goto(url, {waitUntil: 'load'});
 
   page.on('pageerror', error => {
     throw error;

--- a/packages/e2e-tests/puppeteer/scripts/rps.ts
+++ b/packages/e2e-tests/puppeteer/scripts/rps.ts
@@ -1,6 +1,6 @@
 import {Page} from 'puppeteer';
 
-import {waitForAndClickButton, setUpBrowser, loadRPSApp} from '../helpers';
+import {waitForAndClickButton, setUpBrowser, loadWeb3App} from '../helpers';
 import {getEnvBool} from '@statechannels/devtools';
 
 export async function login(rpsTabA: Page, rpsTabB: Page): Promise<boolean> {
@@ -149,8 +149,8 @@ export async function bResigns(rpsTabA: Page, rpsTabB: Page): Promise<boolean> {
     const rpsTabA = (await browserA.pages())[0];
     const rpsTabB = (await browserB.pages())[0];
 
-    await loadRPSApp(rpsTabA, 0);
-    await loadRPSApp(rpsTabB, 1);
+    await loadWeb3App(rpsTabA, 0);
+    await loadWeb3App(rpsTabB, 1);
 
     await login(rpsTabA, rpsTabB);
   }

--- a/packages/e2e-tests/puppeteer/scripts/rps.ts
+++ b/packages/e2e-tests/puppeteer/scripts/rps.ts
@@ -1,6 +1,6 @@
 import {Page} from 'puppeteer';
 
-import {waitForAndClickButton, setUpBrowser, loadWeb3App} from '../helpers';
+import {waitForAndClickButton, setUpBrowser, loadDapp} from '../helpers';
 import {getEnvBool} from '@statechannels/devtools';
 
 export async function login(rpsTabA: Page, rpsTabB: Page): Promise<boolean> {
@@ -149,8 +149,8 @@ export async function bResigns(rpsTabA: Page, rpsTabB: Page): Promise<boolean> {
     const rpsTabA = (await browserA.pages())[0];
     const rpsTabB = (await browserB.pages())[0];
 
-    await loadWeb3App(rpsTabA, 0);
-    await loadWeb3App(rpsTabB, 1);
+    await loadDapp(rpsTabA, 0);
+    await loadDapp(rpsTabB, 1);
 
     await login(rpsTabA, rpsTabB);
   }

--- a/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
+++ b/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
@@ -3,7 +3,6 @@ import {Page} from 'puppeteer';
 import * as fs from 'fs';
 
 function prepareUploadFile(path: string): void {
-  // Write deterministic content to the test file.
   const content = 'web3torrent\n'.repeat(100000);
   const buf = Buffer.from(content);
   fs.writeFile(path, buf, err => {
@@ -16,9 +15,9 @@ function prepareUploadFile(path: string): void {
 
 export async function uploadFile(page: Page): Promise<string> {
   await page.waitForSelector('input[type=file]');
-  // Generated from command: openssl rand -out random.txt -base64 $(( 2**20 * 3/4 * 4 ))
-  const fileToUpload = '/tmp/web3torrent-tests-stub';
 
+  // Generate a /tmp file with deterministic data for upload testing
+  const fileToUpload = '/tmp/web3torrent-tests-stub';
   prepareUploadFile(fileToUpload);
 
   // https://pub.dev/documentation/puppeteer/latest/puppeteer/FileChooser-class.html
@@ -30,18 +29,17 @@ export async function uploadFile(page: Page): Promise<string> {
     upload.dispatchEvent(new Event('change', {bubbles: true}));
   });
 
-  await page.waitFor(3000);
-
-  const downloadLink = await page.$eval('#download-link', a => a.getAttribute('href'));
+  const downloadLinkSelector = '#download-link';
+  await page.waitForSelector(downloadLinkSelector);
+  const downloadLink = await page.$eval(downloadLinkSelector, a => a.getAttribute('href'));
 
   return downloadLink ? downloadLink : '';
 }
 
 export async function startDownload(page: Page, url: string): Promise<void> {
   await page.goto(url);
-  const downloadButton = '#download-button';
+  const downloadButton = '#download-button:not([disabled])';
   await page.waitForSelector(downloadButton);
-  await page.waitFor(2000);
   await page.click(downloadButton);
 }
 

--- a/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
+++ b/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
@@ -3,7 +3,7 @@ import {Page} from 'puppeteer';
 
 export async function uploadFile(page: Page): Promise<string> {
   await page.waitForSelector('input[type=file]');
-  const fileToUpload = 'file.pdf';
+  const fileToUpload = 'sample.txt';
 
   // https://pub.dev/documentation/puppeteer/latest/puppeteer/FileChooser-class.html
   // Not clear why puppeteer FileChooser won't work out of box. We are doing it manually for now.

--- a/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
+++ b/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
@@ -16,22 +16,19 @@ export async function uploadFile(page: Page): Promise<string> {
 
   await page.waitFor(3000);
 
-  const downloadLink = await page.$eval(
-    '#root > main > section > section.torrentInfo > div:nth-child(2) > a',
-    a => a.getAttribute('href')
-  );
+  const downloadLink = await page.$eval('#download-link', a => a.getAttribute('href'));
 
   return downloadLink ? downloadLink : '';
 }
 
 export async function startDownload(page: Page, url: string): Promise<void> {
   await page.goto(url);
-  const downloadButton = '#root > main > section > button';
+  const downloadButton = '#download-button';
   await page.waitForSelector(downloadButton);
   await page.waitFor(2000);
   await page.click(downloadButton);
 }
 
 export async function cancelDownload(page: Page): Promise<void> {
-  await page.click('#root > main > section > section.downloadingInfo > button');
+  await page.click('#cancel-download-button');
 }

--- a/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
+++ b/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
@@ -1,0 +1,12 @@
+import {Page} from 'puppeteer';
+export async function seederUploadsAFile(page: Page): Promise<string> {
+  return page.url();
+}
+
+export async function startDownload(page: Page): Promise<void> {
+  page;
+}
+
+export async function cancelDownload(page: Page): Promise<void> {
+  page;
+}

--- a/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
+++ b/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
@@ -1,9 +1,25 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {Page} from 'puppeteer';
+import * as fs from 'fs';
+
+function prepareUploadFile(path: string): void {
+  // Write deterministic content to the test file.
+  const content = 'web3torrent\n'.repeat(100000);
+  const buf = Buffer.from(content);
+  fs.writeFile(path, buf, err => {
+    if (err) {
+      console.log(err);
+      throw new Error('Failed to prepare the upload file');
+    }
+  });
+}
 
 export async function uploadFile(page: Page): Promise<string> {
   await page.waitForSelector('input[type=file]');
-  const fileToUpload = 'sample.txt';
+  // Generated from command: openssl rand -out random.txt -base64 $(( 2**20 * 3/4 * 4 ))
+  const fileToUpload = '/tmp/web3torrent-tests-stub';
+
+  prepareUploadFile(fileToUpload);
 
   // https://pub.dev/documentation/puppeteer/latest/puppeteer/FileChooser-class.html
   // Not clear why puppeteer FileChooser won't work out of box. We are doing it manually for now.

--- a/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
+++ b/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
@@ -1,12 +1,37 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {Page} from 'puppeteer';
-export async function seederUploadsAFile(page: Page): Promise<string> {
-  return page.url();
+
+export async function uploadFile(page: Page): Promise<string> {
+  await page.waitForSelector('input[type=file]');
+  const fileToUpload = 'file.pdf';
+
+  // https://pub.dev/documentation/puppeteer/latest/puppeteer/FileChooser-class.html
+  // Not clear why puppeteer FileChooser won't work out of box. We are doing it manually for now.
+  const inputUploadHandle = await page.$('input[type=file]');
+  await inputUploadHandle!.uploadFile(fileToUpload);
+  await inputUploadHandle!.evaluate(upload => {
+    // eslint-disable-next-line no-undef
+    upload.dispatchEvent(new Event('change', {bubbles: true}));
+  });
+
+  await page.waitFor(3000);
+
+  const downloadLink = await page.$eval(
+    '#root > main > section > section.torrentInfo > div:nth-child(2) > a',
+    a => a.getAttribute('href')
+  );
+
+  return downloadLink ? downloadLink : '';
 }
 
-export async function startDownload(page: Page): Promise<void> {
-  page;
+export async function startDownload(page: Page, url: string): Promise<void> {
+  await page.goto(url);
+  const downloadButton = '#root > main > section > button';
+  await page.waitForSelector(downloadButton);
+  await page.waitFor(2000);
+  await page.click(downloadButton);
 }
 
 export async function cancelDownload(page: Page): Promise<void> {
-  page;
+  await page.click('#root > main > section > section.downloadingInfo > button');
 }

--- a/packages/e2e-tests/tsconfig.json
+++ b/packages/e2e-tests/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "lib": [
+      "DOM"
+    ]
   }
 }

--- a/packages/web3torrent/src/components/form/form-button/FormButton.tsx
+++ b/packages/web3torrent/src/components/form/form-button/FormButton.tsx
@@ -15,6 +15,7 @@ const FormButton: React.FC<FormButtonProps> = ({
 }: FormButtonProps) => {
   return (
     <button
+      id={`${name || className}-button`}
       data-test-selector={`${name || className}-button`}
       disabled={disabled}
       onClick={onClick}

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -93,11 +93,11 @@ class ChannelsList extends React.Component<UploadInfoProps> {
           {channelsInfo.length > 0 && (
             <thead>
               <tr className="peerInfo">
-                <td className="channel">Status</td>
-                <td className="channel-id">Channel</td>
-                <td className="peer-id">Peer</td>
-                <td className="transferred">Data</td>
-                <td className="earned">Funds</td>
+                <td>Status</td>
+                <td>Channel</td>
+                <td>Peer</td>
+                <td>Data</td>
+                <td>Funds</td>
               </tr>
             </thead>
           )}

--- a/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.tsx
@@ -35,6 +35,7 @@ const DownloadInfo: React.FC<DownloadInfoProps> = ({
               status={torrent.status}
             />
             <button
+              id="cancel-download-button"
               type="button"
               className="button cancel"
               onClick={() => cancel(torrent.infoHash)}

--- a/packages/web3torrent/src/components/torrent-info/magnet-link-button/MagnetLinkButton.tsx
+++ b/packages/web3torrent/src/components/torrent-info/magnet-link-button/MagnetLinkButton.tsx
@@ -6,6 +6,7 @@ export const MagnetLinkButton: React.FC<{}> = () => {
 
   return (
     <a
+      id="download-link"
       href={window.location.href}
       className="fileLink"
       type="button"


### PR DESCRIPTION
Addresses: https://github.com/statechannels/monorepo/issues/1328

Assumption: The browser setup of web3torrent is the same as rps, so I reuse the helper functions. 

- [x] Not clear whether / how much xstate-wallet UI with web3torrent will change. That might impact the pupeteer DOM elements listening.
- [x] Implement the helpers to listen to DOM elements and invoke events.
- [x] Figure out how to set up web3torrent apps in CI (right now it listens to localhost:3000 which I think is point to rps.