### PR TITLE
[web3t] Torrents on welcome screen are *our* pre-seeded torrents

### DIFF
--- a/packages/web3torrent/package.json
+++ b/packages/web3torrent/package.json
@@ -109,6 +109,7 @@
     "prettier:check": "prettier --check '**/*.{scss,json}' --ignore-path '.eslintignore'",
     "prettier:write": "prettier --write '**/*.{scss,json}' --ignore-path '.eslintignore'",
     "start": "node scripts/start.js",
+    "start:tracker-logs-on": "DEBUG='web3torrent:tracker' yarn start",
     "start:alt": "PORT=3333 node scripts/start.js",
     "start:shared-ganache": "NODE_ENV=development npx start-shared-ganache",
     "start:tracker": "node tracker/index.js",

--- a/packages/web3torrent/src/components/share-list/ShareList.test.tsx
+++ b/packages/web3torrent/src/components/share-list/ShareList.test.tsx
@@ -3,7 +3,7 @@ import Adapter from 'enzyme-adapter-react-16';
 import {createMemoryHistory} from 'history';
 import React from 'react';
 import {MemoryRouter as Router} from 'react-router-dom';
-import {mockTorrents} from '../../constants';
+import {preSeededTorrents} from '../../constants';
 import {RoutePath} from '../../routes';
 import {ShareList, ShareListProps} from './ShareList';
 import {calculateWei, prettyPrintWei} from '../../utils/calculateWei';
