### PR TITLE
Add proper support check, refactor state storage

### DIFF
--- a/packages/xstate-wallet/src/integration-tests/closing.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/closing.test.ts
@@ -4,7 +4,7 @@ import {bigNumberify, hexZeroPad} from 'ethers/utils';
 import waitForExpect from 'wait-for-expect';
 import {simpleEthAllocation} from '../utils';
 import {State, SignedState} from '../store/types';
-import {signState} from '../store/state-utils';
+import {createSignatureEntry} from '../store/state-utils';
 import {CHALLENGE_DURATION, NETWORK_ID} from '../constants';
 import {AddressZero} from 'ethers/constants';
 jest.setTimeout(30000);
@@ -48,7 +48,7 @@ test('concludes on their turn', async () => {
 
   const allSignState: SignedState = {
     ...state,
-    signatures: [playerA, playerB].map(({privateKey}) => signState(state, privateKey))
+    signatures: [playerA, playerB].map(({privateKey}) => createSignatureEntry(state, privateKey))
   };
 
   const {channelId} = await playerB.store.createEntry(allSignState);

--- a/packages/xstate-wallet/src/serde/wire-format/deserialize.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/deserialize.ts
@@ -19,6 +19,7 @@ import {
 import {bigNumberify} from 'ethers/utils';
 import {makeDestination} from '../../utils';
 import {convertToInternalParticipant} from '../../messaging';
+import {getSignerAddress} from '../../store/state-utils';
 
 export function deserializeMessage(message: WireMessage): Message {
   const signedStates = message?.data?.signedStates?.map(ss => deserializeState(ss));
@@ -33,14 +34,21 @@ export function deserializeMessage(message: WireMessage): Message {
 export function deserializeState(state: SignedStateWire): SignedState {
   const stateWithoutChannelId = {...state};
   delete stateWithoutChannelId.channelId;
-
-  return {
+  const deserializedState = {
     ...stateWithoutChannelId,
     challengeDuration: bigNumberify(state.challengeDuration),
     channelNonce: bigNumberify(state.channelNonce),
     turnNum: bigNumberify(state.turnNum),
     outcome: deserializeOutcome(state.outcome),
     participants: stateWithoutChannelId.participants.map(convertToInternalParticipant)
+  };
+
+  return {
+    ...deserializedState,
+    signatures: state.signatures.map(sig => ({
+      signature: sig,
+      signer: getSignerAddress(deserializedState, sig)
+    }))
   };
 }
 

--- a/packages/xstate-wallet/src/serde/wire-format/example.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/example.ts
@@ -7,20 +7,20 @@ export const wireStateFormat = {
   participants: [
     {
       destination: '0x00000000000000000000000063E3FB11830c01ac7C9C64091c14Bb6CbAaC9Ac7',
-      participantId: '0xAE363d29fc0f6A9bbBbEcC87751e518Cd9CA83C0',
-      signingAddress: '0xAE363d29fc0f6A9bbBbEcC87751e518Cd9CA83C0'
+      participantId: '0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf',
+      signingAddress: '0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf' // key: 0x95942b296854c97024ca3145abef8930bf329501b718c0f66d57dba596ff1318
     },
     {
       destination: '0x00000000000000000000000063E3FB11830c01ac7C9C64091c14Bb6CbAaC9Ac7',
-      participantId: '0x590A3Bd8D4A3b78411B3bDFb481E44e85C7345c0',
-      signingAddress: '0x590A3Bd8D4A3b78411B3bDFb481E44e85C7345c0'
+      participantId: '0x2222E21c8019b14dA16235319D34b5Dd83E644A9',
+      signingAddress: '0x2222E21c8019b14dA16235319D34b5Dd83E644A9' // key: 0xb3ab7b031311fe1764b657a6ae7133f19bac97acd1d7edca9409daa35892e727
     }
   ],
   appData:
     '0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016345785d8a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004444444444444444444444444444444444444444444444444444444444444444',
   appDefinition: '0x430869383d611bBB1ce7Ca207024E7901bC26b40',
   challengeDuration: '0x00000000000000000000000000000000000000000000000000000000000004a0',
-  channelId: '0x9afc73af1808170a4ee408649219ee8322957645e40e227cb1ea29ea98034699',
+  channelId: '0x59fb8a0bff0f4553b0169d4b6cad93f3baa9edd94bd28c954ae0ad1622252967',
   chainId: '0x2329',
   channelNonce: '0x11b1a311d845ca99f8e3c9a5f828f574b1afe2c3a0eb8cd51115dff18f0f34a0',
   isFinal: false,
@@ -41,7 +41,7 @@ export const wireStateFormat = {
   ],
   turnNum: '0x0000000000000000000000000000000000000000000000000000000000000001',
   signatures: [
-    '0x733ccfc3b0b13b446de290a9b056a5b9d7eb1538c1d48f8b863f731a0ea522c46ad30427d0859d782c98ccdc5fe10fc9c3d6480ee5080f70fd96128e4d61d50728'
+    '0x13151e7faaa5524a223869ba2fbb20419031049defc685dda8e7b35bcfc797c56c7ac82ff32fb02ce618c73efb8a233479ad2bbc25b9c1d67ded33517d4d5ff51c'
   ]
 };
 
@@ -49,13 +49,13 @@ export const internalStateFormat = {
   participants: [
     {
       destination: makeDestination('0x63E3FB11830c01ac7C9C64091c14Bb6CbAaC9Ac7'),
-      participantId: '0xAE363d29fc0f6A9bbBbEcC87751e518Cd9CA83C0',
-      signingAddress: '0xAE363d29fc0f6A9bbBbEcC87751e518Cd9CA83C0'
+      participantId: '0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf',
+      signingAddress: '0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf'
     },
     {
       destination: makeDestination('0x63E3FB11830c01ac7C9C64091c14Bb6CbAaC9Ac7'),
-      participantId: '0x590A3Bd8D4A3b78411B3bDFb481E44e85C7345c0',
-      signingAddress: '0x590A3Bd8D4A3b78411B3bDFb481E44e85C7345c0'
+      participantId: '0x2222E21c8019b14dA16235319D34b5Dd83E644A9',
+      signingAddress: '0x2222E21c8019b14dA16235319D34b5Dd83E644A9'
     }
   ],
   appData:
@@ -89,32 +89,32 @@ export const internalStateFormat = {
   signatures: [
     {
       signature:
-        '0x733ccfc3b0b13b446de290a9b056a5b9d7eb1538c1d48f8b863f731a0ea522c46ad30427d0859d782c98ccdc5fe10fc9c3d6480ee5080f70fd96128e4d61d50728',
-      signer: '0xAE363d29fc0f6A9bbBbEcC87751e518Cd9CA83C0'
+        '0x13151e7faaa5524a223869ba2fbb20419031049defc685dda8e7b35bcfc797c56c7ac82ff32fb02ce618c73efb8a233479ad2bbc25b9c1d67ded33517d4d5ff51c',
+      signer: '0x2222E21c8019b14dA16235319D34b5Dd83E644A9'
     }
   ]
 };
 export const wireMessageFormat: WireMessage = {
-  recipient: '0xAE363d29fc0f6A9bbBbEcC87751e518Cd9CA83C0',
-  sender: '0x590A3Bd8D4A3b78411B3bDFb481E44e85C7345c0',
+  recipient: '0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf',
+  sender: '0x2222E21c8019b14dA16235319D34b5Dd83E644A9',
   data: {
     signedStates: [wireStateFormat],
     objectives: [
       {
         type: 'OpenChannel',
         data: {
-          targetChannelId: '0x9afc73af1808170a4ee408649219ee8322957645e40e227cb1ea29ea98034699'
+          targetChannelId: '0x59fb8a0bff0f4553b0169d4b6cad93f3baa9edd94bd28c954ae0ad1622252967'
         },
         participants: [
           {
             destination: '0x00000000000000000000000063E3FB11830c01ac7C9C64091c14Bb6CbAaC9Ac7',
-            participantId: '0xAE363d29fc0f6A9bbBbEcC87751e518Cd9CA83C0',
-            signingAddress: '0xAE363d29fc0f6A9bbBbEcC87751e518Cd9CA83C0'
+            participantId: '0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf',
+            signingAddress: '0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf'
           },
           {
             destination: '0x00000000000000000000000063E3FB11830c01ac7C9C64091c14Bb6CbAaC9Ac7',
-            participantId: '0x590A3Bd8D4A3b78411B3bDFb481E44e85C7345c0',
-            signingAddress: '0x590A3Bd8D4A3b78411B3bDFb481E44e85C7345c0'
+            participantId: '0x2222E21c8019b14dA16235319D34b5Dd83E644A9',
+            signingAddress: '0x2222E21c8019b14dA16235319D34b5Dd83E644A9'
           }
         ]
       }
@@ -127,17 +127,17 @@ export const internalMessageFormat: Message = {
   objectives: [
     {
       type: 'OpenChannel',
-      data: {targetChannelId: '0x9afc73af1808170a4ee408649219ee8322957645e40e227cb1ea29ea98034699'},
+      data: {targetChannelId: '0x59fb8a0bff0f4553b0169d4b6cad93f3baa9edd94bd28c954ae0ad1622252967'},
       participants: [
         {
           destination: makeDestination('0x63E3FB11830c01ac7C9C64091c14Bb6CbAaC9Ac7'),
-          participantId: '0xAE363d29fc0f6A9bbBbEcC87751e518Cd9CA83C0',
-          signingAddress: '0xAE363d29fc0f6A9bbBbEcC87751e518Cd9CA83C0'
+          participantId: '0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf',
+          signingAddress: '0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf'
         },
         {
           destination: makeDestination('0x63E3FB11830c01ac7C9C64091c14Bb6CbAaC9Ac7'),
-          participantId: '0x590A3Bd8D4A3b78411B3bDFb481E44e85C7345c0',
-          signingAddress: '0x590A3Bd8D4A3b78411B3bDFb481E44e85C7345c0'
+          participantId: '0x2222E21c8019b14dA16235319D34b5Dd83E644A9',
+          signingAddress: '0x2222E21c8019b14dA16235319D34b5Dd83E644A9'
         }
       ]
     }

--- a/packages/xstate-wallet/src/serde/wire-format/example.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/example.ts
@@ -87,7 +87,11 @@ export const internalStateFormat = {
   },
   turnNum: bigNumberify('0x0000000000000000000000000000000000000000000000000000000000000001'),
   signatures: [
-    '0x733ccfc3b0b13b446de290a9b056a5b9d7eb1538c1d48f8b863f731a0ea522c46ad30427d0859d782c98ccdc5fe10fc9c3d6480ee5080f70fd96128e4d61d50728'
+    {
+      signature:
+        '0x733ccfc3b0b13b446de290a9b056a5b9d7eb1538c1d48f8b863f731a0ea522c46ad30427d0859d782c98ccdc5fe10fc9c3d6480ee5080f70fd96128e4d61d50728',
+      signer: '0xAE363d29fc0f6A9bbBbEcC87751e518Cd9CA83C0'
+    }
   ]
 };
 export const wireMessageFormat: WireMessage = {

--- a/packages/xstate-wallet/src/serde/wire-format/serde.test.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/serde.test.ts
@@ -9,15 +9,12 @@ import {serializeState, serializeMessage} from './serialize';
 import {deserializeState, deserializeMessage} from './deserialize';
 import {validateState} from '@statechannels/wire-format';
 
-// TODO: Get this working
-// It looks like the signature data captured is no longer correct?
-// I'd verify this but we didn't store the private key :(
-it.skip('works for states', () => {
+it('works for states', () => {
   expect(serializeState(internalStateFormat)).toEqual(wireStateFormat);
   expect(deserializeState(wireStateFormat)).toEqual(internalStateFormat);
 });
 
-it.skip('works for a message', () => {
+it('works for a message', () => {
   const {recipient, sender} = wireMessageFormat;
   expect(serializeMessage(internalMessageFormat, recipient, sender)).toEqual(wireMessageFormat);
   expect(deserializeMessage(wireMessageFormat)).toEqual(internalMessageFormat);

--- a/packages/xstate-wallet/src/serde/wire-format/serde.test.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/serde.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-disabled-tests */
 import {
   wireStateFormat,
   internalStateFormat,
@@ -8,12 +9,15 @@ import {serializeState, serializeMessage} from './serialize';
 import {deserializeState, deserializeMessage} from './deserialize';
 import {validateState} from '@statechannels/wire-format';
 
-it('works for states', () => {
+// TODO: Get this working
+// It looks like the signature data captured is no longer correct?
+// I'd verify this but we didn't store the private key :(
+it.skip('works for states', () => {
   expect(serializeState(internalStateFormat)).toEqual(wireStateFormat);
   expect(deserializeState(wireStateFormat)).toEqual(internalStateFormat);
 });
 
-it('works for a message', () => {
+it.skip('works for a message', () => {
   const {recipient, sender} = wireMessageFormat;
   expect(serializeMessage(internalMessageFormat, recipient, sender)).toEqual(wireMessageFormat);
   expect(deserializeMessage(wireMessageFormat)).toEqual(internalMessageFormat);

--- a/packages/xstate-wallet/src/serde/wire-format/serialize.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/serialize.ts
@@ -30,7 +30,8 @@ export function serializeState(state: SignedState): SignedStateWire {
     channelNonce: bigNumberToUint256(state.channelNonce),
     turnNum: bigNumberToUint256(state.turnNum),
     outcome: serializeOutcome(state.outcome),
-    channelId: calculateChannelId(state)
+    channelId: calculateChannelId(state),
+    signatures: state.signatures.map(s => s.signature)
   };
 }
 

--- a/packages/xstate-wallet/src/store/channel-store-entry.ts
+++ b/packages/xstate-wallet/src/store/channel-store-entry.ts
@@ -122,7 +122,7 @@ export class ChannelStoreEntry {
     return this.signedStates.find(s => this.mySignature(s, s.signatures));
   }
 
-  get latestSupportedByMe() {
+  get latestSignedByMe() {
     const vars = this._latestSupportedByMe;
     if (!vars) throw new Error('No state supported by me');
     return {...this.channelConstants, ...vars};

--- a/packages/xstate-wallet/src/store/channel-store-entry.ts
+++ b/packages/xstate-wallet/src/store/channel-store-entry.ts
@@ -3,24 +3,32 @@ import {
   StateVariables,
   SignedState,
   Participant,
-  ChannelStoredData
+  ChannelStoredData,
+  StateVariablesWithHash,
+  SignedStateWithHash
 } from './types';
-import {signState, hashState, getSignerAddress, calculateChannelId} from './state-utils';
+import {hashState, calculateChannelId, createSignatureEntry} from './state-utils';
 import _ from 'lodash';
 import {BigNumber, bigNumberify} from 'ethers/utils';
 
 import {Funding} from './store';
+export interface SignatureEntry {
+  signature: string;
+  signer: string;
+}
+
+export type SignedStateVariables = StateVariables & {signatures: SignatureEntry[]};
 
 export class ChannelStoreEntry {
   public readonly channelConstants: ChannelConstants;
   public readonly myIndex: number;
-  private stateVariables: Record<string, StateVariables & Partial<ChannelConstants>> = {};
-  private signatures: Record<string, Array<string | undefined>> = {};
+  private stateVariables: Array<StateVariablesWithHash> = [];
+  private signatures: Record<string, Array<SignatureEntry>> = {};
   public funding: Funding | undefined = undefined;
   public readonly applicationSite?: string;
   constructor(channelData: ChannelStoredData) {
     this.myIndex = channelData.myIndex;
-    this.stateVariables = channelData.stateVariables;
+
     this.signatures = channelData.signatures;
     this.funding = channelData.funding;
     this.applicationSite = channelData.applicationSite;
@@ -32,20 +40,7 @@ export class ChannelStoreEntry {
       channelNonce: bigNumberify(channelData.channelConstants.channelNonce)
     };
 
-    this.stateVariables = _.transform(this.stateVariables, (result, stateVariables, stateHash) => {
-      result[stateHash] = _.pick(
-        stateVariables,
-        'turnNum',
-        'outcome',
-        'appData',
-        'isFinal',
-        'participants',
-        'channelNonce',
-        'appDefinition',
-        'challengeDuration',
-        'chainId'
-      );
-    });
+    this.stateVariables = channelData.stateVariables;
   }
 
   public setFunding(funding: Funding) {
@@ -53,40 +48,23 @@ export class ChannelStoreEntry {
   }
 
   public get sortedStates() {
-    return this.sortedByDescendingTurnNum.map(s => ({...this.channelConstants, ...s}));
+    return this.signedStates.map(s => ({...this.channelConstants, ...s}));
   }
 
-  private mySignature(stateVars: StateVariables, signatures: string[]): boolean {
-    const state = {...stateVars, ...this.channelConstants};
-    return signatures.some(sig => getSignerAddress(state, sig) === this.myAddress);
+  private mySignature(stateVars: StateVariables, signatures: SignatureEntry[]): boolean {
+    return signatures.some(sig => sig.signer === this.myAddress);
   }
 
   private get myAddress(): string {
     return this.participants[this.myIndex].signingAddress;
   }
 
-  private getStateVariables(k): StateVariables {
-    const vars = this.stateVariables[k];
-    if (!vars) throw 'No variable found';
-    return vars;
-  }
-
-  private getFilteredSignatures(k): string[] {
-    function isString(x: string | undefined): x is string {
-      return x !== undefined;
-    }
-    return (this.signatures[k] || []).filter(isString);
-  }
-
-  private get signedStates(): Array<StateVariables & {signatures: string[]}> {
-    return Object.keys(this.stateVariables).map(k => ({
-      ...this.getStateVariables(k),
-      signatures: this.getFilteredSignatures(k)
+  private get signedStates(): Array<SignedStateWithHash> {
+    return this.stateVariables.map(s => ({
+      ...this.channelConstants,
+      ...s,
+      signatures: this.signatures[s.stateHash]
     }));
-  }
-
-  private get sortedByDescendingTurnNum(): Array<StateVariables & {signatures: string[]}> {
-    return this.signedStates.sort((a, b) => b.turnNum.sub(a.turnNum).toNumber());
   }
 
   get isSupported() {
@@ -98,89 +76,36 @@ export class ChannelStoreEntry {
   }
 
   private get _supported() {
-    return this.sortedByDescendingTurnNum.find(s => this.stateIsSupported(s));
+    const latestSupport = this._support;
+    return latestSupport.length === 0 ? undefined : latestSupport[0];
   }
-  private stateSupport(
-    state: StateVariables & {
-      signatures: string[];
-    }
-  ): Array<
-    StateVariables & {
-      signatures: string[];
-    }
-  > {
-    const support = [state];
 
-    const signers = new Set<string>();
-    // Check if everyone is signed the current state
-    for (const a of state.signatures.map(sig =>
-      getSignerAddress({...this.channelConstants, ...state}, sig)
-    )) {
-      signers.add(a);
-      if (signers.size === this.nParticipants()) {
-        return support;
-      }
-    }
-    // Find remaining states with a lower turn number
-    const remainingStatesToCheck = this.sortedByDescendingTurnNum.filter(s =>
-      s.turnNum.lt(state.turnNum)
-    );
-
-    for (const s of remainingStatesToCheck) {
-      support.push(s);
-
-      for (const a of s.signatures.map(sig =>
-        getSignerAddress({...this.channelConstants, ...s}, sig)
-      )) {
-        // TODO: Explain b b a a
-        if (signers.has(a)) {
-          throw new Error('State is not supported');
-        }
-
-        signers.add(a);
-        if (signers.size === this.nParticipants()) {
-          return support;
-        }
-      }
-    }
-    return support;
+  public get support(): Array<SignedState> {
+    return this._support.map(s => ({...s, ...this.channelConstants}));
   }
-  private stateIsSupported(
-    state: StateVariables & {
-      signatures: string[];
-    }
-  ): boolean {
-    const signers = new Set<string>();
-    // Check if everyone is signed the current state
-    for (const a of state.signatures.map(sig =>
-      getSignerAddress({...this.channelConstants, ...state}, sig)
-    )) {
-      signers.add(a);
-      if (signers.size === this.nParticipants()) {
-        return true;
-      }
-    }
-    // Find remaining states with a lower turn number
-    const remainingStatesToCheck = this.sortedByDescendingTurnNum.filter(s =>
-      s.turnNum.lt(state.turnNum)
-    );
 
-    for (const s of remainingStatesToCheck)
-      for (const a of s.signatures.map(sig =>
-        getSignerAddress({...this.channelConstants, ...s}, sig)
-      )) {
-        // TODO: Explain b b a a
-        if (signers.has(a)) {
-          return false;
-        }
+  private get _support(): Array<SignedStateWithHash> {
+    const support: Array<SignedStateWithHash> = [];
 
-        signers.add(a);
-        if (signers.size === this.nParticipants()) {
-          return true;
+    const participantsWhoHaveNotSigned = new Set(this.participants.map(p => p.signingAddress));
+
+    for (const signedState of this.signedStates.reverse()) {
+      const moverIndex = signedState.turnNum.mod(this.nParticipants()).toNumber();
+      const moverForThisTurn = this.participants[moverIndex].signingAddress;
+
+      // If the mover hasn't signed the state then we know it cannot be part of the support
+      if (signedState.signatures.some(s => s.signer === moverForThisTurn)) {
+        support.push(signedState);
+
+        for (const signature of signedState.signatures) {
+          participantsWhoHaveNotSigned.delete(signature.signer);
+          if (participantsWhoHaveNotSigned.size === 0) {
+            return support;
+          }
         }
       }
-
-    return false;
+    }
+    return [];
   }
 
   get supported() {
@@ -188,18 +113,13 @@ export class ChannelStoreEntry {
     if (!vars) throw new Error('No supported state found');
     return {...this.channelConstants, ...vars};
   }
-  get support() {
-    if (!this.isSupported) {
-      return []; // TODO: throw error?
-    }
-    return this.stateSupport(this.supported).map(s => ({...s, ...this.channelConstants}));
-  }
+
   get isSupportedByMe() {
     return !!this._latestSupportedByMe;
   }
 
   private get _latestSupportedByMe() {
-    return this.sortedByDescendingTurnNum.find(s => this.mySignature(s, s.signatures));
+    return this.signedStates.find(s => this.mySignature(s, s.signatures));
   }
 
   get latestSupportedByMe() {
@@ -209,7 +129,7 @@ export class ChannelStoreEntry {
   }
 
   get latest() {
-    return {...this.channelConstants, ...this.sortedByDescendingTurnNum[0]};
+    return {...this.channelConstants, ...this.signedStates[this.signedStates.length - 1]};
   }
 
   get latestState() {
@@ -227,74 +147,54 @@ export class ChannelStoreEntry {
   signAndAdd(stateVars: StateVariables, privateKey: string): SignedState {
     const state = {...stateVars, ...this.channelConstants};
 
-    const signatureString = signState(state, privateKey);
+    const signatureEntry = createSignatureEntry(state, privateKey);
 
-    this.addState(stateVars, signatureString);
-
+    this.addState(stateVars, signatureEntry);
+    const stateHash = hashState(state);
     return {
       ...stateVars,
       ...this.channelConstants,
-      signatures: this.getFilteredSignatures(hashState(state))
+      signatures: this.signatures[stateHash]
     };
   }
 
-  addState(stateVars: StateVariables, signature: string) {
-    const state = {
-      ...stateVars,
-      ...this.channelConstants
-    };
+  addState(stateVars: StateVariables, signatureEntry: SignatureEntry) {
+    const state = {...stateVars, ...this.channelConstants};
     const stateHash = hashState(state);
-    this.stateVariables[stateHash] = stateVars;
+    this.stateVariables.push({...stateVars, stateHash});
     const {participants} = this.channelConstants;
 
     // check the signature
-    const signer = getSignerAddress(state, signature);
-    const signerIndex = participants.findIndex(p => p.signingAddress === signer);
+
+    const signerIndex = participants.findIndex(p => p.signingAddress === signatureEntry.signer);
 
     if (signerIndex === -1) {
       throw new Error('State not signed by a participant of this channel');
     }
 
-    const signatures =
-      this.signatures[stateHash] ?? new Array<string | undefined>(this.nParticipants());
-    signatures[signerIndex] = signature;
+    const signatures = this.signatures[stateHash] ?? new Array<SignatureEntry>();
+    signatures.push(signatureEntry);
     this.signatures[stateHash] = signatures;
 
-    // TODO: Supported checks are not very efficient so we don't want to GC to aggresively
-    if (stateVars.turnNum.mod(100).eq(0)) {
-      this.clearOldStates();
-    }
-    console.log('AFTER GC');
-    console.log(Object.keys(this.stateVariables));
+    //this.clearOldStates();
   }
 
-  private clearOldStates() {
-    this.stateVariables = _.transform(this.stateVariables, (result, stateVars, stateHash) => {
-      console.log(stateHash);
-      console.log(`SUPPORTED ${this.isSupported}`);
-      if (this.isSupported) console.log(`INSUPPORT ${this.inSupport(stateHash)} `);
-      if (this.isSupported) {
-        console.log(`BIGGER_TURNUM ${stateVars.turnNum.gt(this.supported.turnNum)}`);
-        console.log(
-          `TURNNUMS STATEVAR ${stateVars.turnNum.toNumber()} SUPPORTED ${this.supported.turnNum.toNumber()}`
-        );
-      }
-      if (
-        !this.isSupported ||
-        this.inSupport(stateHash) ||
-        stateVars.turnNum.gte(this.supported.turnNum)
-      )
-        result[stateHash] = stateVars;
-    });
-  }
-
-  private inSupport(key): boolean {
-    const supportKeys = this.isSupported
-      ? // TODO get the proper keys
-        this.support.map(state => hashState(state))
-      : [];
-    return supportKeys.indexOf(key) !== -1;
-  }
+  // private clearOldStates() {
+  //   // If we don't have a supported state we don't clean anything out
+  //   if (this.isSupported) {
+  //     const supportedIndex = this.stateVariables.findIndex(
+  //       sv => sv.stateHash === this._supported?.stateHash
+  //     );
+  //     if (supportedIndex > this.stateVariables.length - 1) {
+  //       // TODO: Need to sanitize out the signatures
+  //       this.stateVariables = (this._support as Array<StateVariablesWithHash>).concat(
+  //         this.stateVariables.slice(supportedIndex + 1)
+  //       );
+  //     } else {
+  //       this.stateVariables = this._support;
+  //     }
+  //   }
+  // }
 
   private nParticipants(): number {
     return this.channelConstants.participants.length;
@@ -307,7 +207,7 @@ export class ChannelStoreEntry {
       channelNonce: this.channelConstants.channelNonce.toString()
     };
 
-    const stateVariables: Record<string, any> = ChannelStoreEntry.prepareStateVariables(
+    const stateVariables = ChannelStoreEntry.prepareStateVariables(
       _.cloneDeep(this.stateVariables)
     );
 
@@ -340,11 +240,10 @@ export class ChannelStoreEntry {
   }
 
   private static prepareStateVariables(
-    stateVariables,
+    stateVariables, // TODO: Make this typesafe!
     parserFunction: (data: string | BigNumber) => BigNumber | string = v => new BigNumber(v)
   ) {
-    for (const stateHash in stateVariables) {
-      const state = stateVariables[stateHash];
+    for (const state of stateVariables) {
       if (state.turnNum) {
         state.turnNum = parserFunction(state.turnNum);
       }

--- a/packages/xstate-wallet/src/store/state-utils.ts
+++ b/packages/xstate-wallet/src/store/state-utils.ts
@@ -19,6 +19,8 @@ import {
 } from '@statechannels/nitro-protocol';
 import {joinSignature, splitSignature, bigNumberify} from 'ethers/utils';
 import _ from 'lodash';
+import {Wallet} from 'ethers';
+import {SignatureEntry} from './channel-store-entry';
 
 function toNitroState(state: State): NitroState {
   const {challengeDuration, appDefinition, channelNonce, participants, chainId} = state;
@@ -44,7 +46,7 @@ function toNitroState(state: State): NitroState {
 export function toNitroSignedState(signedState: SignedState): NitroSignedState[] {
   const state = toNitroState(signedState);
   const {signatures} = signedState;
-  return signatures.map(sig => ({state, signature: splitSignature(sig)}));
+  return signatures.map(sig => ({state, signature: splitSignature(sig.signature)}));
 }
 
 export function calculateChannelId(channelConstants: ChannelConstants): string {
@@ -57,6 +59,12 @@ export function calculateChannelId(channelConstants: ChannelConstants): string {
   });
 }
 
+export function createSignatureEntry(state: State, privateKey: string): SignatureEntry {
+  const {address} = new Wallet(privateKey);
+  const nitroState = toNitroState(state);
+  const {signature} = signNitroState(nitroState, privateKey);
+  return {signature: joinSignature(signature), signer: address};
+}
 export function signState(state: State, privateKey: string): string {
   const nitroState = toNitroState(state);
   const {signature} = signNitroState(nitroState, privateKey);

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -200,10 +200,10 @@ export class XstateStore implements Store {
 
     // TODO: There could be concurrency problems which lead to entries potentially being overwritten.
     await this.setNonce(addresses, state.channelNonce);
-    const key = hashState(state);
+
     const data: ChannelStoredData = {
       channelConstants: state,
-      stateVariables: {[key]: state},
+      stateVariables: [{...state, stateHash: hashState(state)}],
       signatures: {},
       myIndex,
       funding: undefined,

--- a/packages/xstate-wallet/src/store/tests/indexedDB-store.test.ts
+++ b/packages/xstate-wallet/src/store/tests/indexedDB-store.test.ts
@@ -3,7 +3,7 @@ import {XstateStore} from '../store';
 import {State, Objective} from '../types';
 import {bigNumberify, BigNumber} from 'ethers/utils';
 import {Wallet} from 'ethers';
-import {calculateChannelId, signState} from '../state-utils';
+import {calculateChannelId, createSignatureEntry} from '../state-utils';
 import {NETWORK_ID, CHALLENGE_DURATION} from '../../constants';
 import {simpleEthAllocation, makeDestination} from '../../utils';
 import {IndexedDBBackend as Backend} from '../indexedDB-backend';
@@ -39,7 +39,7 @@ const challengeDuration = bigNumberify(CHALLENGE_DURATION);
 const channelConstants = {chainId, participants, channelNonce, appDefinition, challengeDuration};
 const state: State = {...stateVars, ...channelConstants};
 const channelId = calculateChannelId(channelConstants);
-const signature = signState(state, aPrivateKey);
+const signature = createSignatureEntry(state, aPrivateKey);
 const signedState = {...state, signatures: [signature]};
 const signedStates = [signedState];
 
@@ -148,7 +148,7 @@ describe('pushMessage', () => {
 
     const nextState = {...state, turnNum: state.turnNum.add(2)};
     await store.pushMessage({
-      signedStates: [{...nextState, signatures: [signState(nextState, bPrivateKey)]}]
+      signedStates: [{...nextState, signatures: [createSignatureEntry(nextState, bPrivateKey)]}]
     });
     expect((await store.getEntry(channelId)).latest).toMatchObject(nextState);
   });

--- a/packages/xstate-wallet/src/store/tests/memory-store.test.ts
+++ b/packages/xstate-wallet/src/store/tests/memory-store.test.ts
@@ -135,7 +135,7 @@ describe('createChannel', () => {
 });
 
 describe('pushMessage', () => {
-  it.only('stores states', async () => {
+  it('stores states', async () => {
     const store = await aStore();
     await store.createChannel(
       signedState.participants,

--- a/packages/xstate-wallet/src/store/tests/memory-store.test.ts
+++ b/packages/xstate-wallet/src/store/tests/memory-store.test.ts
@@ -1,5 +1,5 @@
 import {bigNumberify, BigNumber} from 'ethers/utils';
-import {calculateChannelId, signState} from './../state-utils';
+import {calculateChannelId, createSignatureEntry} from './../state-utils';
 import {ChannelStoreEntry} from '../channel-store-entry';
 import {MemoryBackend as Backend} from '../memory-backend';
 import {NETWORK_ID, CHALLENGE_DURATION} from '../../constants';
@@ -37,7 +37,7 @@ const challengeDuration = bigNumberify(CHALLENGE_DURATION);
 const channelConstants = {chainId, participants, channelNonce, appDefinition, challengeDuration};
 const state: State = {...stateVars, ...channelConstants};
 const channelId = calculateChannelId(channelConstants);
-const signature = signState(state, aPrivateKey);
+const signature = createSignatureEntry(state, aPrivateKey);
 const signedState = {...state, signatures: [signature]};
 const signedStates = [signedState];
 
@@ -135,7 +135,7 @@ describe('createChannel', () => {
 });
 
 describe('pushMessage', () => {
-  it('stores states', async () => {
+  it.only('stores states', async () => {
     const store = await aStore();
     await store.createChannel(
       signedState.participants,
@@ -146,7 +146,7 @@ describe('pushMessage', () => {
 
     const nextState = {...state, turnNum: state.turnNum.add(2)};
     await store.pushMessage({
-      signedStates: [{...nextState, signatures: [signState(nextState, bPrivateKey)]}]
+      signedStates: [{...nextState, signatures: [createSignatureEntry(nextState, bPrivateKey)]}]
     });
     expect((await store.getEntry(channelId)).latest).toMatchObject(nextState);
   });

--- a/packages/xstate-wallet/src/store/types.ts
+++ b/packages/xstate-wallet/src/store/types.ts
@@ -1,5 +1,6 @@
 import {BigNumber} from 'ethers/utils';
 import {Funding} from './store';
+import {SignatureEntry} from './channel-store-entry';
 
 export interface SiteBudget {
   domain: string;
@@ -29,7 +30,7 @@ export interface StateVariables {
   appData: string;
   isFinal: boolean;
 }
-
+export type StateVariablesWithHash = StateVariables & Hashed;
 export type Destination = string & {_isDestination: void};
 export interface AllocationItem {
   destination: Destination;
@@ -70,10 +71,13 @@ export interface ChannelConstants {
 export interface State extends ChannelConstants, StateVariables {}
 
 interface Signed {
-  signatures: string[];
+  signatures: SignatureEntry[];
 }
-
+interface Hashed {
+  stateHash: string;
+}
 export interface SignedState extends State, Signed {}
+export type SignedStateWithHash = SignedState & Hashed;
 export interface SignedStateVariables extends StateVariables, Signed {}
 
 type _Objective<Name, Data> = {
@@ -130,12 +134,12 @@ export interface Message {
 }
 
 export type ChannelStoredData = {
-  stateVariables: Record<string, StateVariables>;
+  stateVariables: Array<StateVariablesWithHash>;
   channelConstants: Omit<ChannelConstants, 'challengeDuration' | 'channelNonce'> & {
     challengeDuration: BigNumber | string;
     channelNonce: BigNumber | string;
   };
-  signatures: Record<string, Array<string | undefined>>;
+  signatures: Record<string, Array<SignatureEntry>>;
   funding: Funding | undefined;
   applicationSite: string | undefined;
   myIndex: number;

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -304,7 +304,7 @@ export const applicationWorkflow = (
 
   const guards: WorkflowGuards = {
     channelOpen: (context: ChannelIdExists, event: ChannelUpdated): boolean =>
-      !event.storeEntry.latestSupportedByMe.isFinal,
+      !event.storeEntry.latestSignedByMe.isFinal,
     channelClosing: (context: ChannelIdExists, event: ChannelUpdated): boolean =>
       !!event.storeEntry.latest?.isFinal,
 
@@ -362,8 +362,8 @@ export const applicationWorkflow = (
     getDataForCreateChannelAndFund: async (
       context: ChannelParamsExist
     ): Promise<CreateAndFund.Init> => {
-      const {latestSupportedByMe, channelId} = await store.getEntry(context.channelId);
-      const allocation = checkThat(latestSupportedByMe.outcome, isSimpleEthAllocation);
+      const {latestSignedByMe, channelId} = await store.getEntry(context.channelId);
+      const allocation = checkThat(latestSignedByMe.outcome, isSimpleEthAllocation);
       return {channelId, allocation};
     },
     getDataForCreateChannelConfirmation: async (

--- a/packages/xstate-wallet/src/workflows/close-ledger-and-withdraw.ts
+++ b/packages/xstate-wallet/src/workflows/close-ledger-and-withdraw.ts
@@ -80,7 +80,7 @@ export const config: StateNodeConfig<WorkflowContext, any, any> = {
 const getFinalState = (store: Store): WorkflowServices['getFinalState'] => async ({
   opponent: hub
 }) => {
-  const {latestSupportedByMe, latest} = await store.getLedger(hub.participantId);
+  const {latestSignedByMe: latestSupportedByMe, latest} = await store.getLedger(hub.participantId);
 
   // If we've received a new final state that matches our outcome we support that
   if (latest.isFinal && outcomesEqual(latestSupportedByMe.outcome, latest.outcome)) {

--- a/packages/xstate-wallet/src/workflows/conclude-channel.ts
+++ b/packages/xstate-wallet/src/workflows/conclude-channel.ts
@@ -14,22 +14,22 @@ const WORKFLOW = 'conclude-channel';
 export type Init = {channelId: string};
 
 const finalState = (store: Store) => async (context: Init): Promise<SupportState.Init> => {
-  const {sortedStates, latestSupportedByMe, latest} = await store.getEntry(context.channelId);
+  const {sortedStates, latestSignedByMe, latest} = await store.getEntry(context.channelId);
 
   const latestFinalState: State | undefined = sortedStates.filter(s => s.isFinal)[0];
 
   // If we've received a new final state that matches our outcome we support that
-  if (outcomesEqual(latestSupportedByMe.outcome, latestFinalState?.outcome)) {
+  if (outcomesEqual(latestSignedByMe.outcome, latestFinalState?.outcome)) {
     return {state: latestFinalState};
   }
 
   // If we've supported a final state, send it
-  if (latestSupportedByMe.isFinal) {
-    return {state: latestSupportedByMe};
+  if (latestSignedByMe.isFinal) {
+    return {state: latestSignedByMe};
   }
 
   // Otherwise create a new final state
-  return {state: {...latestSupportedByMe, turnNum: latest.turnNum.add(1), isFinal: true}};
+  return {state: {...latestSignedByMe, turnNum: latest.turnNum.add(1), isFinal: true}};
 };
 
 const supportState = (store: Store) => SupportState.machine(store);

--- a/packages/xstate-wallet/src/workflows/support-state.ts
+++ b/packages/xstate-wallet/src/workflows/support-state.ts
@@ -47,9 +47,7 @@ const sendState = (store: Store) => async ({state, channelId}: HasChannelId) => 
     // If we've already supported this state, we might as well re-send it.
     (isSupportedByMe && statesEqual(entry.latestSignedByMe, state)) ||
     // Otherwise, we only send it if we haven't signed any new states.
-    (isSupported &&
-      statesEqual(entry.latestSignedByMe, entry.supported) &&
-      entry.supported.turnNum.lt(state.turnNum)) ||
+    (isSupported && entry.supported.turnNum.lt(state.turnNum)) ||
     // We always support a final state if it matches the outcome that we have signed
     (state.isFinal && outcomesEqual(state.outcome, entry.latestSignedByMe.outcome))
   ) {

--- a/packages/xstate-wallet/src/workflows/support-state.ts
+++ b/packages/xstate-wallet/src/workflows/support-state.ts
@@ -45,13 +45,13 @@ const sendState = (store: Store) => async ({state, channelId}: HasChannelId) => 
     // If we've haven't already signed a state, there's no harm in supporting one.
     !isSupportedByMe ||
     // If we've already supported this state, we might as well re-send it.
-    (isSupportedByMe && statesEqual(entry.latestSupportedByMe, state)) ||
+    (isSupportedByMe && statesEqual(entry.latestSignedByMe, state)) ||
     // Otherwise, we only send it if we haven't signed any new states.
     (isSupported &&
-      statesEqual(entry.latestSupportedByMe, entry.supported) &&
+      statesEqual(entry.latestSignedByMe, entry.supported) &&
       entry.supported.turnNum.lt(state.turnNum)) ||
     // We always support a final state if it matches the outcome that we have signed
-    (state.isFinal && outcomesEqual(state.outcome, entry.latestSupportedByMe.outcome))
+    (state.isFinal && outcomesEqual(state.outcome, entry.latestSignedByMe.outcome))
   ) {
     await store.signAndAddState(channelId, state);
   } else {

--- a/packages/xstate-wallet/src/workflows/tests/application.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/application.test.ts
@@ -241,7 +241,7 @@ it('starts concluding when receiving a final state', async () => {
       chainId: '0x0',
       channelNonce: bigNumberify('0x0'),
       participants: [],
-      signatures: ['0x0']
+      signatures: [{signature: '0x0', signer: '0x0'}]
     }
   ];
   const services: Partial<WorkflowServices> = {

--- a/packages/xstate-wallet/src/workflows/tests/create-and-fund.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/create-and-fund.test.ts
@@ -6,7 +6,7 @@ import {Init, machine} from '../create-and-fund';
 import {Store} from '../../store';
 import {bigNumberify} from 'ethers/utils';
 import _ from 'lodash';
-import {firstState, signState, calculateChannelId} from '../../store/state-utils';
+import {firstState, calculateChannelId, createSignatureEntry} from '../../store/state-utils';
 import {ChannelConstants, Outcome, State} from '../../store/types';
 import {AddressZero} from 'ethers/constants';
 import {checkThat, isSimpleEthAllocation, add} from '../../utils';
@@ -77,7 +77,7 @@ let bStore: TestStore;
 
 const allSignState = (state: State) => ({
   ...state,
-  signatures: [wallet1, wallet2].map(({privateKey}) => signState(state, privateKey))
+  signatures: [wallet1, wallet2].map(({privateKey}) => createSignatureEntry(state, privateKey))
 });
 
 let chain: FakeChain;
@@ -132,7 +132,9 @@ test('it uses virtual funding when enabled', async () => {
 
   let state = ledgerState([first, third], ledgerAmounts);
   let ledgerId = calculateChannelId(state);
-  let signatures = [wallet1, wallet3].map(({privateKey}) => signState(state, privateKey));
+  let signatures = [wallet1, wallet3].map(({privateKey}) =>
+    createSignatureEntry(state, privateKey)
+  );
   await aStore.createBudget(budget(bigNumberify(7), bigNumberify(7)));
   await bStore.createBudget(budget(bigNumberify(7), bigNumberify(7)));
   chain.depositSync(ledgerId, '0', depositAmount);
@@ -140,7 +142,7 @@ test('it uses virtual funding when enabled', async () => {
 
   state = ledgerState([second, third], ledgerAmounts);
   ledgerId = calculateChannelId(state);
-  signatures = [wallet2, wallet3].map(({privateKey}) => signState(state, privateKey));
+  signatures = [wallet2, wallet3].map(({privateKey}) => createSignatureEntry(state, privateKey));
 
   chain.depositSync(ledgerId, '0', depositAmount);
   await bStore.setLedgerByEntry(await bStore.createEntry({...state, signatures}));

--- a/packages/xstate-wallet/src/workflows/tests/ledger-funding.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/ledger-funding.test.ts
@@ -7,7 +7,7 @@ import {Init, machine, Errors} from '../ledger-funding';
 import {Store} from '../../store';
 import {bigNumberify} from 'ethers/utils';
 import _ from 'lodash';
-import {firstState, signState, calculateChannelId} from '../../store/state-utils';
+import {firstState, calculateChannelId, createSignatureEntry} from '../../store/state-utils';
 import {ChannelConstants, Outcome, State} from '../../store/types';
 import {AddressZero} from 'ethers/constants';
 
@@ -67,7 +67,7 @@ let bStore: TestStore;
 
 const allSignState = (state: State) => ({
   ...state,
-  signatures: [wallet1, wallet2].map(({privateKey}) => signState(state, privateKey))
+  signatures: [wallet1, wallet2].map(({privateKey}) => createSignatureEntry(state, privateKey))
 });
 
 beforeEach(async () => {

--- a/packages/xstate-wallet/src/workflows/tests/ledger-funding.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/ledger-funding.test.ts
@@ -129,8 +129,10 @@ test('locks', async () => {
 
   const aService = interpret(machine(aStore).withContext(context));
   const bService = interpret(machine(bStore).withContext(context));
-
-  const status = await aStore.acquireChannelLock(context.ledgerChannelId);
+  // Note: We need player B to block on the lock since technically
+  // if player B signs state 1 then state 1 is supported and it won't block
+  // waiting for player A
+  const status = await bStore.acquireChannelLock(context.ledgerChannelId);
   expect(status).toEqual({
     channelId: context.ledgerChannelId,
     lock: expect.any(Guid)
@@ -139,8 +141,8 @@ test('locks', async () => {
   [aService, bService].map(s => s.start());
 
   await waitForExpect(async () => {
-    expect(aService.state.value).toEqual('acquiringLock');
-    expect(bService.state.value).toEqual({fundingTarget: 'supportState'});
+    expect(bService.state.value).toEqual('acquiringLock');
+    expect(aService.state.value).toEqual({fundingTarget: 'supportState'});
   }, EXPECT_TIMEOUT);
 
   aService.onTransition(s => {
@@ -149,13 +151,13 @@ test('locks', async () => {
       expect((s.context as any).lock).not.toEqual(status.lock);
     }
   });
-  await aStore.releaseChannelLock(status);
+  await bStore.releaseChannelLock(status);
 
   await waitForExpect(async () => {
     expect(aService.state.value).toEqual('success');
   }, EXPECT_TIMEOUT);
 
-  expect(aStore._channelLocks[context.ledgerChannelId]).toBeUndefined();
+  expect(bStore._channelLocks[context.ledgerChannelId]).toBeUndefined();
 });
 
 const twelveTotalAllocated = outcome;

--- a/packages/xstate-wallet/src/workflows/tests/simple-hub.ts
+++ b/packages/xstate-wallet/src/workflows/tests/simple-hub.ts
@@ -1,7 +1,7 @@
 import {Message} from '../../store/types';
 import {Observable, fromEvent} from 'rxjs';
 import {EventEmitter} from 'eventemitter3';
-import {signState} from '../../store/state-utils';
+import {createSignatureEntry} from '../../store/state-utils';
 import {ethers} from 'ethers';
 
 export class SimpleHub {
@@ -21,8 +21,7 @@ export class SimpleHub {
 
       const hubIdx = participants.findIndex(p => p.signingAddress === address);
       if (hubIdx > -1) {
-        const signature = signState(signedState, this.privateKey);
-        signatures[hubIdx] = signature;
+        signatures.push(createSignatureEntry(signedState, this.privateKey));
 
         this._eventEmitter.emit('addToOutbox', {
           signedStates: [{...signedState, signatures}],

--- a/packages/xstate-wallet/src/workflows/tests/store.ts
+++ b/packages/xstate-wallet/src/workflows/tests/store.ts
@@ -21,11 +21,12 @@ export class TestStore extends XstateStore implements Store {
       .map(p => p.signingAddress)
       .findIndex(a => a === address);
     const {funding, applicationSite} = opts || {};
+    const stateHash = hashState(signedState);
     const entry = new ChannelStoreEntry({
       channelConstants: signedState,
       myIndex,
-      stateVariables: {[hashState(signedState)]: signedState},
-      signatures: {[hashState(signedState)]: signedState.signatures},
+      stateVariables: [{...signedState, stateHash}],
+      signatures: {[stateHash]: signedState.signatures},
       funding,
       applicationSite
     });

--- a/packages/xstate-wallet/src/workflows/tests/virtual-defunding.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/virtual-defunding.test.ts
@@ -4,7 +4,7 @@ import waitForExpect from 'wait-for-expect';
 import {SimpleHub} from './simple-hub';
 import {bigNumberify, BigNumberish} from 'ethers/utils';
 import _ from 'lodash';
-import {signState, calculateChannelId} from '../../store/state-utils';
+import {calculateChannelId, createSignatureEntry} from '../../store/state-utils';
 import {Participant, Outcome, SignedState, ChannelConstants} from '../../store/types';
 import {AddressZero, HashZero} from 'ethers/constants';
 import {add, simpleEthAllocation, simpleEthGuarantee, makeDestination} from '../../utils';
@@ -57,7 +57,9 @@ const state = (
 
   return {
     ...state,
-    signatures: constants.participants.map(p => signState(state, privateKeys[p.participantId]))
+    signatures: constants.participants.map(p =>
+      createSignatureEntry(state, privateKeys[p.participantId])
+    )
   };
 };
 

--- a/packages/xstate-wallet/src/workflows/tests/virtual-funding.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/virtual-funding.test.ts
@@ -4,7 +4,7 @@ import waitForExpect from 'wait-for-expect';
 import {SimpleHub} from './simple-hub';
 import {bigNumberify} from 'ethers/utils';
 import _ from 'lodash';
-import {firstState, signState, calculateChannelId} from '../../store/state-utils';
+import {firstState, createSignatureEntry, calculateChannelId} from '../../store/state-utils';
 import {ChannelConstants, Outcome, State} from '../../store/types';
 import {AddressZero} from 'ethers/constants';
 import {add, simpleEthAllocation, makeDestination, simpleEthGuarantee} from '../../utils';
@@ -83,7 +83,10 @@ test('virtual funding with smart hub', async () => {
 
   [aStore, hubStore, bStore].forEach(async (store: TestStore) => {
     const state = firstState(outcome, jointChannel);
-    await store.createEntry({...state, signatures: [signState(state, wallet1.privateKey)]});
+    await store.createEntry({
+      ...state,
+      signatures: [createSignatureEntry(state, wallet1.privateKey)]
+    });
   });
 
   let state = ledgerState([first, third], ledgerAmounts);
@@ -91,7 +94,9 @@ test('virtual funding with smart hub', async () => {
   chain.depositSync(ledgerId, '0', depositAmount);
   await Promise.all(
     [aStore, hubStore].map(async (store: TestStore) => {
-      const signatures = [wallet1, wallet3].map(({privateKey}) => signState(state, privateKey));
+      const signatures = [wallet1, wallet3].map(({privateKey}) =>
+        createSignatureEntry(state, privateKey)
+      );
       await store.setLedgerByEntry(await store.createEntry({...state, signatures}));
     })
   );
@@ -101,7 +106,9 @@ test('virtual funding with smart hub', async () => {
   chain.depositSync(ledgerId, '0', depositAmount);
   await Promise.all(
     [bStore, hubStore].map(async (store: TestStore) => {
-      const signatures = [wallet2, wallet3].map(({privateKey}) => signState(state, privateKey));
+      const signatures = [wallet2, wallet3].map(({privateKey}) =>
+        createSignatureEntry(state, privateKey)
+      );
       await store.setLedgerByEntry(await store.createEntry({...state, signatures}));
     })
   );
@@ -140,19 +147,24 @@ test('virtual funding with a simple hub', async () => {
 
   [aStore, bStore].forEach(async (store: TestStore) => {
     const state = firstState(outcome, jointChannel);
-    await store.createEntry({...state, signatures: [signState(state, wallet1.privateKey)]});
+    await store.createEntry({
+      ...state,
+      signatures: [createSignatureEntry(state, wallet1.privateKey)]
+    });
   });
 
   let state = ledgerState([first, third], ledgerAmounts);
   let ledgerId = calculateChannelId(state);
-  let signatures = [wallet1, wallet3].map(({privateKey}) => signState(state, privateKey));
+  let signatures = [wallet1, wallet3].map(({privateKey}) =>
+    createSignatureEntry(state, privateKey)
+  );
 
   chain.depositSync(ledgerId, '0', depositAmount);
   await aStore.setLedgerByEntry(await aStore.createEntry({...state, signatures}));
 
   state = ledgerState([second, third], ledgerAmounts);
   ledgerId = calculateChannelId(state);
-  signatures = [wallet2, wallet3].map(({privateKey}) => signState(state, privateKey));
+  signatures = [wallet2, wallet3].map(({privateKey}) => createSignatureEntry(state, privateKey));
 
   chain.depositSync(ledgerId, '0', depositAmount);
   await bStore.setLedgerByEntry(await bStore.createEntry({...state, signatures}));
@@ -237,7 +249,13 @@ test('invalid joint state', async () => {
   };
 
   await store.pushMessage({
-    signedStates: [{...invalidState, signatures: [signState(invalidState, wallet1.privateKey)]}]
+    signedStates: [
+      {
+        ...invalidState,
+
+        signatures: [createSignatureEntry(invalidState, wallet1.privateKey)]
+      }
+    ]
   });
 
   await waitForExpect(() => expect(service.state.value).toEqual('failure'), EXPECT_TIMEOUT);

--- a/packages/xstate-wallet/src/workflows/virtual-funding-as-hub.ts
+++ b/packages/xstate-wallet/src/workflows/virtual-funding-as-hub.ts
@@ -95,7 +95,7 @@ export const config: MachineConfig<Init, any, any> = {
 
 const getDeductions = (store: Store) => async (ctx: Init): Promise<Deductions> => {
   const entry = await store.getEntry(ctx.jointChannelId);
-  const {latestSupportedByMe} = entry;
+  const {latestSignedByMe: latestSupportedByMe} = entry;
   const {allocationItems} = checkThat(latestSupportedByMe.outcome, isSimpleEthAllocation);
 
   return {

--- a/packages/xstate-wallet/src/workflows/virtual-funding-as-hub.ts
+++ b/packages/xstate-wallet/src/workflows/virtual-funding-as-hub.ts
@@ -94,7 +94,8 @@ export const config: MachineConfig<Init, any, any> = {
 };
 
 const getDeductions = (store: Store) => async (ctx: Init): Promise<Deductions> => {
-  const {latestSupportedByMe} = await store.getEntry(ctx.jointChannelId);
+  const entry = await store.getEntry(ctx.jointChannelId);
+  const {latestSupportedByMe} = entry;
   const {allocationItems} = checkThat(latestSupportedByMe.outcome, isSimpleEthAllocation);
 
   return {

--- a/packages/xstate-wallet/src/workflows/virtual-funding-as-leaf.ts
+++ b/packages/xstate-wallet/src/workflows/virtual-funding-as-leaf.ts
@@ -215,7 +215,7 @@ export const jointChannelUpdate = (store: Store) => ({
     .toPromise();
 
 const getDeductions = (store: Store) => async (ctx: Init): Promise<Deductions> => {
-  const {latestSupportedByMe, myIndex} = await store.getEntry(ctx.jointChannelId);
+  const {latestSignedByMe: latestSupportedByMe, myIndex} = await store.getEntry(ctx.jointChannelId);
   const {allocationItems} = checkThat(latestSupportedByMe.outcome, isSimpleEthAllocation);
 
   const outcomeIdx = myIndex === ParticipantIdx.A ? OutcomeIdx.A : OutcomeIdx.B;


### PR DESCRIPTION
Changes the storage of states to use a simple array and update the `support` and `supported` functions to perform an actual supported check instead of relying on the amount of signatures.

Running after this change I'm seeing less cpu usage and download speeds of `2-4MB/s`.

Fixes #1344 
