### PR TITLE
Reorganise xstate utils

### DIFF
--- a/packages/xstate-wallet/src/allocate-to-target.test.ts
+++ b/packages/xstate-wallet/src/allocate-to-target.test.ts
@@ -4,7 +4,7 @@ import {
   simpleEthAllocation,
   simpleTokenAllocation,
   makeDestination
-} from './utils/outcome';
+} from './utils';
 import {AllocationItem} from './store/types';
 import {bigNumberify} from 'ethers/utils';
 

--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -3,7 +3,7 @@ import {
   createETHDepositTransaction,
   Transactions
 } from '@statechannels/nitro-protocol';
-import {getProvider} from './utils/contract-utils';
+import {getProvider} from './utils';
 import {ethers} from 'ethers';
 import {BigNumber, bigNumberify, hexZeroPad} from 'ethers/utils';
 import {State, SignedState} from './store/types';

--- a/packages/xstate-wallet/src/integration-tests/approve-budget.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/approve-budget.test.ts
@@ -3,7 +3,7 @@ import {FakeChain} from '../chain';
 import {Player, generateApproveBudgetAndFundRequest, hookUpMessaging} from './helpers';
 import {FundLedger} from '../store/types';
 import {checkThat} from '../utils';
-import {isSimpleEthAllocation} from '../utils/outcome';
+import {isSimpleEthAllocation} from '../utils';
 
 import {bigNumberify, hexZeroPad} from 'ethers/utils';
 import {ApproveBudgetAndFundResponse} from '@statechannels/client-api-schema/src';

--- a/packages/xstate-wallet/src/integration-tests/approve-budget.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/approve-budget.test.ts
@@ -2,8 +2,7 @@ import {filter, map, first} from 'rxjs/operators';
 import {FakeChain} from '../chain';
 import {Player, generateApproveBudgetAndFundRequest, hookUpMessaging} from './helpers';
 import {FundLedger} from '../store/types';
-import {checkThat} from '../utils';
-import {isSimpleEthAllocation} from '../utils';
+import {checkThat, isSimpleEthAllocation} from '../utils';
 
 import {bigNumberify, hexZeroPad} from 'ethers/utils';
 import {ApproveBudgetAndFundResponse} from '@statechannels/client-api-schema/src';

--- a/packages/xstate-wallet/src/integration-tests/close-withdraw.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/close-withdraw.test.ts
@@ -4,7 +4,7 @@ import {CloseAndWithdrawResponse} from '@statechannels/client-api-schema';
 import {filter, map, first} from 'rxjs/operators';
 
 import {CHALLENGE_DURATION} from '../constants';
-import {simpleEthAllocation} from '../utils/outcome';
+import {simpleEthAllocation} from '../utils';
 import {bigNumberify} from 'ethers/utils';
 import {isCloseLedger, CloseLedger} from '../store/types';
 import waitForExpect from 'wait-for-expect';

--- a/packages/xstate-wallet/src/integration-tests/closing.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/closing.test.ts
@@ -2,7 +2,7 @@ import {FakeChain} from '../chain';
 import {Player, hookUpMessaging, generateCloseRequest} from './helpers';
 import {bigNumberify, hexZeroPad} from 'ethers/utils';
 import waitForExpect from 'wait-for-expect';
-import {simpleEthAllocation} from '../utils/outcome';
+import {simpleEthAllocation} from '../utils';
 import {State, SignedState} from '../store/types';
 import {signState} from '../store/state-utils';
 import {CHALLENGE_DURATION, NETWORK_ID} from '../constants';

--- a/packages/xstate-wallet/src/integration-tests/helpers.ts
+++ b/packages/xstate-wallet/src/integration-tests/helpers.ts
@@ -20,7 +20,7 @@ import {Guid} from 'guid-typescript';
 import * as CloseLedgerAndWithdraw from '../workflows/close-ledger-and-withdraw';
 import {TestStore} from '../workflows/tests/store';
 import {ETH_TOKEN} from '../constants';