@@ -14,7 +14,7 @@ function setup(withNoTorrents = false) {
   const history = createMemoryHistory();
   const props: ShareListProps = {
     history,
-    torrents: withNoTorrents ? [] : mockTorrents
+    torrents: withNoTorrents ? [] : preSeededTorrents
   };
   const component = mount(
     <Router>

--- a/packages/web3torrent/src/components/share-list/ShareList.test.tsx
+++ b/packages/web3torrent/src/components/share-list/ShareList.test.tsx
@@ -45,9 +45,7 @@ describe('<ShareList />', () => {
     const firstFileData = filesData.at(0);
     expect(firstFileData.childAt(0).text()).toBe(props.torrents[0].name);
     expect(firstFileData.childAt(1).text()).toBe(prettier(props.torrents[0].length));
-    expect(firstFileData.childAt(2).text()).toBe(props.torrents[0].numPeers + 'S');
-    expect(firstFileData.childAt(3).text()).toBe(props.torrents[0].numPeers + 'P');
-    expect(firstFileData.childAt(4).text()).toBe(
+    expect(firstFileData.childAt(2).text()).toBe(
       prettyPrintWei(calculateWei(props.torrents[0].length))
     );
     expect(firstFileData.childAt(5).find('button')).not.toBeNull();

--- a/packages/web3torrent/src/components/share-list/share-file/ShareFile.scss
+++ b/packages/web3torrent/src/components/share-list/share-file/ShareFile.scss
@@ -14,6 +14,6 @@
   }
   td.other-cell {
     min-width: 50px;
-    width: 12%;
+    width: 24%;
   }
 }

--- a/packages/web3torrent/src/components/share-list/share-file/ShareFile.tsx
+++ b/packages/web3torrent/src/components/share-list/share-file/ShareFile.tsx
@@ -12,8 +12,6 @@ const ShareFile: React.FC<ShareFileProps> = ({file, goTo}: ShareFileProps) => {
     <tr className={'share-file'}>
       <td className="name-cell">{file.name}</td>
       <td className="other-cell">{prettier(file.length)}</td>
-      <td className="other-cell">{file.numPeers}S</td>
-      <td className="other-cell">{file.numPeers}P</td>
       <td className="other-cell">{prettyPrintWei(calculateWei(file.length))}</td>
       <td className="button-cell">
         <FormButton name="download" onClick={() => goTo(file.magnetURI || file.name || '')}>

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -68,7 +68,7 @@ export const EmptyTorrent = ({
 // Pre Seeded Constants (by StateChannels team)
 export const preSeededTorrents: Array<Partial<Torrent>> = [
   {
-    name: 'Sintel',
+    name: 'Sintel.mp4',
     length: 129241752,
     infoHash: 'c53da4fa28aa2edc1faa91861cce38527414d874',
     magnetURI:

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -70,9 +70,7 @@ export const mockTorrents: Array<Partial<Torrent>> = [
   {
     name: 'Sintel',
     length: 129302391,
-    numSeeds: 47,
-    numPeers: 12,
-    files: [],
+    infoHash: 'c53da4fa28aa2edc1faa91861cce38527414d874',
     magnetURI: 'magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel&xl=129302391'
   },
   {

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -69,9 +69,10 @@ export const EmptyTorrent = ({
 export const mockTorrents: Array<Partial<Torrent>> = [
   {
     name: 'Sintel',
-    length: 129302391,
+    length: 129241752,
     infoHash: 'c53da4fa28aa2edc1faa91861cce38527414d874',
-    magnetURI: 'magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel&xl=129302391'
+    magnetURI:
+      'magnet:?xt=urn%3Abtih%3Ac53da4fa28aa2edc1faa91861cce38527414d874&dn=Sintel.mp4&xl=129241752'
   },
   {
     name: 'Big Buck Bunny',

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -73,8 +73,7 @@ export const mockTorrents: Array<Partial<Torrent>> = [
     numSeeds: 47,
     numPeers: 12,
     files: [],
-    magnetURI:
-      'magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fsintel.torrent'
+    magnetURI: 'magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel&xl=129302391'
   },
   {
     name: 'Big Buck Bunny',
@@ -83,7 +82,7 @@ export const mockTorrents: Array<Partial<Torrent>> = [
     numPeers: 6,
     files: [],
     magnetURI:
-      'magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&dn=Big+Buck+Bunny&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fbig-buck-bunny.torrent'
+      'magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&dn=Big+Buck+Bunny&xl=276445467'
   },
   {
     name: 'Cosmos Laundromat',
@@ -92,7 +91,7 @@ export const mockTorrents: Array<Partial<Torrent>> = [
     numPeers: 6,
     files: [],
     magnetURI:
-      'magnet:?xt=urn:btih:c9e15763f722f23e98a29decdfae341b98d53056&dn=Cosmos+Laundromat&tr=udp%3A%2F%2Fexplodie.org%3A6969&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.empire-js.us%3A1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=wss%3A%2F%2Ftracker.btorrent.xyz&tr=wss%3A%2F%2Ftracker.fastcast.nz&tr=wss%3A%2F%2Ftracker.openwebtorrent.com&ws=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2F&xs=https%3A%2F%2Fwebtorrent.io%2Ftorrents%2Fcosmos-laundromat.torrent'
+      'magnet:?xt=urn:btih:c9e15763f722f23e98a29decdfae341b98d53056&dn=Cosmos+Laundromat&xl=220864086'
   }
 ];
 

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -65,34 +65,23 @@ export const EmptyTorrent = ({
   wires: []
 } as unknown) as Torrent;
 
-// Mocked Constants
-export const mockTorrents: Array<Partial<Torrent>> = [
+// Pre Seeded Constants (by StateChannels team)
+export const preSeededTorrents: Array<Partial<Torrent>> = [
   {
     name: 'Sintel',
     length: 129241752,
     infoHash: 'c53da4fa28aa2edc1faa91861cce38527414d874',
     magnetURI:
       'magnet:?xt=urn%3Abtih%3Ac53da4fa28aa2edc1faa91861cce38527414d874&dn=Sintel.mp4&xl=129241752'
-  },
-  {
-    name: 'Big Buck Bunny',
-    length: 276445467,
-    numSeeds: 8,
-    numPeers: 6,
-    files: [],
-    magnetURI:
-      'magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&dn=Big+Buck+Bunny&xl=276445467'
-  },
-  {
-    name: 'Cosmos Laundromat',
-    length: 220864086,
-    numSeeds: 10,
-    numPeers: 6,
-    files: [],
-    magnetURI:
-      'magnet:?xt=urn:btih:c9e15763f722f23e98a29decdfae341b98d53056&dn=Cosmos+Laundromat&xl=220864086'
   }
 ];
+
+export const testTorrent = {
+  name: 'Big Buck Bunny',
+  length: 276445467,
+  magnetURI:
+    'magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&dn=Big+Buck+Bunny&xl=276445467'
+};
 
 export const mockCurrentUser = '0x8fd00f170fdf3772c5ebdcd90bf257316c69ba45';
 const mockBalance = 200000000000000;

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -17,7 +17,6 @@ import {
 import {utils} from 'ethers';
 import {ChannelState, PaymentChannelClient} from '../clients/payment-channel-client';
 import {
-  mockTorrents,
   defaultTrackers,
   fireBaseConfig,
   HUB,
@@ -28,7 +27,8 @@ import {
   INITIAL_SEEDER_BALANCE,
   AUTO_FUND_LEDGER,
   BLOCK_LENGTH,
-  PEER_TRUST
+  PEER_TRUST,
+  testTorrent
 } from '../constants';
 import * as firebase from 'firebase/app';
 import 'firebase/database';
@@ -124,7 +124,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     log('Testing torrenting capability...');
     let torrentId;
     const gotAWire = new Promise(resolve => {
-      super.add(mockTorrents[1].magnetURI, (torrent: Torrent) => {
+      super.add(testTorrent.magnetURI, (torrent: Torrent) => {
         torrentId = torrent.infoHash;
         torrent.once('wire', wire => resolve(true));
       });

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -124,7 +124,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     log('Testing torrenting capability...');
     let torrentId;
     const gotAWire = new Promise(resolve => {
-      super.add(mockTorrents[0].magnetURI, (torrent: Torrent) => {
+      super.add(mockTorrents[1].magnetURI, (torrent: Torrent) => {
         torrentId = torrent.infoHash;
         torrent.once('wire', wire => resolve(true));
       });

--- a/packages/web3torrent/src/pages/welcome/Welcome.tsx
+++ b/packages/web3torrent/src/pages/welcome/Welcome.tsx
@@ -45,6 +45,11 @@ class Welcome extends React.Component<RouteComponentProps & Props, {[infoHash: s
     this.trackerClient.on('update', this.updateIfSeederFound);
     this.trackerClient.start();
   }
+
+  componentWillUnmount() {
+    this.trackerClient.off('update', this.updateIfSeederFound);
+  }
+
   render() {
     const {history, ready} = this.props;
     return (

--- a/packages/web3torrent/src/pages/welcome/Welcome.tsx
+++ b/packages/web3torrent/src/pages/welcome/Welcome.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {RouteComponentProps} from 'react-router-dom';
 import {FormButton} from '../../components/form';
 import {ShareList} from '../../components/share-list/ShareList';
-import {mockTorrents, defaultTrackers} from '../../constants';
+import {preSeededTorrents, defaultTrackers} from '../../constants';
 import {RoutePath} from '../../routes';
 import './Welcome.scss';
 import {Client} from 'bittorrent-tracker';
@@ -74,7 +74,7 @@ class Welcome extends React.Component<RouteComponentProps & Props, {[infoHash: s
         </div>
         <h2>Download a sample file</h2>
         <ShareList
-          torrents={mockTorrents.filter(torrent => this.state[torrent.infoHash])}
+          torrents={preSeededTorrents.filter(torrent => this.state[torrent.infoHash])}
           history={history}
         />
         <h2>Or share a file</h2>

--- a/packages/web3torrent/src/pages/welcome/Welcome.tsx
+++ b/packages/web3torrent/src/pages/welcome/Welcome.tsx
@@ -1,50 +1,89 @@
+import debug from 'debug';
 import React from 'react';
 import {RouteComponentProps} from 'react-router-dom';
 import {FormButton} from '../../components/form';
 import {ShareList} from '../../components/share-list/ShareList';
-import {mockTorrents} from '../../constants';
+import {mockTorrents, defaultTrackers} from '../../constants';
 import {RoutePath} from '../../routes';
 import './Welcome.scss';
+import {Client} from 'bittorrent-tracker';
+
+const log = debug('web3torrent:welcome-page-tracker-client');
+
+const requiredOpts = {
+  infoHash: ['c53da4fa28aa2edc1faa91861cce38527414d874'], // Sintel.mp4 concentrate on this torrent for now
+  peerId: '2d5757303030372d37454e613073307937495630', // hex string or Buffer
+  announce: defaultTrackers, // list of tracker server urls,
+  port: 6881 // torrent client port, (in browser, optional)
+};
+const optionalOpts = {
+  getAnnounceOpts: () => ({pseAccount: '0x7F0126D6c4270498b6514Cb934a3274898f68777'}) // dummy pseAccount, but it works
+};
 
 interface Props {
   ready: boolean;
 }
 
-const Welcome: React.FC<RouteComponentProps & Props> = props => {
-  const {history, ready} = props;
-  return (
-    <section className="section fill">
-      <div className="jumbotron">
-        <h1>Streaming file transfer over WebTorrent</h1>
-        <h2>TORRENTS ON THE WEB</h2>
-      </div>
-      <div className="subtitle">
-        <p>
-          Web3Torrent offers a new experience for sharing files in a decentralized way via paid
-          streaming, bringing together{' '}
-          <a href="https://statechannels.org" target="_blank" rel="noopener noreferrer">
-            State Channels
-          </a>{' '}
-          and{' '}
-          <a href="https://webtorrent.io/" target="_blank" rel="noopener noreferrer">
-            WebTorrent
-          </a>
-          , a JavaScript implementation of the BitTorrent protocol.
-        </p>
-      </div>
-      <h2>Download a sample file</h2>
-      <ShareList torrents={mockTorrents} history={history} />
-      <h2>Or share a file</h2>
-      <FormButton
-        name="upload"
-        block={true}
-        disabled={!ready}
-        onClick={() => history.push(RoutePath.Upload)}
-      >
-        Upload
-      </FormButton>
-    </section>
-  );
-};
+class Welcome extends React.Component<RouteComponentProps & Props, {[infoHash: string]: boolean}> {
+  trackerClient: Client; // bittorrent tracker client
+  state = {c53da4fa28aa2edc1faa91861cce38527414d874: false}; // do not display by default
+
+  updateIfSeederFound(data: any) {
+    log('got an announce response from tracker: ' + data.announce);
+    if (data.complete > 0) {
+      // there are some seeders for this torrent
+      this.setState({[requiredOpts.infoHash[0]]: true});
+      // this torrent should be displayed
+      log(`Seeder found for ${requiredOpts.infoHash[0]}`);
+    }
+  }
+
+  constructor(props) {
+    super(props);
+    this.trackerClient = new Client({...requiredOpts, ...optionalOpts});
+    this.updateIfSeederFound = this.updateIfSeederFound.bind(this);
+    this.trackerClient.on('update', this.updateIfSeederFound);
+    this.trackerClient.start();
+  }
+  render() {
+    const {history, ready} = this.props;
+    return (
+      <section className="section fill">
+        <div className="jumbotron">
+          <h1>Streaming file transfer over WebTorrent</h1>
+          <h2>TORRENTS ON THE WEB</h2>
+        </div>
+        <div className="subtitle">
+          <p>
+            Web3Torrent offers a new experience for sharing files in a decentralized way via paid
+            streaming, bringing together{' '}
+            <a href="https://statechannels.org" target="_blank" rel="noopener noreferrer">
+              State Channels
+            </a>{' '}
+            and{' '}
+            <a href="https://webtorrent.io/" target="_blank" rel="noopener noreferrer">
+              WebTorrent
+            </a>
+            , a JavaScript implementation of the BitTorrent protocol.
+          </p>
+        </div>
+        <h2>Download a sample file</h2>
+        <ShareList
+          torrents={mockTorrents.filter(torrent => this.state[torrent.infoHash])}
+          history={history}
+        />
+        <h2>Or share a file</h2>
+        <FormButton
+          name="upload"
+          block={true}
+          disabled={!ready}
+          onClick={() => history.push(RoutePath.Upload)}
+        >
+          Upload
+        </FormButton>
+      </section>
+    );
+  }
+}
 
 export default Welcome;

--- a/packages/web3torrent/src/pages/welcome/Welcome.tsx
+++ b/packages/web3torrent/src/pages/welcome/Welcome.tsx
@@ -48,6 +48,7 @@ class Welcome extends React.Component<RouteComponentProps & Props, {[infoHash: s
 
   componentWillUnmount() {
     this.trackerClient.off('update', this.updateIfSeederFound);
+    this.trackerClient.stop();
   }
 
   render() {


### PR DESCRIPTION
Current behaviour: There are 3 torrents on the Welcome page. Clicking on Download will connect you, via a public tracker, to any webtorrent client (bypassing state channels flow). 

With this PR: The Welcome page is now a class that wraps a bittorrent tracker client, connects to *only* our whitelisted tracker(s) (not the public ones!) and will display a torrent if it can find at least one seeder on that tracker. When clicking, you have to do the proper state-channels-enabled flow as you would when sharing a magnet link. 

Closes #1331 .

TODO: 

- [ ] Swap `Sintel.mp4` for some more interesting content: `ForceMove.pdf`? A video presentation someone has made / will make? Suggestions welcome.
- [ ] Figure out if a tracker will drop a seeder if they go offline / close their browser