### PR TITLE
Refactor approve budget workflow

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,7 @@
         "${relativeFile}",
         "--config",
         // ... because we need some way of locating this jest config
-        "${workspaceFolder}/packages/xstate-wallet/jest.config.js"
+        "${workspaceFolder}/packages/xstate-wallet/config/jest/jest.config.js"
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
     {"directory": "packages/tic-tac-toe", "changeProcessCWD": true},
     {"directory": "packages/wallet", "changeProcessCWD": true},
     {"directory": "packages/wallet-specs", "changeProcessCWD": true}
-  ]
+  ],
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/packages/xstate-wallet/package.json
+++ b/packages/xstate-wallet/package.json
@@ -21,7 +21,7 @@
     "react": "16.12.0",
     "react-dom": "16.12.0",
     "rxjs": "6.5.4",
-    "xstate": "4.7.7"
+    "xstate": "4.8.0"
   },
   "devDependencies": {
     "@babel/core": "7.8.3",

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -101,7 +101,8 @@ export class ChannelWallet {
             budget: request.budget,
             requestId: request.requestId
           }),
-          workflowId
+          workflowId,
+          true // devtools
         );
         this.workflows.push(workflow);
 
@@ -133,14 +134,14 @@ export class ChannelWallet {
   }
   private startWorkflow(
     machineConfig: StateNode<any, any, any, any>,
-    workflowId: string
+    workflowId: string,
+    devTools = false
   ): Workflow {
     if (this.isWorkflowIdInUse(workflowId)) {
       throw new Error(`There is already a workflow running with id ${workflowId}`);
     }
-    const machine = interpret<any, any, any>(machineConfig, {
-      devTools: true
-    })
+
+    const machine = interpret<any, any, any>(machineConfig, {devTools})
       .onTransition((state, event) => process.env.ADD_LOGS && logTransition(state, event, this.id))
 
       .onDone(() => (this.workflows = this.workflows.filter(w => w.id !== workflowId)))

--- a/packages/xstate-wallet/src/index.ts
+++ b/packages/xstate-wallet/src/index.ts
@@ -35,3 +35,5 @@ import extractDomain from 'extract-domain';
 
   window.parent.postMessage('WalletReady', '*');
 })();
+
+import './render';

--- a/packages/xstate-wallet/src/integration-tests/approve-budget.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/approve-budget.test.ts
@@ -2,7 +2,7 @@ import {filter, map, first} from 'rxjs/operators';
 import {FakeChain} from '../chain';
 import {Player, generateApproveBudgetAndFundRequest, hookUpMessaging} from './helpers';
 import {FundLedger} from '../store/types';
-import {checkThat, isSimpleEthAllocation} from '../utils';
+import {assertSimpleEthAllocation} from '../utils';
 
 import {bigNumberify, hexZeroPad} from 'ethers/utils';
 import {ApproveBudgetAndFundResponse} from '@statechannels/client-api-schema/src';
@@ -36,7 +36,7 @@ it('allows for a wallet to approve a budget and fund with the hub', async () => 
       hub.startCreateAndFundLedger({
         ledgerId: o.data.ledgerId,
         participants: o.participants,
-        initialOutcome: checkThat(entry.latest.outcome, isSimpleEthAllocation)
+        initialOutcome: assertSimpleEthAllocation(entry.latest.outcome)
       });
     });
 
