### PR TITLE
Private Tracker Deployment Preparation, Client Capability Testing improvements

### DIFF
--- a/packages/web3torrent/src/App.test.tsx
+++ b/packages/web3torrent/src/App.test.tsx
@@ -2,30 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import {web3torrent, Web3TorrentContext} from './clients/web3torrent-client';
-
-// This tests fails with the following error message
-// /Users/georgeknee/statechannels/monorepo/node_modules/webtorrent/lib/torrent.js:232
-//
-// if (this._rechokeIntervalId.unref) this._rechokeIntervalId.unref()
-// ^
-//
-// TypeError: Cannot read property 'unref' of undefined
-// at Torrent._onParsedTorrent (/Users/georgeknee/statechannels/monorepo/node_modules/webtorrent/lib/torrent.js:232:33)
-// at process.nextTick (/Users/georgeknee/statechannels/monorepo/node_modules/webtorrent/lib/torrent.js:205:14)
-// at process._tickCallback (internal/process/next_tick.js:61:11)
-
-// The issue seems to be related to https://github.com/webtorrent/bittorrent-protocol/issues/44
-
-// The test will pass if we disable the call to WebTorrentPaidStreamingClient.testTorrentingCapability() inside App.tsx
-
-// Currently the App.tsx component is arguably responsible for too much: e.g. enabling the web3torrent client and state channel provider. We should figure out a way to test the rendering of App.tsx in isolation from that; possibly by moving the WebTorrentPaidStreamingClient.enable() call elsewhere.
-// https://github.com/statechannels/monorepo/issues/1291
-
 afterAll(() => {
   web3torrent.destroy();
 });
 