-import {makeDestination} from '../utils/outcome';
+import {makeDestination} from '../utils';
 import {hexZeroPad} from 'ethers/utils';
 
 export class Player {

--- a/packages/xstate-wallet/src/integration-tests/running.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/running.test.ts
@@ -2,7 +2,7 @@ import {FakeChain} from '../chain';
 import {Player, hookUpMessaging, generatePlayerUpdate} from './helpers';
 import {bigNumberify} from 'ethers/utils';
 import waitForExpect from 'wait-for-expect';
-import {simpleEthAllocation} from '../utils/outcome';
+import {simpleEthAllocation} from '../utils';
 import {first} from 'rxjs/operators';
 jest.setTimeout(30000);
 test('accepts states when running', async () => {

--- a/packages/xstate-wallet/src/messaging.ts
+++ b/packages/xstate-wallet/src/messaging.ts
@@ -23,14 +23,14 @@ import * as jrs from 'jsonrpc-lite';
 import {fromEvent, Observable} from 'rxjs';
 import {ChannelStoreEntry} from './store/channel-store-entry';
 import {validateMessage} from '@statechannels/wire-format';
-import {unreachable} from './utils';
+import {unreachable, isSimpleEthAllocation, makeDestination} from './utils';
 import {isAllocation, Message, SiteBudget, Participant} from './store/types';
 import {serializeAllocation, serializeSiteBudget} from './serde/app-messages/serialize';
 import {deserializeMessage} from './serde/wire-format/deserialize';
 import {serializeMessage} from './serde/wire-format/serialize';
 import {AppRequestEvent} from './event-types';
 import {deserializeAllocations, deserializeBudgetRequest} from './serde/app-messages/deserialize';
-import {isSimpleEthAllocation, makeDestination} from './utils/outcome';
+
 import {bigNumberify} from 'ethers/utils';
 import {CHALLENGE_DURATION, NETWORK_ID, WALLET_VERSION} from './constants';
 import {Store} from './store';

--- a/packages/xstate-wallet/src/serde/app-messages/deserialize.ts
+++ b/packages/xstate-wallet/src/serde/app-messages/deserialize.ts
@@ -15,7 +15,7 @@ import {
 import {assetHolderAddress, ETH_ASSET_HOLDER_ADDRESS} from '../../constants';
 import {bigNumberify} from 'ethers/utils';
 import {AddressZero} from 'ethers/constants';
-import {makeDestination} from '../../utils/outcome';
+import {makeDestination} from '../../utils';
 
 export function deserializeBudgetRequest(
   budgetRequest: AppBudgetRequest,

--- a/packages/xstate-wallet/src/serde/app-messages/example.ts
+++ b/packages/xstate-wallet/src/serde/app-messages/example.ts
@@ -2,7 +2,7 @@ import {Allocations} from '@statechannels/client-api-schema';
 import {SimpleAllocation, MixedAllocation} from '../../store/types';
 import {bigNumberify} from 'ethers/utils';
 import {ETH_ASSET_HOLDER_ADDRESS, ETH_TOKEN} from '../../constants';
-import {makeDestination} from '../../utils/outcome';
+import {makeDestination} from '../../utils';
 
 export const externalEthAllocation: Allocations = [
   {

--- a/packages/xstate-wallet/src/serde/wire-format/deserialize.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/deserialize.ts
@@ -17,7 +17,7 @@ import {
   Objective
 } from '../../store/types';
 import {bigNumberify} from 'ethers/utils';
-import {makeDestination} from '../../utils/outcome';
+import {makeDestination} from '../../utils';
 import {convertToInternalParticipant} from '../../messaging';
 
 export function deserializeMessage(message: WireMessage): Message {

--- a/packages/xstate-wallet/src/serde/wire-format/example.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/example.ts
@@ -1,7 +1,7 @@
 import {bigNumberify} from 'ethers/utils';
 import {Message} from '../../store/types';
 import {Message as WireMessage} from '@statechannels/wire-format';
-import {makeDestination} from '../../utils/outcome';
+import {makeDestination} from '../../utils';
 
 export const wireStateFormat = {
   participants: [

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -28,8 +28,7 @@ import {Guid} from 'guid-typescript';
 import {MemoryBackend} from './memory-backend';
 import {Errors} from '.';
 import AsyncLock from 'async-lock';
-import {checkThat} from '../utils';
-import {isSimpleEthAllocation} from '../utils/outcome';
+import {checkThat, isSimpleEthAllocation} from '../utils';
 
 interface DirectFunding {
   type: 'Direct';

--- a/packages/xstate-wallet/src/store/tests/indexedDB-store.test.ts
+++ b/packages/xstate-wallet/src/store/tests/indexedDB-store.test.ts
@@ -5,7 +5,7 @@ import {bigNumberify, BigNumber} from 'ethers/utils';
 import {Wallet} from 'ethers';
 import {calculateChannelId, signState} from '../state-utils';
 import {NETWORK_ID, CHALLENGE_DURATION} from '../../constants';
-import {simpleEthAllocation, makeDestination} from '../../utils/outcome';
+import {simpleEthAllocation, makeDestination} from '../../utils';
 import {IndexedDBBackend as Backend} from '../indexedDB-backend';
 import {ChannelStoreEntry} from '../channel-store-entry';
 require('fake-indexeddb/auto');

--- a/packages/xstate-wallet/src/store/tests/memory-store.test.ts
+++ b/packages/xstate-wallet/src/store/tests/memory-store.test.ts
@@ -3,7 +3,7 @@ import {calculateChannelId, signState} from './../state-utils';
 import {ChannelStoreEntry} from '../channel-store-entry';
 import {MemoryBackend as Backend} from '../memory-backend';
 import {NETWORK_ID, CHALLENGE_DURATION} from '../../constants';
-import {simpleEthAllocation, makeDestination} from '../../utils/outcome';
+import {simpleEthAllocation, makeDestination} from '../../utils';
 import {State, Objective} from './../types';
 import {Wallet} from 'ethers';
 import {XstateStore} from './../store';

--- a/packages/xstate-wallet/src/ui/stories/approve-budget-and-fund-workflow.stories.tsx
+++ b/packages/xstate-wallet/src/ui/stories/approve-budget-and-fund-workflow.stories.tsx
@@ -13,7 +13,7 @@ import {ApproveBudgetAndFund} from '../approve-budget-and-fund-workflow';
 import {SiteBudget, Participant} from '../../store/types';
 import {MessagingServiceInterface, MessagingService} from '../../messaging';
 import {XstateStore} from '../../store';
-import {ethBudget} from '../../utils/budget-utils';
+import {ethBudget} from '../../utils';
 
 const store = new XstateStore();
 

--- a/packages/xstate-wallet/src/ui/stories/confirm-create-channel-workflow.stories.tsx
+++ b/packages/xstate-wallet/src/ui/stories/confirm-create-channel-workflow.stories.tsx
@@ -10,7 +10,7 @@ import {Participant} from '@statechannels/client-api-schema';
 import {renderComponentInFrontOfApp} from './helpers';
 
 import {bigNumberify} from 'ethers/utils';
-import {simpleEthAllocation} from '../../utils/outcome';
+import {simpleEthAllocation} from '../../utils';
 import React from 'react';
 import {ConfirmCreateChannel} from '../confirm-create-channel-workflow';
 import {XstateStore} from '../../store';

--- a/packages/xstate-wallet/src/utils/budget-utils.ts
+++ b/packages/xstate-wallet/src/utils/budget-utils.ts
@@ -2,6 +2,7 @@ import {SiteBudget, AssetBudget} from '../store/types';
 import {HUB_ADDRESS, ETH_ASSET_HOLDER_ADDRESS} from '../constants';
 import {bigNumberify} from 'ethers/utils';
 import _ from 'lodash';
+import {checkThat, exists} from './helpers';
 
 export function ethBudget(site: string, opts: Partial<AssetBudget>): SiteBudget {
   return {
@@ -25,4 +26,12 @@ export function forEthAsset(budget: SiteBudget): AssetBudget {
   const ethPart = budget.forAsset[ETH_ASSET_HOLDER_ADDRESS];
   if (!ethPart) throw 'No eth part!';
   return ethPart;
+}
+
+export function extractEthAssetBudget(budget: SiteBudget): AssetBudget {
+  if (Object.keys(budget.forAsset).length !== 1) {
+    throw new Error('Cannot handle mixed budget');
+  }
+
+  return checkThat<AssetBudget>(budget.forAsset[ETH_ASSET_HOLDER_ADDRESS], exists);
 }

--- a/packages/xstate-wallet/src/utils/helpers.ts
+++ b/packages/xstate-wallet/src/utils/helpers.ts
@@ -1,6 +1,5 @@
 import {StateNodeConfig, DoneInvokeEvent, TransitionConfig} from 'xstate';
 import {hexZeroPad} from 'ethers/utils';
-
 export function unreachable(x: never) {
   return x;
 }

--- a/packages/xstate-wallet/src/utils/index.ts
+++ b/packages/xstate-wallet/src/utils/index.ts
@@ -1,0 +1,6 @@
+export * from './helpers';
+export * from './outcome';
+export * from './budget-utils';
+export * from './contract-utils';
+export * from './math-utils';
+export * from './workflow-utils';

--- a/packages/xstate-wallet/src/utils/outcome.ts
+++ b/packages/xstate-wallet/src/utils/outcome.ts
@@ -10,11 +10,16 @@ import {ETH_ASSET_HOLDER_ADDRESS} from '../constants';
 import _ from 'lodash';
 import {bigNumberify} from 'ethers/utils';
 import {ethers} from 'ethers';
+import {checkThat} from './helpers';
 
 export function isSimpleEthAllocation(outcome: Outcome): outcome is SimpleAllocation {
   return (
     outcome.type === 'SimpleAllocation' && outcome.assetHolderAddress === ETH_ASSET_HOLDER_ADDRESS
   );
+}
+
+export function assertSimpleEthAllocation(outcome: Outcome): SimpleAllocation {
+  return checkThat(outcome, isSimpleEthAllocation);
 }
 
 export const simpleEthAllocation = (allocationItems: AllocationItem[]): SimpleAllocation => ({

--- a/packages/xstate-wallet/src/utils/workflow-utils.ts
+++ b/packages/xstate-wallet/src/utils/workflow-utils.ts
@@ -39,7 +39,7 @@ export const connectToStore: <T>(config: Config<T>, options: Options) => Machine
 Since machines typically  don't have sync access to a store, we invoke a promise to get the
 desired outcome; that outcome can then be forwarded to the invoked service.
 */
-export function getDataAndInvoke<T>(
+export function getDataAndInvoke2<T>(
   data: string,
   src: string,
   onDone?: string,

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -16,7 +16,7 @@ import {
 import {sendDisplayMessage, MessagingServiceInterface, convertToChannelResult} from '../messaging';
 import {filter, map, tap, flatMap, first} from 'rxjs/operators';
 import * as CCC from './confirm-create-channel';
-import {createMockGuard, getDataAndInvoke} from '../utils/workflow-utils';
+import {createMockGuard, getDataAndInvoke2} from '../utils/workflow-utils';
 import {Store} from '../store';
 import {StateVariables} from '../store/types';
 import {ChannelStoreEntry} from '../store/channel-store-entry';
@@ -132,7 +132,7 @@ const generateConfig = (
         JOIN_CHANNEL: {target: 'confirmJoinChannelWorkflow'}
       }
     },
-    confirmCreateChannelWorkflow: getDataAndInvoke(
+    confirmCreateChannelWorkflow: getDataAndInvoke2(
       'getDataForCreateChannelConfirmation',
       'invokeCreateChannelConfirmation',
       'createChannelInStore'
@@ -141,7 +141,7 @@ const generateConfig = (
       initial: 'signFirstState',
       states: {
         signFirstState: {invoke: {src: 'signFirstState', onDone: 'confirmChannelCreation'}},
-        confirmChannelCreation: getDataAndInvoke(
+        confirmChannelCreation: getDataAndInvoke2(
           'getDataForCreateChannelConfirmation',
           'invokeCreateChannelConfirmation',
           'done'
@@ -167,7 +167,7 @@ const generateConfig = (
       }
     },
 
-    openChannelAndFundProtocol: getDataAndInvoke(
+    openChannelAndFundProtocol: getDataAndInvoke2(
       'getDataForCreateChannelAndFund',
       'invokeCreateChannelAndFundProtocol',
       'running'

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -16,14 +16,19 @@ import {
 import {sendDisplayMessage, MessagingServiceInterface, convertToChannelResult} from '../messaging';
 import {filter, map, tap, flatMap, first} from 'rxjs/operators';
 import * as CCC from './confirm-create-channel';
-import {createMockGuard, getDataAndInvoke2} from '../utils/workflow-utils';
+import {
+  createMockGuard,
+  getDataAndInvoke2,
+  isSimpleEthAllocation,
+  unreachable,
+  checkThat
+} from '../utils';
 import {Store} from '../store';
 import {StateVariables} from '../store/types';
 import {ChannelStoreEntry} from '../store/channel-store-entry';
 import {bigNumberify} from 'ethers/utils';
 import {ConcludeChannel, CreateAndFund} from './';
-import {isSimpleEthAllocation} from '../utils/outcome';
-import {unreachable, checkThat} from '../utils';
+
 import {
   PlayerStateUpdate,
   ChannelUpdated,

--- a/packages/xstate-wallet/src/workflows/approve-budget-and-fund.ts
+++ b/packages/xstate-wallet/src/workflows/approve-budget-and-fund.ts
@@ -20,10 +20,10 @@ import {serializeSiteBudget} from '../serde/app-messages/serialize';
 
 import {CreateAndFundLedger} from '../workflows';
 import {ETH_ASSET_HOLDER_ADDRESS} from '../constants';
-import {simpleEthAllocation} from '../utils/outcome';
+import {simpleEthAllocation, checkThat, exists} from '../utils';
 
 import _ from 'lodash';
-import {checkThat, exists} from '../utils';
+
 interface UserApproves {
   type: 'USER_APPROVES_BUDGET';
 }

--- a/packages/xstate-wallet/src/workflows/confirm-create-channel.ts
+++ b/packages/xstate-wallet/src/workflows/confirm-create-channel.ts
@@ -1,7 +1,7 @@
 import {MachineConfig, Action, StateSchema, Machine, Condition, StateMachine, State} from 'xstate';
 import {Participant} from '@statechannels/client-api-schema';
 import {sendDisplayMessage} from '../messaging';
-import {createMockGuard} from '../utils/workflow-utils';
+import {createMockGuard} from '../utils';
 import {Store} from '../store';
 import {SimpleAllocation} from '../store/types';
 import {BigNumber} from 'ethers/utils';

--- a/packages/xstate-wallet/src/workflows/create-and-fund-ledger.ts
+++ b/packages/xstate-wallet/src/workflows/create-and-fund-ledger.ts
@@ -16,9 +16,7 @@ import {SupportState} from '.';
 import {CHALLENGE_DURATION} from '../constants';
 import {bigNumberify} from 'ethers/utils';
 import * as Depositing from './depositing';
-import {getDataAndInvoke, checkThat} from '../utils';
-import {isSimpleEthAllocation} from '../utils/outcome';
-import {add} from '../utils/math-utils';
+import {getDataAndInvoke, checkThat, isSimpleEthAllocation, add} from '../utils';
 
 type WorkflowActions = {
   assignChannelId: AssignAction<WorkflowContext, DoneInvokeEvent<string>>;

--- a/packages/xstate-wallet/src/workflows/create-and-fund.ts
+++ b/packages/xstate-wallet/src/workflows/create-and-fund.ts
@@ -11,11 +11,16 @@ import {filter, map, first} from 'rxjs/operators';
 import _ from 'lodash';
 import {SimpleAllocation, isVirtuallyFund, StateVariables, Outcome} from '../store/types';
 
-import {MachineFactory} from '../utils/workflow-utils';
+import {
+  MachineFactory,
+  add,
+  isSimpleEthAllocation,
+  simpleEthAllocation,
+  checkThat,
+  getDataAndInvoke
+} from '../utils';
 import {Store} from '../store';
-import {add} from '../utils/math-utils';
-import {isSimpleEthAllocation, simpleEthAllocation} from '../utils/outcome';
-import {checkThat, getDataAndInvoke} from '../utils';
+
 import {SupportState, VirtualFundingAsLeaf, Depositing} from '.';
 import {from, Observable} from 'rxjs';
 import {CHALLENGE_DURATION, HUB, ETH_ASSET_HOLDER_ADDRESS, useVirtualFunding} from '../constants';

--- a/packages/xstate-wallet/src/workflows/depositing.ts
+++ b/packages/xstate-wallet/src/workflows/depositing.ts
@@ -2,8 +2,7 @@ import {bigNumberify, BigNumber} from 'ethers/utils';
 import {Machine, MachineConfig, assign, spawn} from 'xstate';
 import {Store} from '../store';
 import {map, filter} from 'rxjs/operators';
-import {MachineFactory} from '../utils/workflow-utils';
-import {exists} from '../utils';
+import {MachineFactory, exists} from '../utils';
 
 export type Init = {
   channelId: string;

--- a/packages/xstate-wallet/src/workflows/direct-funding.ts
+++ b/packages/xstate-wallet/src/workflows/direct-funding.ts
@@ -5,12 +5,16 @@ import {AddressZero, HashZero} from 'ethers/constants';
 
 import * as Depositing from './depositing';
 import * as SupportState from './support-state';
-import {getDataAndInvoke2, MachineFactory} from '../utils/workflow-utils';
+import {
+  getDataAndInvoke2,
+  MachineFactory,
+  add,
+  isSimpleEthAllocation,
+  simpleEthAllocation,
+  checkThat
+} from '../utils';
 import {Store} from '../store';
 import {Outcome, SimpleAllocation, AllocationItem, Destination} from '../store/types';
-import {add} from '../utils/math-utils';
-import {isSimpleEthAllocation, simpleEthAllocation} from '../utils/outcome';
-import {checkThat} from '../utils';
 
 const WORKFLOW = 'direct-funding';
 

--- a/packages/xstate-wallet/src/workflows/direct-funding.ts
+++ b/packages/xstate-wallet/src/workflows/direct-funding.ts
@@ -5,7 +5,7 @@ import {AddressZero, HashZero} from 'ethers/constants';
 
 import * as Depositing from './depositing';
 import * as SupportState from './support-state';
-import {getDataAndInvoke, MachineFactory} from '../utils/workflow-utils';
+import {getDataAndInvoke2, MachineFactory} from '../utils/workflow-utils';
 import {Store} from '../store';
 import {Outcome, SimpleAllocation, AllocationItem, Destination} from '../store/types';
 import {add} from '../utils/math-utils';
@@ -54,9 +54,9 @@ export const config: MachineConfig<any, any, any> = {
   initial: 'checkCurrentLevel',
   states: {
     checkCurrentLevel,
-    updatePrefundOutcome: getDataAndInvoke('getPrefundOutcome', 'supportState', 'funding'),
-    funding: getDataAndInvoke('getDepositingInfo', 'fundingService', 'updatePostfundOutcome'),
-    updatePostfundOutcome: getDataAndInvoke('getPostfundOutcome', 'supportState', 'success'),
+    updatePrefundOutcome: getDataAndInvoke2('getPrefundOutcome', 'supportState', 'funding'),
+    funding: getDataAndInvoke2('getDepositingInfo', 'fundingService', 'updatePostfundOutcome'),
+    updatePostfundOutcome: getDataAndInvoke2('getPostfundOutcome', 'supportState', 'success'),
     success: {type: 'final'},
     failure: {type: 'final'}
   }

--- a/packages/xstate-wallet/src/workflows/ledger-funding.ts
+++ b/packages/xstate-wallet/src/workflows/ledger-funding.ts
@@ -2,11 +2,16 @@ import {Machine, MachineConfig, ServiceConfig, assign, DoneInvokeEvent} from 'xs
 
 import {SupportState} from '.';
 import {Store, Errors as StoreErrors, Funding} from '../store';
-import {allocateToTarget, isSimpleEthAllocation} from '../utils/outcome';
+import {
+  allocateToTarget,
+  isSimpleEthAllocation,
+  getDataAndInvoke,
+  checkThat,
+  add,
+  assignError
+} from '../utils';
 import {AllocationItem} from '../store/types';
-import {getDataAndInvoke, checkThat} from '../utils';
-import {add} from '../utils/math-utils';
-import {assignError} from '../utils/workflow-utils';
+
 import {escalate} from '../actions';
 
 const WORKFLOW = 'ledger-funding';

--- a/packages/xstate-wallet/src/workflows/tests/application.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/application.test.ts
@@ -9,7 +9,7 @@ import {ChannelStoreEntry} from '../../store/channel-store-entry';
 import {MessagingService, MessagingServiceInterface} from '../../messaging';
 import {bigNumberify} from 'ethers/utils';
 import {calculateChannelId} from '../../store/state-utils';
-import {simpleEthAllocation} from '../../utils/outcome';
+import {simpleEthAllocation} from '../../utils';
 import {CreateChannelEvent, ChannelUpdated, JoinChannelEvent} from '../../event-types';
 
 jest.setTimeout(50000);

--- a/packages/xstate-wallet/src/workflows/tests/create-and-fund.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/create-and-fund.test.ts
@@ -9,8 +9,8 @@ import _ from 'lodash';
 import {firstState, signState, calculateChannelId} from '../../store/state-utils';
 import {ChannelConstants, Outcome, State} from '../../store/types';
 import {AddressZero} from 'ethers/constants';
-import {checkThat} from '../../utils';
-import {isSimpleEthAllocation} from '../../utils/outcome';
+import {checkThat, isSimpleEthAllocation, add} from '../../utils';
+
 import {
   wallet1,
   wallet2,
@@ -27,7 +27,7 @@ import {subscribeToMessages} from './message-service';
 import * as constants from '../../constants';
 import {FakeChain} from '../../chain';
 import {SimpleHub} from './simple-hub';
-import {add} from '../../utils/math-utils';
+
 import {TestStore} from './store';
 
 jest.setTimeout(20000);

--- a/packages/xstate-wallet/src/workflows/tests/data.ts
+++ b/packages/xstate-wallet/src/workflows/tests/data.ts
@@ -2,7 +2,7 @@ import {ethers} from 'ethers';
 import {Participant, State, SiteBudget} from '../../store/types';
 import {BigNumberish, bigNumberify, BigNumber} from 'ethers/utils';
 import {CHALLENGE_DURATION, HUB, HUB_ADDRESS, ETH_ASSET_HOLDER_ADDRESS} from '../../constants';
-import {simpleEthAllocation, makeDestination} from '../../utils/outcome';
+import {simpleEthAllocation, makeDestination} from '../../utils';
 
 export const wallet1 = new ethers.Wallet(
   '0x95942b296854c97024ca3145abef8930bf329501b718c0f66d57dba596ff1318'

--- a/packages/xstate-wallet/src/workflows/tests/ledger-funding.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/ledger-funding.test.ts
@@ -1,6 +1,6 @@
 import {interpret} from 'xstate';
 import waitForExpect from 'wait-for-expect';
-import {add} from '../../utils/math-utils';
+import {add, checkThat, isSimpleEthAllocation} from '../../utils';
 
 import {Init, machine, Errors} from '../ledger-funding';
 
@@ -10,8 +10,7 @@ import _ from 'lodash';
 import {firstState, signState, calculateChannelId} from '../../store/state-utils';
 import {ChannelConstants, Outcome, State} from '../../store/types';
 import {AddressZero} from 'ethers/constants';
-import {checkThat} from '../../utils';
-import {isSimpleEthAllocation} from '../../utils/outcome';
+
 import {FakeChain, Chain} from '../../chain';
 import {wallet1, wallet2, participants} from './data';
 import {subscribeToMessages} from './message-service';

--- a/packages/xstate-wallet/src/workflows/tests/virtual-defunding.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/virtual-defunding.test.ts
@@ -7,8 +7,7 @@ import _ from 'lodash';
 import {signState, calculateChannelId} from '../../store/state-utils';
 import {Participant, Outcome, SignedState, ChannelConstants} from '../../store/types';
 import {AddressZero, HashZero} from 'ethers/constants';
-import {add} from '../../utils/math-utils';
-import {simpleEthAllocation, simpleEthGuarantee, makeDestination} from '../../utils/outcome';
+import {add, simpleEthAllocation, simpleEthGuarantee, makeDestination} from '../../utils';
 
 import {wallet1, wallet2, wallet3, threeParticipants as participants} from './data';
 import {subscribeToMessages} from './message-service';

--- a/packages/xstate-wallet/src/workflows/tests/virtual-funding.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/virtual-funding.test.ts
@@ -7,8 +7,7 @@ import _ from 'lodash';
 import {firstState, signState, calculateChannelId} from '../../store/state-utils';
 import {ChannelConstants, Outcome, State} from '../../store/types';
 import {AddressZero} from 'ethers/constants';
-import {add} from '../../utils/math-utils';
-import {simpleEthAllocation, makeDestination, simpleEthGuarantee} from '../../utils/outcome';
+import {add, simpleEthAllocation, makeDestination, simpleEthGuarantee} from '../../utils';
 
 import {
   wallet1,

--- a/packages/xstate-wallet/src/workflows/virtual-defunding-as-hub.ts
+++ b/packages/xstate-wallet/src/workflows/virtual-defunding-as-hub.ts
@@ -2,15 +2,14 @@ const PROTOCOL = 'virtual-defunding-as-hub';
 import {SupportState} from '.';
 import {defundGuarantorInLedger} from './virtual-defunding-as-leaf';
 import {OutcomeIdx} from './virtual-funding-as-leaf';
-import {checkThat, getDataAndInvoke} from '../utils';
-import {isSimpleEthAllocation} from '../utils/outcome';
+import {checkThat, getDataAndInvoke, isSimpleEthAllocation, add} from '../utils';
+
 import {isGuarantees, isIndirectFunding, Store} from '../store';
 import {StateNodeConfig, assign, DoneInvokeEvent, Machine} from 'xstate';
 import {map, filter, tap, first} from 'rxjs/operators';
 import {ChannelStoreEntry} from '../store/channel-store-entry';
 import _ from 'lodash';
 import {AllocationItem} from '../store/types';
-import {add} from '../utils/math-utils';
 
 export type Init = {jointChannelId: string};
 

--- a/packages/xstate-wallet/src/workflows/virtual-defunding-as-leaf.ts
+++ b/packages/xstate-wallet/src/workflows/virtual-defunding-as-leaf.ts
@@ -1,7 +1,7 @@
-import {checkThat, getDataAndInvoke} from '../utils';
+import {checkThat, getDataAndInvoke, isSimpleEthAllocation, simpleEthAllocation} from '../utils';
 
 import {SupportState} from '.';
-import {isSimpleEthAllocation, simpleEthAllocation} from '../utils/outcome';
+
 import {OutcomeIdx, ParticipantIdx} from './virtual-funding-as-leaf';
 import {StateNodeConfig, assign, DoneInvokeEvent, Machine} from 'xstate';
 

--- a/packages/xstate-wallet/src/workflows/virtual-funding-as-hub.ts
+++ b/packages/xstate-wallet/src/workflows/virtual-funding-as-hub.ts
@@ -13,8 +13,7 @@ import {filter, flatMap} from 'rxjs/operators';
 
 import {Store} from '../store';
 import {LedgerFunding, VirtualFundingAsLeaf} from '.';
-import {checkThat} from '../utils';
-import {isSimpleEthAllocation} from '../utils/outcome';
+import {checkThat, isSimpleEthAllocation} from '../utils';
 
 import {FundGuarantor, AllocationItem, isFundGuarantor, Participant} from '../store/types';
 

--- a/packages/xstate-wallet/src/workflows/virtual-funding-as-leaf.ts
+++ b/packages/xstate-wallet/src/workflows/virtual-funding-as-leaf.ts
@@ -12,20 +12,22 @@ import {filter, map, take, flatMap, tap} from 'rxjs/operators';
 
 import {Store, supportedStateFeed} from '../store';
 import {SupportState, LedgerFunding} from '.';
-import {checkThat, getDataAndInvoke} from '../utils';
 import {
+  checkThat,
+  getDataAndInvoke,
   simpleEthGuarantee,
   isSimpleEthAllocation,
   simpleEthAllocation,
-  makeDestination
-} from '../utils/outcome';
+  makeDestination,
+  assignError
+} from '../utils';
 
 import {FundGuarantor, AllocationItem} from '../store/types';
 
 import {bigNumberify} from 'ethers/utils';
 import {CHALLENGE_DURATION} from '../constants';
 import _ from 'lodash';
-import {assignError} from '../utils/workflow-utils';
+
 import {escalate} from '../actions';
 
 export const enum OutcomeIdx {


### PR DESCRIPTION
This PR tidies up the utils in xstate wallet. In particular it:

1. Moves `utils.ts` -> `utils/helpers.ts`
2. Exports all utils from `utils/index.ts`
3. De-duplicates between two versions of `getDataAndInvoke`
4. Updates all other packages to import from the top level of utils.

To do 3, I have temporarily added `getDataAndInvoke2` to make it obvious that there are two versions in the codebase. Ideally we would consolidate around one version, but I don't have the context to do that in every case yet.