@@ -65,7 +65,7 @@ it('allows for a wallet to approve a budget and fund with the hub', async () => 
   // Check that the ledger channel is set up correct
   const ledgerEntry = await playerA.store.getLedger(hub.signingAddress);
   expect(ledgerEntry.isSupported).toBe(true);
-  const allocation = checkThat(ledgerEntry.supported.outcome, isSimpleEthAllocation);
+  const allocation = assertSimpleEthAllocation(ledgerEntry.supported.outcome);
   expect(allocation.allocationItems).toContainEqual({
     destination: hub.destination,
     amount: bigNumberify(hexZeroPad('0x5', 32))

--- a/packages/xstate-wallet/src/render.tsx
+++ b/packages/xstate-wallet/src/render.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {useMachine} from '@xstate/react';
+
+import {machine} from './workflows/approve-budget-and-fund';
+import {ethers} from 'ethers';
+import {ChainWatcher} from './chain';
+import {MemoryBackend} from './store/memory-backend';
+import {TestStore} from './workflows/tests/store';
+import {MessagingService} from './messaging';
+import {ethBudget} from './utils/budget-utils';
+
+const {privateKey} = ethers.Wallet.createRandom();
+const chain = new ChainWatcher();
+const backend = new MemoryBackend();
+const store = new TestStore(chain, backend);
+store.initialize([privateKey]);
+const messagingService = new MessagingService(store);
+const alice = {
+  participantId: 'a',
+  signingAddress: '0xa',
+  destination: '0xad' as any
+};
+const hub = {
+  participantId: 'b',
+  signingAddress: '0xb',
+  destination: '0xbd' as any
+};
+const testContext = {
+  budget: ethBudget('rps.statechannels.org', {}),
+  requestId: 55,
+  player: alice,
+  hub
+};
+
+const approveBudgetAndFund = machine(store, messagingService, testContext);
+
+function Toggle() {
+  const [current, send] = useMachine(approveBudgetAndFund, {devTools: true});
+
+  return (
+    <button onClick={() => send('USER_APPROVES_BUDGET')}>
+      {current.matches('inactive') ? 'Off' : 'On'}
+    </button>
+  );
+}
+
+ReactDOM.render(<Toggle />, document.getElementById('root'));

--- a/packages/xstate-wallet/src/store/index.ts
+++ b/packages/xstate-wallet/src/store/index.ts
@@ -3,6 +3,7 @@ import {filter, map} from 'rxjs/operators';
 import {StateVariables} from './types';
 
 export {Store, XstateStore} from './store';
+export * from './types';
 
 // TODO: Move to somewhere better?
 export function supportedStateFeed(store: Store, channelId: string) {

--- a/packages/xstate-wallet/src/ui/approve-budget-and-fund-workflow.tsx
+++ b/packages/xstate-wallet/src/ui/approve-budget-and-fund-workflow.tsx
@@ -16,7 +16,7 @@ export const ApproveBudgetAndFund = (props: Props) => {
   const {budget} = current.context;
   const {playerAmount, hubAmount} = getAmountsFromBudget(budget);
 
-  const prompt = (
+  const waitForUserApproval = ({waiting}: {waiting: boolean} = {waiting: false}) => (
     <Flex alignItems="center" flexDirection="column">
       <Heading>App Budget</Heading>
 
@@ -27,12 +27,16 @@ export const ApproveBudgetAndFund = (props: Props) => {
 
       <Table>
         <thead>
-          <th>Send</th>
-          <th>Receive</th>
+          <tr>
+            <th>Send</th>
+            <th>Receive</th>
+          </tr>
         </thead>
         <tbody>
-          <td>{formatEther(playerAmount)} ETH</td>
-          <td>{formatEther(hubAmount)} ETH</td>
+          <tr>
+            <td>{formatEther(playerAmount)} ETH</td>
+            <td>{formatEther(hubAmount)} ETH</td>
+          </tr>
         </tbody>
       </Table>
 
@@ -41,13 +45,29 @@ export const ApproveBudgetAndFund = (props: Props) => {
       <Text textAlign="center" pb={3}>
         To enable this, you will need to make a deposit of {formatEther(playerAmount)} ETH.
       </Text>
-      <Button onClick={() => props.send('USER_APPROVES_BUDGET')}>Approve budget</Button>
+      <Button disabled={waiting} onClick={() => props.send('USER_APPROVES_BUDGET')}>
+        Approve budget
+      </Button>
       <Button.Text onClick={() => props.send('USER_REJECTS_BUDGET')}>Cancel</Button.Text>
     </Flex>
   );
-  if (current.value.toString() === 'waitForUserApproval') {
-    return prompt;
-  } else {
-    return <div></div>;
+
+  const waitForPreFS = (
+    <Flex alignItems="center" flexDirection="column">
+      <Heading>App Budget</Heading>
+
+      <Text textAlign="center">Waiting for the hub to respond.</Text>
+    </Flex>
+  );
+
+  switch (current.value.toString()) {
+    case 'waitForUserApproval':
+      return waitForUserApproval();
+    case 'createLedgerStartState':
+      return waitForUserApproval({waiting: true});
+    case 'waitForPreFS':
+      return waitForPreFS;
+    default:
+      return <div>todo</div>;
   }
 };

--- a/packages/xstate-wallet/src/ui/enable-ethereum-workflow.tsx
+++ b/packages/xstate-wallet/src/ui/enable-ethereum-workflow.tsx
@@ -5,7 +5,7 @@ import {Button, Box, Flex, Icon, Text, MetaMaskButton, Flash, Heading} from 'rim
 
 import ConnectionBanner from '@rimble/connection-banner';
 import RimbleUtils from '@rimble/utils';
-import {WorkflowState} from '../workflows/approve-budget-and-fund';
+import {WorkflowState} from '../workflows/ethereum-enable';
 import {WindowContext} from './window-context';
 
 interface Props {
@@ -27,83 +27,77 @@ export const EnableEthereum = (props: Props) => {
     </MetaMaskButton.Outline>
   );
 
-  const NoNetwork = () => {
-    return (
-      <div>
-        <Flash variant={'danger'}>
-          <Flex alignItems="center" justifyContent="space-between" flexDirection="column">
-            <Flex alignItems="center" pb={3} flexDirection="column">
-              <Box>
-                <Icon name="Warning" size="44" />
-              </Box>
-              <Flex flexDirection="column">
-                <Text fontWeight="bold" color={'inherit'} textAlign="center">
-                  Install the MetaMask browser extension to use our blockchain features in your
-                  current browser
-                </Text>
-              </Flex>
-            </Flex>
-
-            <MetaMaskButton as="a" href="https://metamask.io/" target="_blank" color={'white'}>
-              Install MetaMask
-            </MetaMaskButton>
-          </Flex>
-        </Flash>
-      </div>
-    );
-  };
-
-  const WrongNetwork = () => {
-    return (
-      <div>
-        <Flash variant={'danger'}>
-          <Flex alignItems="center" flexDirection="column">
+  const NoNetwork = () => (
+    <div>
+      <Flash variant={'danger'}>
+        <Flex alignItems="center" justifyContent="space-between" flexDirection="column">
+          <Flex alignItems="center" pb={3} flexDirection="column">
             <Box>
               <Icon name="Warning" size="44" />
             </Box>
             <Flex flexDirection="column">
-              <Text fontWeight="bold" color={'inherit'} textAlign="center" pb={3}>
-                Switch to the {RimbleUtils.getEthNetworkNameById(targetNetwork)} network in MetaMask
-              </Text>
-              <Text color={'inherit'} textAlign="center">
-                To use our blockchain features, you need to be on the{' '}
-                {RimbleUtils.getEthNetworkNameById(targetNetwork)} network. You're currently on{' '}
-                {RimbleUtils.getEthNetworkNameById(currentNetwork)}.
+              <Text fontWeight="bold" color={'inherit'} textAlign="center">
+                Install the MetaMask browser extension to use our blockchain features in your
+                current browser
               </Text>
             </Flex>
           </Flex>
-        </Flash>
-      </div>
-    );
-  };
 
-  const NotWeb3Browser = () => {
-    return (
-      <div>
-        <Flash variant={'danger'}>
-          <Flex alignItems="center" flexDirection="column">
-            <Box>
-              <Icon name="Warning" size="44" />
-            </Box>
-            <Flex flexDirection="column">
-              <Text fontWeight="bold" color={'inherit'}>
-                Your browser doesn't support our blockchain features
-              </Text>
-              {RimbleUtils.isMobileDevice() ? (
-                <Text color={'inherit'}>
-                  Try a mobile wallet browser like Status, Coinbase wallet or Cipher
-                </Text>
-              ) : (
-                <Text color={'inherit'}>
-                  Switch to either Brave, FireFox, Opera, or Chrome to continue
-                </Text>
-              )}
-            </Flex>
+          <MetaMaskButton as="a" href="https://metamask.io/" target="_blank" color={'white'}>
+            Install MetaMask
+          </MetaMaskButton>
+        </Flex>
+      </Flash>
+    </div>
+  );
+
+  const WrongNetwork = () => (
+    <div>
+      <Flash variant={'danger'}>
+        <Flex alignItems="center" flexDirection="column">
+          <Box>
+            <Icon name="Warning" size="44" />
+          </Box>
+          <Flex flexDirection="column">
+            <Text fontWeight="bold" color={'inherit'} textAlign="center" pb={3}>
+              Switch to the {RimbleUtils.getEthNetworkNameById(targetNetwork)} network in MetaMask
+            </Text>
+            <Text color={'inherit'} textAlign="center">
+              To use our blockchain features, you need to be on the{' '}
+              {RimbleUtils.getEthNetworkNameById(targetNetwork)} network. You are currently on{' '}
+              {RimbleUtils.getEthNetworkNameById(currentNetwork)}.
+            </Text>
           </Flex>
-        </Flash>
-      </div>
-    );
-  };
+        </Flex>
+      </Flash>
+    </div>
+  );
+
+  const NotWeb3Browser = () => (
+    <div>
+      <Flash variant={'danger'}>
+        <Flex alignItems="center" flexDirection="column">
+          <Box>
+            <Icon name="Warning" size="44" />
+          </Box>
+          <Flex flexDirection="column">
+            <Text fontWeight="bold" color={'inherit'}>
+              Your browser does not support our blockchain features
+            </Text>
+            {RimbleUtils.isMobileDevice() ? (
+              <Text color={'inherit'}>
+                Try a mobile wallet browser like Status, Coinbase wallet or Cipher
+              </Text>
+            ) : (
+              <Text color={'inherit'}>
+                Switch to either Brave, FireFox, Opera, or Chrome to continue
+              </Text>
+            )}
+          </Flex>
+        </Flex>
+      </Flash>
+    </div>
+  );
 
   const button = () => {
     switch (currentState.value.toString()) {

--- a/packages/xstate-wallet/src/ui/stories/approve-budget-and-fund-workflow.stories.tsx
+++ b/packages/xstate-wallet/src/ui/stories/approve-budget-and-fund-workflow.stories.tsx
@@ -1,8 +1,4 @@
-import {
-  approveBudgetAndFundWorkflow,
-  config,
-  WorkflowContext
-} from '../../workflows/approve-budget-and-fund';
+import {machine as approveBudgetAndFundWorkflow} from '../../workflows/approve-budget-and-fund';
 export default {title: 'X-state wallet'};
 import {storiesOf} from '@storybook/react';
 import {interpret} from 'xstate';
@@ -33,21 +29,17 @@ const hub: Participant = {
   signingAddress: '0xb',
   destination: '0xbd' as any
 };
-const testContext: WorkflowContext = {
+const testContext = {
   budget,
   requestId: 55,
   player: alice,
   hub
 };
+const workflow = approveBudgetAndFundWorkflow(store, messagingService, testContext);
 
-if (config.states) {
-  Object.keys(config.states).forEach(state => {
-    const machine = interpret<any, any, any>(
-      approveBudgetAndFundWorkflow(store, messagingService, testContext).withContext(testContext),
-      {
-        devTools: true
-      }
-    ); // start a new interpreted machine for each story
+if (workflow.states) {
+  Object.keys(workflow.states).forEach(state => {
+    const machine = interpret(workflow, {devTools: true}); // start a new interpreted machine for each story
     machine.onEvent(event => console.log(event.type)).start(state);
     storiesOf('Workflows / Approve Budget And Fund', module).add(
       state.toString(),

--- a/packages/xstate-wallet/src/ui/stories/confirm-create-channel-workflow.stories.tsx
+++ b/packages/xstate-wallet/src/ui/stories/confirm-create-channel-workflow.stories.tsx
@@ -14,9 +14,11 @@ import {simpleEthAllocation} from '../../utils';
 import React from 'react';
 import {ConfirmCreateChannel} from '../confirm-create-channel-workflow';
 import {XstateStore} from '../../store';
+import {MessagingService} from '../../messaging';
 
 const store = new XstateStore();
 store.initialize(['0x8624ebe7364bb776f891ca339f0aaa820cc64cc9fca6a28eec71e6d8fc950f29']);
+const messagingService = new MessagingService(store);
 
 const alice: Participant = {
   participantId: 'a',
@@ -42,7 +44,7 @@ const testContext: WorkflowContext = {
 if (config.states) {
   Object.keys(config.states).forEach(state => {
     const machine = interpret<any, any, any>(
-      confirmChannelCreationWorkflow(store, testContext).withContext(testContext),
+      confirmChannelCreationWorkflow(store, messagingService, testContext).withContext(testContext),
       {
         devTools: true
       }

--- a/packages/xstate-wallet/src/ui/wallet.tsx
+++ b/packages/xstate-wallet/src/ui/wallet.tsx
@@ -6,6 +6,7 @@ import './wallet.scss';
 import {ApplicationWorkflow} from './application-workflow';
 import {EnableEthereum} from './enable-ethereum-workflow';
 import {Layout} from './layout';
+import {ApproveBudgetAndFund} from './approve-budget-and-fund-workflow';
 
 interface Props {
   workflow: Interpreter<any, any, any>;
@@ -21,6 +22,9 @@ export const Wallet = (props: Props) => {
         )}
         {props.workflow.id === 'enable-ethereum' && (
           <EnableEthereum current={current} send={send} />
+        )}
+        {props.workflow.id === 'approve-budget-and-fund' && (
+          <ApproveBudgetAndFund current={current} send={send} />
         )}
       </Layout>
     </WindowContext.Provider>

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -13,7 +13,7 @@ import {
   State
 } from 'xstate';
 
-import {sendDisplayMessage, MessagingServiceInterface, convertToChannelResult} from '../messaging';
+import {MessagingServiceInterface, convertToChannelResult} from '../messaging';
 import {filter, map, tap, flatMap, first} from 'rxjs/operators';
 import * as CCC from './confirm-create-channel';
 import {
@@ -263,10 +263,10 @@ export const applicationWorkflow = (
       }
     },
     displayUi: () => {
-      sendDisplayMessage('Show');
+      messagingService.sendDisplayMessage('Show');
     },
     hideUi: () => {
-      sendDisplayMessage('Hide');
+      messagingService.sendDisplayMessage('Hide');
     },
     assignChannelParams: assign((context, event: CreateChannelEvent): ChannelParamsExist &
       RequestIdExists => ({
@@ -358,7 +358,7 @@ export const applicationWorkflow = (
     invokeCreateChannelAndFundProtocol: (_, event: DoneInvokeEvent<CreateAndFund.Init>) =>
       CreateAndFund.machine(store, event.data),
     invokeCreateChannelConfirmation: (context, event: DoneInvokeEvent<CCC.WorkflowContext>) =>
-      CCC.confirmChannelCreationWorkflow(store, event.data),
+      CCC.confirmChannelCreationWorkflow(store, messagingService, event.data),
     getDataForCreateChannelAndFund: async (
       context: ChannelParamsExist
     ): Promise<CreateAndFund.Init> => {

--- a/packages/xstate-wallet/src/workflows/approve-budget-and-fund.ts
+++ b/packages/xstate-wallet/src/workflows/approve-budget-and-fund.ts
@@ -1,153 +1,343 @@
 import {
   StateSchema,
-  State,
   Action,
-  MachineConfig,
-  Machine,
   StateMachine,
-  ServiceConfig
+  ActionObject,
+  createMachine,
+  Guard,
+  State as XStateState,
+  assign,
+  DoneInvokeEvent
 } from 'xstate';
-import {
-  SiteBudget,
-  AllocationItem,
-  Participant,
-  AssetBudget,
-  SimpleAllocation
-} from '../store/types';
-import {sendDisplayMessage, MessagingServiceInterface} from '../messaging';
-import {Store} from '../store';
-import {serializeSiteBudget} from '../serde/app-messages/serialize';
-
-import {CreateAndFundLedger} from '../workflows';
-import {ETH_ASSET_HOLDER_ADDRESS} from '../constants';
-import {simpleEthAllocation, checkThat, exists} from '../utils';
+import {SiteBudget, Participant, SimpleAllocation, AssetBudget} from '../store/types';
 
 import _ from 'lodash';
+import {BigNumber, bigNumberify} from 'ethers/utils';
+import {Store, State as ChannelState} from '../store';
+import {CHALLENGE_DURATION, ETH_ASSET_HOLDER_ADDRESS} from '../constants';
+import {checkThat, exists, simpleEthAllocation} from '../utils';
+import {sendDisplayMessage, MessagingServiceInterface} from '../messaging';
+import {serializeSiteBudget} from '../serde/app-messages/serialize';
+import {filter, map, first} from 'rxjs/operators';
+import {statesEqual} from '../store/state-utils';
 
-interface UserApproves {
-  type: 'USER_APPROVES_BUDGET';
+interface ChainEvent {
+  type: 'CHAIN_EVENT';
+  blockNum: number;
+  balance: BigNumber;
 }
-interface UserRejects {
-  type: 'USER_REJECTS_BUDGET';
-}
-export type WorkflowEvent = UserApproves | UserRejects;
 
-export interface WorkflowContext {
+type Event =
+  | {type: 'USER_APPROVES_BUDGET'}
+  | {type: 'USER_REJECTS_BUDGET'}
+  | {type: 'USER_APPROVES_RETRY'}
+  | {type: 'USER_REJECTS_RETRY'}
+  | ChainEvent;
+
+interface Initial {
   budget: SiteBudget;
   player: Participant;
   hub: Participant;
   requestId: number;
 }
-
-export interface WorkflowServices extends Record<string, ServiceConfig<WorkflowContext>> {
-  createAndFundLedger: (context: WorkflowContext, event: any) => StateMachine<any, any, any, any>;
+interface LedgerExists extends Initial {
+  ledgerId: string;
+  ledgerState: ChannelState;
 }
-export interface WorkflowStateSchema extends StateSchema<WorkflowContext> {
+interface Deposit {
+  depositAt: BigNumber;
+  totalAfterDeposit: BigNumber;
+  fundedAt: BigNumber;
+}
+
+interface Chain {
+  ledgerTotal: BigNumber;
+  lastChangeBlockNum: number;
+  currentBlockNum: number;
+}
+
+interface Transaction {
+  transactionId: string;
+}
+
+type Typestate =
+  | {value: 'waitForApproval'; context: Initial}
+  | {value: 'createLedger'; context: Initial}
+  | {value: 'waitForPreFS'; context: LedgerExists}
+  | {value: {deposit: 'init'}; context: LedgerExists & Deposit}
+  | {value: {deposit: 'waitTurn'}; context: LedgerExists & Deposit & Chain}
+  | {value: {deposit: 'submitTransaction'}; context: LedgerExists & Deposit & Chain}
+  | {value: {deposit: 'retry'}; context: LedgerExists & Deposit & Chain}
+  | {value: {deposit: 'waitMining'}; context: LedgerExists & Deposit & Chain & Transaction}
+  | {value: {deposit: 'waitFullyFunded'}; context: LedgerExists & Deposit & Chain}
+  | {value: 'done'; context: LedgerExists}
+  | {value: 'failure'; context: Initial};
+
+type Context = Typestate['context'];
+
+export interface Schema extends StateSchema<Context> {
   states: {
     waitForUserApproval: {};
-    fundLedger: {};
+    createLedger: {};
+    waitForPreFS: {};
+    deposit: {
+      states: {
+        init: {};
+        waitTurn: {};
+        submitTransaction: {};
+        retry: {};
+        waitMining: {};
+        waitFullyFunded: {};
+      };
+    };
     done: {};
     failure: {};
   };
 }
-export type WorkflowState = State<WorkflowContext, WorkflowEvent, WorkflowStateSchema, any>;
+
+export type WorkflowState = XStateState<Context, Event, Schema, Typestate>;
 
 export interface WorkflowActions {
-  hideUi: Action<WorkflowContext, any>;
-  displayUi: Action<WorkflowContext, any>;
-  sendResponse: Action<WorkflowContext, any>;
-  sendBudgetUpdated: Action<WorkflowContext, any>;
-  updateBudget: Action<WorkflowContext, any>;
+  hideUi: Action<Context, any>;
+  displayUi: Action<Context, any>;
+  sendResponse: Action<Context, any>;
+  sendBudgetUpdated: Action<Context, any>;
 }
-export type StateValue = keyof WorkflowStateSchema['states'];
+export type StateValue = keyof Schema['states'];
 
-const generateConfig = (
-  actions: WorkflowActions
-): MachineConfig<WorkflowContext, WorkflowStateSchema, WorkflowEvent> => ({
-  id: 'approve-budget-and-fund',
-  initial: 'fundLedger',
-  entry: [actions.displayUi, actions.updateBudget],
-  states: {
-    waitForUserApproval: {
-      on: {
-        USER_APPROVES_BUDGET: {target: 'fundLedger', actions: []},
-        USER_REJECTS_BUDGET: {target: 'failure'}
-      }
-    },
-    fundLedger: {invoke: {src: 'createAndFundLedger', onDone: 'done'}},
-    done: {
-      type: 'final',
-      entry: [
-        actions.hideUi,
-        actions.sendResponse,
-        /* This might be overkill */ actions.sendBudgetUpdated
-      ]
-    },
-    failure: {type: 'final'}
-  }
-});
-
-const mockActions: WorkflowActions = {
-  hideUi: 'hideUi',
-  displayUi: 'displayUi',
-  sendResponse: 'sendResponse',
-  sendBudgetUpdated: 'sendBudgetUpdated',
-  updateBudget: 'updateBudget'
-};
-
-export const approveBudgetAndFundWorkflow = (
+export const machine = (
   store: Store,
   messagingService: MessagingServiceInterface,
-  context: WorkflowContext
-): WorkflowMachine => {
-  const services: WorkflowServices = {
-    createAndFundLedger: (context: WorkflowContext) =>
-      CreateAndFundLedger.createAndFundLedgerWorkflow(store, {
-        initialOutcome: convertBudgetToAllocation(context),
-        participants: [context.player, context.hub]
-      })
+  context: Initial
+): StateMachine<Context, Schema, Event, Typestate> =>
+  createMachine<Context, Event, Typestate>({
+    id: 'approve-budget-and-fund',
+    context,
+    initial: 'waitForUserApproval',
+    entry: displayUI(messagingService),
+    states: {
+      waitForUserApproval: {
+        on: {
+          USER_APPROVES_BUDGET: {target: 'createLedger'},
+          USER_REJECTS_BUDGET: {target: 'failure'}
+        }
+      },
+      createLedger: {
+        invoke: {
+          id: 'createLedgerStartState',
+          src: initializeLedger(store),
+          onDone: {target: 'waitForPreFS', actions: setLedgerInfo}
+        }
+      },
+      waitForPreFS: {
+        invoke: {
+          id: 'subscribeToLedgerUpdates',
+          src: notifyWhenPreFSSupported(store),
+          onDone: {target: 'deposit', actions: assignDepositingInfo}
+        }
+      },
+      deposit: {
+        initial: 'init',
+        invoke: {
+          id: 'observeChain',
+          src: observeLedgerOnChainBalance(store)
+        },
+        on: {
+          CHAIN_EVENT: [
+            {target: 'done', actions: assignChainData, cond: fullAmountConfirmed},
+            {target: '.waitFullyFunded', actions: assignChainData, cond: myAmountConfirmed}
+          ]
+        },
+        states: {
+          init: {
+            on: {
+              CHAIN_EVENT: [
+                {target: 'submitTransaction', actions: assignChainData, cond: priorAmountConfirmed},
+                {target: 'waitTurn', actions: assignChainData}
+              ]
+            }
+          },
+          waitTurn: {
+            on: {
+              CHAIN_EVENT: [
+                {target: 'submitTransaction', actions: assignChainData, cond: priorAmountConfirmed}
+              ]
+            }
+          },
+          submitTransaction: {
+            invoke: {
+              id: 'submitTransaction',
+              src: submitDepositTransaction(store),
+              onDone: {target: 'waitMining', actions: setTransactionId}
+              // onError: {target: 'retry'}
+            }
+          },
+          retry: {
+            on: {
+              USER_APPROVES_RETRY: {target: 'submitTransaction'},
+              USER_REJECTS_RETRY: {target: '#failure'}
+            }
+          },
+          waitMining: {},
+          waitFullyFunded: {}
+        }
+      },
+      done: {
+        id: 'done',
+        type: 'final',
+        entry: [
+          hideUI(messagingService),
+          sendResponse(messagingService)
+          // /* This might be overkill */ actions.sendBudgetUpdated
+        ]
+      },
+      failure: {id: 'failure', type: 'final'}
+    }
+  });
+
+interface LedgerInitRetVal {
+  ledgerId: string;
+  ledgerState: ChannelState;
+}
+
+const initializeLedger = (store: Store) => async (context: Initial): Promise<LedgerInitRetVal> => {
+  const initialOutcome = convertPendingBudgetToAllocation(context);
+  const participants = [context.player, context.hub];
+
+  const stateVars = {
+    outcome: initialOutcome,
+    turnNum: bigNumberify(0),
+    isFinal: false,
+    appData: '0x0'
   };
-  const actions = {
-    // TODO: We should probably set up some standard actions for all workflows
-    displayUi: () => {
-      sendDisplayMessage('Show');
-    },
-    hideUi: () => {
-      sendDisplayMessage('Hide');
-    },
-    sendResponse: (context: WorkflowContext, event) => {
-      messagingService.sendResponse(context.requestId, serializeSiteBudget(context.budget));
-    },
-    sendBudgetUpdated: async (context: WorkflowContext, event) => {
-      await messagingService.sendBudgetNotification(context.budget);
-    },
-    updateBudget: (context: WorkflowContext, event) => store.createBudget(context.budget)
+  const entry = await store.createChannel(participants, CHALLENGE_DURATION, stateVars);
+  await store.setFunding(entry.channelId, {type: 'Direct'});
+  await store.setLedger(entry.channelId);
+
+  return {
+    ledgerId: entry.channelId,
+    ledgerState: entry.latestState
   };
-  const config = generateConfig(actions);
-  return Machine(config).withConfig({services}, context) as WorkflowMachine;
 };
 
-export type WorkflowMachine = StateMachine<WorkflowContext, StateSchema, WorkflowEvent, any>;
+const setLedgerInfo = assign<Context, DoneInvokeEvent<LedgerInitRetVal>>({
+  ledgerId: (context, event) => event.data.ledgerId,
+  ledgerState: (context, event) => event.data.ledgerState
+});
 
-// To keep consistent with the majority of other workflows
-export type Init = WorkflowContext;
-export const machine = approveBudgetAndFundWorkflow;
-
-export const config = generateConfig(mockActions);
-
-function convertBudgetToAllocation({hub, player, budget}: WorkflowContext): SimpleAllocation {
+function convertPendingBudgetToAllocation({hub, player, budget}: Context): SimpleAllocation {
   // TODO: Eventually we will need to support more complex budgets
   if (Object.keys(budget.forAsset).length !== 1) {
     throw new Error('Cannot handle mixed budget');
   }
+  // todo: this throws if the budget is undefined and casts it to a AssetBudget otherwise
+  // maybe this should be called assertBudgetExists ??
   const ethBudget = checkThat<AssetBudget>(budget.forAsset[ETH_ASSET_HOLDER_ADDRESS], exists);
-  const playerItem: AllocationItem = {
+  const playerItem = {
     destination: player.destination,
     amount: ethBudget.availableSendCapacity
   };
-  const hubItem: AllocationItem = {
+  const hubItem = {
     destination: hub.destination,
     amount: ethBudget.availableReceiveCapacity
   };
   return simpleEthAllocation([hubItem, playerItem]);
 }
+
+const displayUI = (messagingService: MessagingServiceInterface): ActionObject<Context, Event> => ({
+  type: 'displayUI',
+  exec: () => sendDisplayMessage('Show')
+});
+const hideUI = (messagingService: MessagingServiceInterface): ActionObject<Context, Event> => ({
+  type: 'hideUI',
+  exec: () => sendDisplayMessage('Hide')
+});
+
+const sendResponse = (
+  messagingService: MessagingServiceInterface
+): ActionObject<Context, Event> => ({
+  type: 'sendResponse',
+  exec: context =>
+    messagingService.sendResponse(context.requestId, serializeSiteBudget(context.budget))
+});
+
+const assignDepositingInfo = assign<Context>({
+  // this is inefficient, but if use the other style of xstate assign, the devtools break ...
+  depositAt: context => calculateDepositInfo(context).depositAt,
+  totalAfterDeposit: context => calculateDepositInfo(context).totalAfterDeposit,
+  fundedAt: context => calculateDepositInfo(context).fundedAt
+});
+
+const calculateDepositInfo = (context: Context) => {
+  const ethBudget = checkThat<AssetBudget>(
+    context.budget.forAsset[ETH_ASSET_HOLDER_ADDRESS],
+    exists
+  );
+  const ourAmount = ethBudget.availableSendCapacity;
+  const hubAmount = ethBudget.availableSendCapacity;
+  const totalAmount = ourAmount.add(hubAmount);
+
+  const depositAt = hubAmount; // hub goes first
+  const totalAfterDeposit = totalAmount;
+  const fundedAt = totalAmount;
+  return {depositAt, totalAfterDeposit, fundedAt};
+};
+
+const notifyWhenPreFSSupported = (store: Store) => ({ledgerState, ledgerId}: LedgerExists) =>
+  store
+    .channelUpdatedFeed(ledgerId)
+    .pipe(
+      filter(({isSupported}) => isSupported),
+      filter(({supported}) => statesEqual(ledgerState, supported)), //store the hash?
+      map(() => 'SUPPORTED'),
+      first()
+    )
+    .toPromise();
+
+const observeLedgerOnChainBalance = (store: Store) => ({ledgerId}: LedgerExists) =>
+  store.chain.chainUpdatedFeed(ledgerId).pipe(
+    map(chainInfo => ({
+      type: 'CHAIN_EVENT',
+      balance: chainInfo.amount,
+      blockNum: chainInfo.blockNum
+    }))
+  );
+
+// // for now don't wait for any number of blocks (until the chain is reporting blockNum)
+const fullAmountConfirmed: Guard<Deposit, ChainEvent> = {
+  type: 'xstate.guard',
+  name: 'fullAmountConfirmed',
+  predicate: (context, event) => event.balance.gte(context.fundedAt)
+};
+const priorAmountConfirmed: Guard<Deposit, ChainEvent> = {
+  type: 'xstate.guard',
+  name: 'priorAmountConfirmed',
+  predicate: (context, event) => event.balance.gte(context.depositAt)
+};
+const myAmountConfirmed: Guard<Deposit, ChainEvent> = {
+  type: 'xstate.guard',
+  name: 'myAmountConfirmed',
+  predicate: (context, event) => event.balance.gte(context.totalAfterDeposit)
+};
+
+const assignChainData = assign<Context, ChainEvent>({
+  ledgerTotal: (context, event: ChainEvent) => event.balance,
+  currentBlockNum: (context, event: ChainEvent) => event.blockNum,
+  lastChangeBlockNum: (context, event: ChainEvent) =>
+    context.ledgerTotal && context.ledgerTotal.eq(event.balance)
+      ? context.lastChangeBlockNum
+      : event.blockNum
+});
+
+const setTransactionId = assign<Context, DoneInvokeEvent<string>>({
+  transactionId: (context, event) => event.data
+});
+
+const submitDepositTransaction = (store: Store) => async (
+  ctx: LedgerExists & Deposit & Chain
+): Promise<string | undefined> => {
+  const amount = ctx.totalAfterDeposit.sub(ctx.ledgerTotal);
+  if (amount.lte(0)) return undefined; // sanity check: we shouldn't be in this state, if this is the case
+
+  return store.chain.deposit(ctx.ledgerId, ctx.ledgerTotal.toHexString(), amount.toHexString());
+};

--- a/packages/xstate-wallet/src/workflows/approve-budget-and-fund.ts
+++ b/packages/xstate-wallet/src/workflows/approve-budget-and-fund.ts
@@ -15,7 +15,7 @@ import {BigNumber, bigNumberify} from 'ethers/utils';
 import {Store, State as ChannelState} from '../store';
 import {CHALLENGE_DURATION, ETH_ASSET_HOLDER_ADDRESS} from '../constants';
 import {checkThat, exists, simpleEthAllocation} from '../utils';
-import {sendDisplayMessage, MessagingServiceInterface} from '../messaging';
+import {MessagingServiceInterface} from '../messaging';
 import {serializeSiteBudget} from '../serde/app-messages/serialize';
 import {filter, map, first} from 'rxjs/operators';
 import {statesEqual} from '../store/state-utils';
@@ -251,11 +251,11 @@ function convertPendingBudgetToAllocation({hub, player, budget}: Context): Simpl
 
 const displayUI = (messagingService: MessagingServiceInterface): ActionObject<Context, Event> => ({
   type: 'displayUI',
-  exec: () => sendDisplayMessage('Show')
+  exec: () => messagingService.sendDisplayMessage('Show')
 });
 const hideUI = (messagingService: MessagingServiceInterface): ActionObject<Context, Event> => ({
   type: 'hideUI',
-  exec: () => sendDisplayMessage('Hide')
+  exec: () => messagingService.sendDisplayMessage('Hide')
 });
 
 const sendResponse = (

--- a/packages/xstate-wallet/src/workflows/close-ledger-and-withdraw.ts
+++ b/packages/xstate-wallet/src/workflows/close-ledger-and-withdraw.ts
@@ -14,7 +14,7 @@ import {SupportState} from '.';
 import {Store} from '../store';
 import {outcomesEqual} from '../store/state-utils';
 import {Participant, Objective, CloseLedger} from '../store/types';
-import {MessagingServiceInterface, sendDisplayMessage} from '../messaging';
+import {MessagingServiceInterface} from '../messaging';
 
 type WorkflowEvent = UserApproves | UserRejects | DoneInvokeEvent<CloseLedger>;
 interface UserApproves {
@@ -139,10 +139,10 @@ const options = (
   actions: {
     clearBudget: clearBudget(store),
     displayUi: () => {
-      sendDisplayMessage('Show');
+      messagingService.sendDisplayMessage('Show');
     },
     hideUi: () => {
-      sendDisplayMessage('Hide');
+      messagingService.sendDisplayMessage('Hide');
     },
     sendResponse: async context =>
       await messagingService.sendResponse(context.requestId, {success: true}),

--- a/packages/xstate-wallet/src/workflows/confirm-create-channel.ts
+++ b/packages/xstate-wallet/src/workflows/confirm-create-channel.ts
@@ -1,10 +1,10 @@
 import {MachineConfig, Action, StateSchema, Machine, Condition, StateMachine, State} from 'xstate';
 import {Participant} from '@statechannels/client-api-schema';
-import {sendDisplayMessage} from '../messaging';
 import {createMockGuard} from '../utils';
 import {Store} from '../store';
 import {SimpleAllocation} from '../store/types';
 import {BigNumber} from 'ethers/utils';
+import {MessagingServiceInterface} from '../messaging';
 
 interface WorkflowActions {
   hideUi: Action<WorkflowContext, any>;
@@ -87,22 +87,25 @@ const mockGuards = {
 export const mockOptions = {actions: mockActions, guards: mockGuards};
 export const mockConfig = generateConfig(mockActions, mockGuards);
 const guards = {noBudget: () => true};
-const actions = {
-  // TODO: We should probably set up some standard actions for all workflows
-  displayUi: () => {
-    sendDisplayMessage('Show');
-  },
-  hideUi: () => {
-    sendDisplayMessage('Hide');
-  }
-};
-export const config = generateConfig(actions, guards);
+export const config = generateConfig(mockActions, guards);
+
 export const confirmChannelCreationWorkflow = (
   _store: Store,
+  messagingService: MessagingServiceInterface,
   context: WorkflowContext
-): WorkflowMachine =>
-  // TODO: Once budgets are a thing this should check for a budget
-  // TODO: We shouldn't need to cast this but some xstate typing is not lining up around stateSchema
-  Machine(config).withConfig({}, context) as WorkflowMachine;
+): WorkflowMachine => {
+  const actions = {
+    // TODO: We should probably set up some standard actions for all workflows
+    displayUi: () => {
+      messagingService.sendDisplayMessage('Show');
+    },
+    hideUi: () => {
+      messagingService.sendDisplayMessage('Hide');
+    }
+  };
+  return Machine(config).withConfig({actions}, context) as WorkflowMachine;
+};
+// TODO: Once budgets are a thing this should check for a budget
+// TODO: We shouldn't need to cast this but some xstate typing is not lining up around stateSchema
 
 export type WorkflowMachine = StateMachine<WorkflowContext, StateSchema, WorkflowEvent, any>;

--- a/packages/xstate-wallet/src/workflows/ethereum-enable.ts
+++ b/packages/xstate-wallet/src/workflows/ethereum-enable.ts
@@ -10,7 +10,7 @@ import {
   ServiceConfig,
   assign
 } from 'xstate';
-import {sendDisplayMessage, MessagingServiceInterface} from '../messaging';
+import {MessagingServiceInterface} from '../messaging';
 import {Store} from '../store';
 import {WALLET_VERSION} from '../constants';
 
@@ -92,10 +92,10 @@ export const ethereumEnableWorkflow = (
   };
   const actions = {
     displayUi: () => {
-      sendDisplayMessage('Show');
+      messagingService.sendDisplayMessage('Show');
     },
     hideUi: () => {
-      sendDisplayMessage('Hide');
+      messagingService.sendDisplayMessage('Hide');
     },
     sendResponse: async (context: WorkflowContext, event) => {
       messagingService.sendResponse(context.requestId, {

--- a/packages/xstate-wallet/src/workflows/tests/approve-budget-and-fund.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/approve-budget-and-fund.test.ts
@@ -1,0 +1,88 @@
+import {
+  wallet1 as playerWallet,
+  wallet2 as hubWallet,
+  first as player,
+  second as hub
+} from './data';
+import {bigNumberify} from 'ethers/utils';
+
+import {ethBudget} from '../../utils/budget-utils';
+import {FakeChain} from '../../chain';
+import {TestStore} from './store';
+import {SimpleHub} from './simple-hub';
+import {subscribeToMessages} from './message-service';
+
+import {machine as approveBudgetAndFund} from '../approve-budget-and-fund';
+import {MessagingService} from '../../messaging';
+import {interpret} from 'xstate';
+import waitForExpect from 'wait-for-expect';
+
+jest.setTimeout(20000);
+const EXPECT_TIMEOUT = process.env.CI ? 9500 : 5000;
+
+const budget = ethBudget('example.com', {
+  availableReceiveCapacity: bigNumberify(5),
+  availableSendCapacity: bigNumberify(5)
+});
+
+hub.participantId = 'hub';
+player.participantId = 'player';
+
+const initialContext = {
+  budget,
+  hub,
+  player,
+  requestId: 123
+};
+let chain, playerStore, hubStore, messagingService;
+
+beforeEach(async () => {
+  chain = new FakeChain();
+  playerStore = new TestStore(chain);
+  messagingService = new MessagingService(playerStore);
+
+  hubStore = new SimpleHub(hubWallet.privateKey);
+  await playerStore.initialize([playerWallet.privateKey]);
+
+  subscribeToMessages({
+    [player.participantId]: playerStore,
+    [hub.participantId]: hubStore
+  });
+});
+
+it('works end to end', async () => {
+  const runningWorkflow = interpret(
+    approveBudgetAndFund(playerStore, messagingService, initialContext)
+  ).start();
+
+  await waitForExpect(async () => {
+    expect(runningWorkflow.state.value).toEqual('waitForUserApproval');
+  }, EXPECT_TIMEOUT);
+
+  await runningWorkflow.send({type: 'USER_APPROVES_BUDGET'});
+  // creates preFS
+  // sends preFS to hub
+  // hub replies with signed preFS
+  // workflow subscribes to chain
+  // chain responds with initial state
+  // it's the hub turn first
+
+  await waitForExpect(async () => {
+    expect(runningWorkflow.state.value).toEqual({deposit: 'waitTurn'});
+  }, EXPECT_TIMEOUT);
+
+  const ledgerId = (runningWorkflow.state.context as any).ledgerId;
+
+  chain.depositSync(ledgerId, 0, 5);
+
+  // goes to submitTransaction
+  // waitMining, which happens immediately
+  // skip waitFullyFunded
+  // end in done
+
+  await waitForExpect(async () => {
+    expect(runningWorkflow.state.value).toEqual('done');
+  }, EXPECT_TIMEOUT);
+
+  expect(true).toBe(true);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -35457,10 +35457,10 @@ xregexp@4.0.0:
   resolved "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz#e698189de49dd2a18cc5687b05e17c8e43943020"
   integrity sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==
 
-xstate@4.7.7:
-  version "4.7.7"
-  resolved "https://registry.npmjs.org/xstate/-/xstate-4.7.7.tgz#3533edec1f8d72f147009301f071dc35f1a5ac33"
-  integrity sha512-ctV7gShkDe+HOLP1MV78FRqWhNtmMJvtGjlgP10N6MeELVxGbvc54WrwfBv0e/xyjSaqveM48Pohut71naqVNA==
+xstate@4.8.0:
+  version "4.8.0"
+  resolved "https://registry.npmjs.org/xstate/-/xstate-4.8.0.tgz#1aefa1f7828f84f61c356785615ffc0824ebf5a2"
+  integrity sha512-xHSYQtCHLkcrFRxa5lK4Lp1rnKt00a80jcKFMQiMBuE+6MvTYv7twwqYpzjsJoKFjGZB3GGEpZAuY1dmlPTh/g==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
This PR flattens out the approve budget workflow, so there's one top level machine that only invokes promises/observables (and not other machines). It adds the ability to view this machine, by navigating to localhost:3055, and using the xstate-devtools.

![Screen Shot 2020-04-02 at 12 32 49 PM](https://user-images.githubusercontent.com/29596/78244711-16110f80-74de-11ea-80d1-08fa48c4d3b9.png)

Todo in later work:
* Make the submitTransaction and deposit sub-machines re-usable