-it.skip('renders app without crashing', () => {
+it('renders app without crashing', () => {
   const div = document.createElement('div');
 
   ReactDOM.render(

--- a/packages/web3torrent/src/App.tsx
+++ b/packages/web3torrent/src/App.tsx
@@ -11,13 +11,15 @@ import File from './pages/file/File';
 import Upload from './pages/upload/Upload';
 import {RoutePath} from './routes';
 import {Web3TorrentContext} from './clients/web3torrent-client';
+import {TorrentClientCapabilities, ClientEvents} from './library/types';
 
 const history = createBrowserHistory();
 class App extends React.Component {
   state = {
     currentNetwork: 'ethereum' in window && Number(window.ethereum.networkVersion),
     requiredNetwork: Number(process.env.REACT_APP_CHAIN_NETWORK_ID),
-    canTorrent: true
+    canTorrent: true,
+    showNetworkWarning: false
   };
 
   static contextType = Web3TorrentContext;
@@ -25,23 +27,39 @@ class App extends React.Component {
   // Adds typing information to this.context
   context!: React.ContextType<typeof Web3TorrentContext>;
 
-  async componentDidMount() {
+  constructor(props) {
+    super(props);
+    this.updateState = this.updateState.bind(this);
+  }
+
+  updateState() {
+    this.setState({
+      ...this.state,
+      showNetworkWarning: this.context.clientCapability === TorrentClientCapabilities.NOT_CAPABLE,
+      currentNetwork: Number(window.ethereum.networkVersion)
+    });
+  }
+
+  componentDidMount() {
+    this.context.on(ClientEvents.CLIENT_CAPABILITY_TEST, this.updateState);
     if ('ethereum' in window) {
       this.setState({...this.state, currentNetwork: Number(window.ethereum.networkVersion)});
-      window.ethereum.on('networkChanged', chainId => {
-        this.setState({...this.state, currentNetwork: Number(chainId)});
-      });
+      window.ethereum.on('networkChanged', this.updateState);
     }
-    this.setState({...this.state, canTorrent: await this.context.testTorrentingCapability(3000)});
+  }
+
+  componentWillUnmount() {
+    this.context.off(ClientEvents.CLIENT_CAPABILITY_TEST, this.updateState);
   }
 
   render() {
-    const {currentNetwork, requiredNetwork, canTorrent} = this.state;
+    const {currentNetwork, requiredNetwork, showNetworkWarning} = this.state;
     const ready = currentNetwork === requiredNetwork;
+
     return (
       <Router history={history}>
         <main>
-          {!canTorrent && (
+          {showNetworkWarning && (
             <Flash variant="danger">
               Looks like you do not have an internet connection or are behind a firewall.
               Web3Torrent may not work on some public wifi networks.

--- a/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.test.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.test.tsx
@@ -37,7 +37,7 @@ const mockDownloadInfo = (torrentProps?: Partial<Torrent>): MockDownloadInfo => 
   };
 };
 
-describe.skip('<DownloadInfo />', () => {
+describe('<DownloadInfo />', () => {
   let downloadInfo: MockDownloadInfo;
 
   beforeEach(() => {

--- a/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.test.tsx
+++ b/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.test.tsx
@@ -1,23 +1,12 @@
 import Enzyme, {mount, ReactWrapper} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import prettier from 'prettier-bytes';
 import React from 'react';
 import {TorrentPeers} from '../../../library/types';
 import {Torrent} from '../../../types';
 import {createMockTorrent, createMockTorrentPeers, testSelector} from '../../../utils/test-utils';
 import {UploadInfo, UploadInfoProps} from './UploadInfo';
-import {calculateWei, prettyPrintWei} from '../../../utils/calculateWei';
 
 Enzyme.configure({adapter: new Adapter()});
-
-type ElementsByLeecher = {
-  [key: string]: {
-    leecherInfoWrapper: ReactWrapper;
-    leecherIdElement: ReactWrapper;
-    leecherDownloadedElement: ReactWrapper;
-    leecherPaid: ReactWrapper;
-  };
-};
 
 type MockUploadInfo = {
   torrent: Partial<Torrent>;
@@ -25,13 +14,14 @@ type MockUploadInfo = {
   uploadInfoWrapper: ReactWrapper<UploadInfoProps>;
   uploadingSectionElement: ReactWrapper;
   numPeersElement: ReactWrapper;
-  leechersSectionElement: ReactWrapper;
-  leechersInfo: ElementsByLeecher;
 };
 
 const mockUploadInfo = (noPeers = false): MockUploadInfo => {
   const peers = noPeers ? {} : createMockTorrentPeers();
-  const torrent = createMockTorrent({numPeers: Object.keys(peers).length}) as Torrent;
+  const torrent = createMockTorrent({
+    numPeers: Object.keys(peers).length,
+    originalSeed: true
+  }) as Torrent;
 
   const uploadInfoWrapper = mount(
     <UploadInfo torrent={torrent} channelCache={{}} mySigningAddress="0x0" />
@@ -42,25 +32,11 @@ const mockUploadInfo = (noPeers = false): MockUploadInfo => {
     torrent,
     peers,
     uploadingSectionElement: uploadInfoWrapper.find('.uploadingInfo'),
-    numPeersElement: uploadInfoWrapper.find(testSelector('numPeers')),
-    leechersSectionElement: uploadInfoWrapper.find('.leechersInfo'),
-    leechersInfo: Object.values(peers)
-      .map(peer => {
-        const leecherInfoWrapper = uploadInfoWrapper.findWhere(node => node.key() === peer.id);
-        return {
-          [peer.id]: {
-            leecherInfoWrapper,
-            leecherIdElement: leecherInfoWrapper.find('.leecher-id'),
-            leecherDownloadedElement: leecherInfoWrapper.find('.leecher-downloaded'),
-            leecherPaid: leecherInfoWrapper.find('.leecher-paid')
-          }
-        } as ElementsByLeecher;
-      })
-      .reduce((accumulated, value) => ({...accumulated, ...value}), {})
+    numPeersElement: uploadInfoWrapper.find(testSelector('numPeers'))
   };
 };
 
-describe.skip('<UploadInfo />', () => {
+describe('<UploadInfo />', () => {
   let uploadInfo: MockUploadInfo;
 
   beforeEach(() => {
@@ -68,43 +44,16 @@ describe.skip('<UploadInfo />', () => {
   });
 
   it('can be instantiated', () => {
-    const {leechersSectionElement, numPeersElement, torrent, uploadingSectionElement} = uploadInfo;
+    const {numPeersElement, torrent, uploadingSectionElement} = uploadInfo;
 
     expect(uploadingSectionElement.exists()).toEqual(true);
     expect(numPeersElement.exists()).toEqual(true);
-    expect(leechersSectionElement.exists()).toEqual(true);
 
     expect(numPeersElement.text()).toEqual(`${torrent.numPeers}`);
-    expect(leechersSectionElement.children().length).toEqual(torrent.numPeers);
   });
 
   it('shows no peer info when no peers exist', () => {
-    const {leechersSectionElement, uploadingSectionElement} = mockUploadInfo(true);
-
+    const {uploadingSectionElement} = mockUploadInfo(true);
     expect(uploadingSectionElement.exists()).toEqual(true);
-    expect(leechersSectionElement.exists()).toEqual(true);
-    expect(leechersSectionElement.children().length).toEqual(0);
   });
-
-  it.each([Object.keys(createMockTorrentPeers())])(
-    'can render leecher info for peer %s',
-    peerId => {
-      const {uploaded} = uploadInfo.peers[peerId].wire;
-      const {
-        leecherInfoWrapper,
-        leecherIdElement,
-        leecherDownloadedElement,
-        leecherPaid
-      } = uploadInfo.leechersInfo[peerId];
-
-      expect(leecherInfoWrapper.exists()).toEqual(true);
-      expect(leecherIdElement.exists()).toEqual(true);
-      expect(leecherDownloadedElement.exists()).toEqual(true);
-      expect(leecherPaid.exists()).toEqual(true);
-
-      expect(leecherIdElement.text()).toEqual(`#${peerId}...`);
-      expect(leecherDownloadedElement.text()).toEqual(prettier(uploaded));
-      expect(leecherPaid.text()).toEqual(`$${prettyPrintWei(calculateWei(uploaded))}`);
-    }
-  );
 });

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -73,7 +73,7 @@ export const preSeededTorrents: Array<Partial<Torrent>> = [
   }
 ];
 
-// Welcoe Page Tracker creation options
+// Welcome Page Tracker creation options
 export const welcomePageTrackerOpts = {
   infoHash: [preSeededTorrents[0].infoHash],
   announce: defaultTrackers,

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -37,9 +37,13 @@ export const fireBaseConfig =
 export const AUTO_FUND_LEDGER = process.env.REACT_APP_AUTO_FUND_LEDGER;
 
 // Tracker URLs
-const protocol = process.env.REACT_APP_TRACKER_URL_HTTP_PROTOCOL;
+const suffix = process.env.REACT_APP_TRACKER_URL_HTTP_PROTOCOL === 'https' ? 's' : '';
 const url = process.env.REACT_APP_TRACKER_URL;
-export const defaultTrackers = [`${protocol}://${url}/announce`, `udp://${url}`, `ws://${url}`];
+export const defaultTrackers = [
+  `http${suffix}://${url}/announce`,
+  `udp://${url}`,
+  `ws${suffix}://${url}`
+];
 
 // Default Torrent Data
 export const EmptyTorrent = ({

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -36,21 +36,12 @@ export const fireBaseConfig =
       };
 export const AUTO_FUND_LEDGER = process.env.REACT_APP_AUTO_FUND_LEDGER;
 
-const httpProtocol = process.env.REACT_APP_TRACKER_URL_HTTP_PROTOCOL;
+// Tracker URLs
+const protocol = process.env.REACT_APP_TRACKER_URL_HTTP_PROTOCOL;
 const url = process.env.REACT_APP_TRACKER_URL;
-export const defaultTrackers = [
-  // 'udp://explodie.org:6969',
-  // 'udp://tracker.coppersurfer.tk:6969',
-  // 'udp://tracker.empire-js.us:1337',
-  // 'udp://tracker.leechers-paradise.org:6969',
-  // 'udp://tracker.opentrackr.org:1337',
-  // 'wss://tracker.btorrent.xyz',
-  // 'wss://tracker.openwebtorrent.com'
-  `${httpProtocol}://${url}/announce`,
-  `udp://${url}`,
-  `ws://${url}`
-];
+export const defaultTrackers = [`${protocol}://${url}/announce`, `udp://${url}`, `ws://${url}`];
 
+// Default Torrent Data
 export const EmptyTorrent = ({
   name: 'unknown',
   magnetURI: '',
@@ -77,6 +68,15 @@ export const preSeededTorrents: Array<Partial<Torrent>> = [
       'magnet:?xt=urn%3Abtih%3Ac53da4fa28aa2edc1faa91861cce38527414d874&dn=Sintel.mp4&xl=129241752'
   }
 ];
+
+// Welcoe Page Tracker creation options
+export const welcomePageTrackerOpts = {
+  infoHash: [preSeededTorrents[0].infoHash],
+  announce: defaultTrackers,
+  peerId: '2d5757303030372d37454e613073307937495630', // random
+  port: 6881,
+  getAnnounceOpts: () => ({pseAccount: '0x7F0126D6c4270498b6514Cb934a3274898f68777'}) // dummy pseAccount, but it works
+};
 
 export const testTorrent = {
   name: 'Big Buck Bunny',

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -8,7 +8,8 @@ export enum ClientEvents {
   CLIENT_RESET = 'client_reset',
   TORRENT_DONE = 'torrent_done',
   TORRENT_ERROR = 'torrent_error',
-  TORRENT_NOTICE = 'torrent_notice'
+  TORRENT_NOTICE = 'torrent_notice',
+  CLIENT_CAPABILITY_TEST = 'client_capability_test'
 }
 
 export enum TorrentEvents {
@@ -44,6 +45,12 @@ export type PaidStreamingExtendedHandshake = {
   pseAccount: string;
   outcomeAddress: string;
 };
+
+export enum TorrentClientCapabilities {
+  CAPABLE = 'CAPABLE',
+  NOT_CAPABLE = 'NOT_CAPABLE',
+  NOT_TESTED = 'NOT_TESTED'
+}
 
 export type PaidStreamingWire = Omit<Wire, 'requests'> &
   {
@@ -182,6 +189,11 @@ declare module 'webtorrent' {
         command: PaidStreamingExtensionNotices;
         data: any;
       }) => void
+    ): this;
+
+    on(
+      event: ClientEvents.CLIENT_CAPABILITY_TEST,
+      callback: (status: TorrentClientCapabilities) => void
     ): this;
   }
 

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -12,7 +12,8 @@ import {
   TorrentEvents,
   WebTorrentAddInput,
   WebTorrentSeedInput,
-  WireEvents
+  WireEvents,
+  TorrentClientCapabilities
 } from './types';
 import {utils} from 'ethers';
 import {ChannelState, PaymentChannelClient} from '../clients/payment-channel-client';
@@ -44,12 +45,15 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
   pseAccount: string;
   outcomeAddress: string;
 
+  clientCapability: TorrentClientCapabilities = TorrentClientCapabilities.NOT_TESTED;
+
   constructor(opts: WebTorrent.Options & Partial<PaidStreamingExtensionOptions> = {}) {
     super(opts);
     this.peersList = {};
     this.pseAccount = opts.pseAccount;
     this.paymentChannelClient = opts.paymentChannelClient;
     this.outcomeAddress = opts.outcomeAddress;
+    if (process.env.NODE_ENV !== 'test') this.testTorrentingCapability();
   }
 
   async enable() {
@@ -69,7 +73,8 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     this.outcomeAddress = null;
   }
 
-  async testTorrentingCapability(timeOut: number) {
+  async testTorrentingCapability(timeOut: number = 3000): Promise<void> {
+    this.emit(ClientEvents.CLIENT_CAPABILITY_TEST, this.clientCapability);
     log('Testing torrenting capability...');
     let torrentId;
     const gotAWire = new Promise(resolve => {
@@ -83,9 +88,13 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     });
     const raceResult = await Promise.race([gotAWire, timer]);
     if (torrentId) {
-      this.remove(torrentId);
+      super.remove(torrentId);
     }
-    return raceResult;
+    this.clientCapability = raceResult
+      ? TorrentClientCapabilities.CAPABLE
+      : TorrentClientCapabilities.NOT_CAPABLE;
+
+    this.emit(ClientEvents.CLIENT_CAPABILITY_TEST, this.clientCapability);
   }
 
   seed(

--- a/packages/web3torrent/src/pages/upload/Upload.tsx
+++ b/packages/web3torrent/src/pages/upload/Upload.tsx
@@ -5,12 +5,7 @@ import {generateMagnetURL} from '../../utils/magnet';
 import './Upload.scss';
 import {Spinner} from '../../components/form/spinner/Spinner';
 
-interface Props {
-  ready: boolean;
-}
-
-const Upload: React.FC<RouteComponentProps & Props> = props => {
-  const {history} = props;
+const Upload: React.FC<RouteComponentProps & {ready: boolean}> = ({history, ready}) => {
   const [showSpinner, setSpinner] = useState<boolean>(false);
 
   return (
@@ -25,7 +20,7 @@ const Upload: React.FC<RouteComponentProps & Props> = props => {
           name="file"
           id="file"
           multiple={true}
-          disabled={!props.ready}
+          disabled={!ready}
           className="inputfile"
           onChange={async event => {
             if (event.target.files && event.target.files[0]) {

--- a/packages/web3torrent/src/pages/welcome/Welcome.tsx
+++ b/packages/web3torrent/src/pages/welcome/Welcome.tsx
@@ -3,22 +3,12 @@ import React from 'react';
 import {RouteComponentProps} from 'react-router-dom';
 import {FormButton} from '../../components/form';
 import {ShareList} from '../../components/share-list/ShareList';
-import {preSeededTorrents, defaultTrackers} from '../../constants';
+import {preSeededTorrents, welcomePageTrackerOpts} from '../../constants';
 import {RoutePath} from '../../routes';
 import './Welcome.scss';
 import {Client} from 'bittorrent-tracker';
 
 const log = debug('web3torrent:welcome-page-tracker-client');
-
-const requiredOpts = {
-  infoHash: ['c53da4fa28aa2edc1faa91861cce38527414d874'], // Sintel.mp4 concentrate on this torrent for now
-  peerId: '2d5757303030372d37454e613073307937495630', // hex string or Buffer
-  announce: defaultTrackers, // list of tracker server urls,
-  port: 6881 // torrent client port, (in browser, optional)
-};
-const optionalOpts = {
-  getAnnounceOpts: () => ({pseAccount: '0x7F0126D6c4270498b6514Cb934a3274898f68777'}) // dummy pseAccount, but it works
-};
 
 interface Props {
   ready: boolean;
@@ -26,21 +16,21 @@ interface Props {
 
 class Welcome extends React.Component<RouteComponentProps & Props, {[infoHash: string]: boolean}> {
   trackerClient: Client; // bittorrent tracker client
-  state = {c53da4fa28aa2edc1faa91861cce38527414d874: false}; // do not display by default
+  state = {[preSeededTorrents[0].infoHash]: false}; // do not display by default
 
   updateIfSeederFound(data: any) {
-    log('got an announce response from tracker: ' + data.announce);
+    log('got an announce response from tracker: ', data);
     if (data.complete > 0) {
       // there are some seeders for this torrent
-      this.setState({[requiredOpts.infoHash[0]]: true});
+      this.setState({[preSeededTorrents[0].infoHash]: true});
       // this torrent should be displayed
-      log(`Seeder found for ${requiredOpts.infoHash[0]}`);
+      log(`Seeder found for ${preSeededTorrents[0].infoHash}`);
     }
   }
 
   constructor(props) {
     super(props);
-    this.trackerClient = new Client({...requiredOpts, ...optionalOpts});
+    this.trackerClient = new Client(welcomePageTrackerOpts);
     this.updateIfSeederFound = this.updateIfSeederFound.bind(this);
     this.trackerClient.on('update', this.updateIfSeederFound);
     this.trackerClient.start();


### PR DESCRIPTION
This PR
- adds support for secure WebSocket connections to the tracker (_wss_).
- moves the Web3TorrentClient network capability testing to the Web3TorrentClient constructor, but only for non-testing environments as this causes problems with tests.
- refactors the app component, and the welcome and upload pages.
- un-skips all the unit tests that were being skipped, and removes non-representative tests.