### PR TITLE
[xstate-wallet] Improve outcomesEqual utility function.

### DIFF
--- a/packages/xstate-wallet/src/store/state-utils.ts
+++ b/packages/xstate-wallet/src/store/state-utils.ts
@@ -107,12 +107,12 @@ export function outcomesEqual(left: Outcome, right?: Outcome) {
     return simpleGuaranteesEqual(left, right);
   }
   if (left.type === 'MixedAllocation' && right?.type === 'MixedAllocation') {
-    if (left.simpleAllocations.length === right.simpleAllocations.length) {
-      return left.simpleAllocations
-        .map((value, index, array) =>
-          simpleAllocationsEqual(left.simpleAllocations[index], right.simpleAllocations[index])
-        )
-        .reduce((a, b) => a && b);
+    return (
+      left.simpleAllocations.length === right.simpleAllocations.length &&
+      _.every(left.simpleAllocations, (_, index) =>
+        simpleAllocationsEqual(left.simpleAllocations[index], right.simpleAllocations[index])
+      )
+    );
     }
   }
   return false;

--- a/packages/xstate-wallet/src/store/state-utils.ts
+++ b/packages/xstate-wallet/src/store/state-utils.ts
@@ -79,18 +79,16 @@ export function statesEqual(left: State, right: State) {
 }
 
 function simpleAllocationsEqual(left: SimpleAllocation, right: SimpleAllocation) {
-  if (left.assetHolderAddress === right.assetHolderAddress) {
-    if ((left.allocationItems.length = right.allocationItems.length)) {
-      return left.allocationItems
-        .map(
-          (value, index, array) =>
-            value.destination === right.allocationItems[index].destination &&
-            value.amount.eq(right.allocationItems[index].amount)
-        )
-        .reduce((a, b) => a && b);
-    }
-  }
-  return false;
+  return (
+    left.assetHolderAddress === right.assetHolderAddress &&
+    left.allocationItems.length === right.allocationItems.length &&
+    _.every(
+      left.allocationItems,
+      (value, index) =>
+        value.destination === right.allocationItems[index].destination &&
+        value.amount.eq(right.allocationItems[index].amount)
+    )
+  );
 }
 
 function simpleGuaranteesEqual(left: SimpleGuarantee, right: SimpleGuarantee) {

--- a/packages/xstate-wallet/src/store/state-utils.ts
+++ b/packages/xstate-wallet/src/store/state-utils.ts
@@ -4,8 +4,7 @@ import {
   Outcome,
   AllocationItem,
   SignedState,
-  SimpleAllocation,
-  SimpleGuarantee
+  SimpleAllocation
 } from './types';
 import {
   State as NitroState,
@@ -91,20 +90,12 @@ function simpleAllocationsEqual(left: SimpleAllocation, right: SimpleAllocation)
   );
 }
 
-function simpleGuaranteesEqual(left: SimpleGuarantee, right: SimpleGuarantee) {
-  return (
-    left.assetHolderAddress === right.assetHolderAddress &&
-    left.targetChannelId == right.targetChannelId &&
-    left.destinations === right.destinations
-  );
-}
-
 export function outcomesEqual(left: Outcome, right?: Outcome) {
   if (left.type === 'SimpleAllocation' && right?.type === 'SimpleAllocation') {
     return simpleAllocationsEqual(left, right);
   }
   if (left.type === 'SimpleGuarantee' && right?.type === 'SimpleGuarantee') {
-    return simpleGuaranteesEqual(left, right);
+    return _.isEqual(left, right);
   }
   if (left.type === 'MixedAllocation' && right?.type === 'MixedAllocation') {
     return (
@@ -113,7 +104,6 @@ export function outcomesEqual(left: Outcome, right?: Outcome) {
         simpleAllocationsEqual(left.simpleAllocations[index], right.simpleAllocations[index])
       )
     );
-    }
   }
   return false;
 }

--- a/packages/xstate-wallet/src/store/tests/outcomes-equal.test.ts
+++ b/packages/xstate-wallet/src/store/tests/outcomes-equal.test.ts
@@ -1,0 +1,26 @@
+import {outcomesEqual} from '../state-utils';
+import {SimpleAllocation} from '../types';
+import {AddressZero, HashZero} from 'ethers/constants';
+import {bigNumberify} from 'ethers/utils';
+
+const simpleAllocation1 = {
+  type: 'SimpleAllocation',
+  assetHolderAddress: AddressZero,
+  allocationItems: [{destination: HashZero, amount: bigNumberify('0x2')}]
+} as SimpleAllocation;
+
+const simpleAllocation2 = {
+  type: 'SimpleAllocation',
+  assetHolderAddress: AddressZero,
+  allocationItems: [{destination: HashZero, amount: bigNumberify('0x02')}]
+} as SimpleAllocation;
+
+describe('outcomesEqual', () => {
+  it('returns equal for identical SimpleAllocations', async () => {
+    expect(outcomesEqual(simpleAllocation1, simpleAllocation1)).toEqual(true);
+  });
+
+  it('returns equal for equivalent SimpleAllocations', async () => {
+    expect(outcomesEqual(simpleAllocation1, simpleAllocation2)).toEqual(true);
+  });
+});

--- a/packages/xstate-wallet/src/store/tests/outcomes-equal.test.ts
+++ b/packages/xstate-wallet/src/store/tests/outcomes-equal.test.ts
@@ -1,19 +1,19 @@
 import {outcomesEqual} from '../state-utils';
-import {SimpleAllocation} from '../types';
+import {SimpleAllocation, Destination} from '../types';
 import {AddressZero, HashZero} from 'ethers/constants';
 import {bigNumberify} from 'ethers/utils';
 
-const simpleAllocation1 = {
+const simpleAllocation1: SimpleAllocation = {
   type: 'SimpleAllocation',
   assetHolderAddress: AddressZero,
-  allocationItems: [{destination: HashZero, amount: bigNumberify('0x2')}]
-} as SimpleAllocation;
+  allocationItems: [{destination: HashZero as Destination, amount: bigNumberify('0x2')}]
+};
 
-const simpleAllocation2 = {
+const simpleAllocation2: SimpleAllocation = {
   type: 'SimpleAllocation',
   assetHolderAddress: AddressZero,
-  allocationItems: [{destination: HashZero, amount: bigNumberify('0x02')}]
-} as SimpleAllocation;
+  allocationItems: [{destination: HashZero as Destination, amount: bigNumberify('0x02')}]
+};
 
 describe('outcomesEqual', () => {
   it('returns equal for identical SimpleAllocations', async () => {

--- a/packages/xstate-wallet/src/workflows/conclude-channel.ts
+++ b/packages/xstate-wallet/src/workflows/conclude-channel.ts
@@ -20,7 +20,6 @@ const finalState = (store: Store) => async (context: Init): Promise<SupportState
 
   // If we've received a new final state that matches our outcome we support that
   if (outcomesEqual(latestSupportedByMe.outcome, latestFinalState?.outcome)) {
-    // outcomesEqual function will return false if there is inconsistent padding of hex strings
     return {state: latestFinalState};
   }
 


### PR DESCRIPTION
Currently this function does not understand that (e.g.)   '0x02' and '0x2' are equal.