### PR TITLE
(Mostly) budget-related fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
       - image: circleci/node:10.16.3
     environment:
       FIREBASE_PREFIX: << pipeline.git.branch >>-1
-      USE_VIRTUAL_FUNDING: 'FALSE'
+      REACT_APP_FUNDING_STRATEGY: Direct
       USE_GANACHE_DEPLOYMENT_CACHE: true
       GANACHE_CACHE_FOLDER: ../../.ganache-deployments
       GANACHE_PORT: 8547

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -186,7 +186,7 @@ export function logTransition(
   id?: string,
   logger = console
 ): void {
-  const to = JSON.stringify(state.value);
+  const to = JSON.stringify(state.value, null, 2);
   if (!state.history) {
     logger.log(`${id || ''} - STARTED ${state.configuration[0].id} TRANSITIONED TO ${to}`);
   } else {

--- a/packages/xstate-wallet/src/integration-tests/funding.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/funding.test.ts
@@ -70,4 +70,9 @@ it('allows for two wallets to fund an app', async () => {
         .toPromise()
     )
   );
+
+  [playerA, playerB].map(async player => {
+    const entry = await player.store.getEntry(channelId);
+    expect(entry.applicationSite).toEqual('localhost');
+  });
 });

--- a/packages/xstate-wallet/src/serde/wire-format/serialize.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/serialize.ts
@@ -24,14 +24,19 @@ function bigNumberToUint256(bigNumber: BigNumber): string {
 }
 
 export function serializeState(state: SignedState): SignedStateWire {
+  const {appData, appDefinition, isFinal, chainId, participants} = state;
   return {
-    ...state,
     challengeDuration: bigNumberToUint256(state.challengeDuration),
     channelNonce: bigNumberToUint256(state.channelNonce),
     turnNum: bigNumberToUint256(state.turnNum),
     outcome: serializeOutcome(state.outcome),
     channelId: calculateChannelId(state),
-    signatures: state.signatures.map(s => s.signature)
+    signatures: state.signatures.map(s => s.signature),
+    appData,
+    appDefinition,
+    isFinal,
+    chainId,
+    participants
   };
 }
 

--- a/packages/xstate-wallet/src/store/channel-store-entry.ts
+++ b/packages/xstate-wallet/src/store/channel-store-entry.ts
@@ -158,7 +158,7 @@ export class ChannelStoreEntry {
     };
   }
 
-  addState(stateVars: StateVariables, signatureEntry: SignatureEntry) {
+  addState(stateVars: StateVariables, signatureEntry: SignatureEntry): SignedState {
     const state = {...stateVars, ...this.channelConstants};
     const stateHash = hashState(state);
     // TODO: This check could be more efficient
@@ -180,6 +180,12 @@ export class ChannelStoreEntry {
     this.signatures[stateHash] = signatures;
 
     this.clearOldStates();
+
+    return this.state({...stateVars, signatures});
+  }
+
+  private state(stateVars: SignedStateVariables): SignedState {
+    return {...this.channelConstants, ...stateVars};
   }
 
   private clearOldStates() {

--- a/packages/xstate-wallet/src/store/channel-store-entry.ts
+++ b/packages/xstate-wallet/src/store/channel-store-entry.ts
@@ -177,7 +177,7 @@ export class ChannelStoreEntry {
       throw new Error('State not signed by a participant of this channel');
     }
 
-    entry.signatures.push(signatureEntry);
+    entry.signatures = _.uniq(_.concat(entry.signatures, signatureEntry));
 
     this.clearOldStates();
 

--- a/packages/xstate-wallet/src/store/index.ts
+++ b/packages/xstate-wallet/src/store/index.ts
@@ -57,6 +57,7 @@ export enum Errors {
   noAssetBudget = "This site's budget does contain this asset",
   channelNotInBudget = "This site's budget does not reference this channel",
   noSiteForChannel = 'No site defined for channel',
+  siteExistsOnChannel = 'Channel already has a site.',
   budgetAlreadyExists = 'There already exists a budget for this site',
   budgetInsufficient = 'Budget insufficient to reserve funds',
   amountUnauthorized = 'Amount unauthorized in current budget',

--- a/packages/xstate-wallet/src/store/index.ts
+++ b/packages/xstate-wallet/src/store/index.ts
@@ -53,7 +53,9 @@ export function isGuarantees(funding): funding is Guarantees {
 }
 export enum Errors {
   channelLocked = 'Channel is locked',
-  noBudget = 'No budget exists for this site',
+  noBudget = 'No budget exists for site. ',
+  noAssetBudget = "This site's budget does contain this asset",
+  channelNotInBudget = "This site's budget does not reference this channel",
   noSiteForChannel = 'No site defined for channel',
   budgetAlreadyExists = 'There already exists a budget for this site',
   budgetInsufficient = 'Budget insufficient to reserve funds',

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -275,7 +275,7 @@ export class XstateStore implements Store {
   public async setApplicationSite(channelId: string, applicationSite: string) {
     const entry = await this.getEntry(channelId);
 
-    if (entry.applicationSite) throw new Error(Errors.noSiteForChannel);
+    if (entry.applicationSite) throw new Error(Errors.siteExistsOnChannel);
 
     await this.backend.setChannel(channelId, {...entry.data(), applicationSite});
   }

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -436,9 +436,8 @@ export class XstateStore implements Store {
 
   public async releaseFunds(assetHolderAddress: string, channelId: string) {
     const {applicationSite} = await this.getEntry(channelId);
-    if (!applicationSite) {
-      throw new Error(Errors.noSiteForChannel);
-    }
+    if (typeof applicationSite !== 'string') throw new Error(Errors.noSiteForChannel);
+
     return await this.budgetLock.acquire<SiteBudget>(applicationSite, async release => {
       const currentBudget = await this.getBudget(applicationSite);
       const assetBudget = currentBudget?.forAsset[assetHolderAddress];
@@ -478,7 +477,7 @@ export class XstateStore implements Store {
   ): Promise<SiteBudget> {
     const entry = await this.getEntry(channelId);
     const site = entry.applicationSite;
-    if (!site) throw new Error(Errors.noSiteForChannel);
+    if (typeof site !== 'string') throw new Error(Errors.noSiteForChannel);
 
     return await this.budgetLock
       .acquire<SiteBudget>(site, async release => {

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -275,7 +275,7 @@ export class XstateStore implements Store {
   public async setApplicationSite(channelId: string, applicationSite: string) {
     const entry = await this.getEntry(channelId);
 
-    if (entry.applicationSite) throw new Error(Errors.siteExistsOnChannel);
+    if (typeof entry.applicationSite === 'string') throw new Error(Errors.siteExistsOnChannel);
 
     await this.backend.setChannel(channelId, {...entry.data(), applicationSite});
   }

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -477,7 +477,7 @@ export class XstateStore implements Store {
   ): Promise<SiteBudget> {
     const entry = await this.getEntry(channelId);
     const site = entry.applicationSite;
-    if (typeof site !== 'string') throw new Error(Errors.noSiteForChannel);
+    if (typeof site !== 'string') throw new Error(Errors.noSiteForChannel + ' ' + channelId);
 
     return await this.budgetLock
       .acquire<SiteBudget>(site, async release => {

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -205,7 +205,6 @@ export class XstateStore implements Store {
     const data: ChannelStoredData = {
       channelConstants: state,
       stateVariables: [{...state, stateHash: hashState(state), signatures: []}],
-      signatures: {},
       myIndex,
       funding: undefined,
       applicationSite

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -204,7 +204,7 @@ export class XstateStore implements Store {
 
     const data: ChannelStoredData = {
       channelConstants: state,
-      stateVariables: [{...state, stateHash: hashState(state)}],
+      stateVariables: [{...state, stateHash: hashState(state), signatures: []}],
       signatures: {},
       myIndex,
       funding: undefined,

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -101,6 +101,7 @@ export interface Store {
   getLedger(peerId: string): Promise<ChannelStoreEntry>;
 
   setFunding(channelId: string, funding: Funding): Promise<void>;
+  setApplicationSite(channelId: string, applicationSite: string): Promise<void>;
   addObjective(objective: Objective): void;
   getBudget: (site: string) => Promise<SiteBudget>;
   createBudget: (budget: SiteBudget) => Promise<void>;
@@ -269,6 +270,14 @@ export class XstateStore implements Store {
     if (!ledgerId) throw new Error(`No ledger exists with peer ${peerId}`);
 
     return await this.getEntry(ledgerId);
+  }
+
+  public async setApplicationSite(channelId: string, applicationSite: string) {
+    const entry = await this.getEntry(channelId);
+
+    if (entry.applicationSite) throw new Error(Errors.noSiteForChannel);
+
+    await this.backend.setChannel(channelId, {...entry.data(), applicationSite});
   }
 
   public async setLedger(ledgerId: string) {

--- a/packages/xstate-wallet/src/store/types.ts
+++ b/packages/xstate-wallet/src/store/types.ts
@@ -77,9 +77,11 @@ interface Signed {
 interface Hashed {
   stateHash: string;
 }
-export interface SignedState extends State, Signed {}
+export type SignedState = State & Signed;
 export type SignedStateWithHash = SignedState & Hashed;
-export interface SignedStateVariables extends StateVariables, Signed {}
+
+export type SignedStateVariables = StateVariables & Signed;
+export type SignedStateVarsWithHash = SignedStateVariables & Hashed;
 
 type _Objective<Name, Data> = {
   participants: Participant[];
@@ -141,7 +143,6 @@ export type ChannelStoredData = {
     challengeDuration: BigNumber | string; // TODO: This probably shouldn't be a BigNumber
     channelNonce: BigNumber | string;
   };
-  signatures: Record<string, any>; // FIXME
   funding: Funding | undefined;
   applicationSite: string | undefined;
   myIndex: number;

--- a/packages/xstate-wallet/src/store/types.ts
+++ b/packages/xstate-wallet/src/store/types.ts
@@ -138,7 +138,7 @@ export interface Message {
 export type ChannelStoredData = {
   stateVariables: Array<SignedStateWithHash>;
   channelConstants: Omit<ChannelConstants, 'challengeDuration' | 'channelNonce'> & {
-    challengeDuration: BigNumber | string;
+    challengeDuration: BigNumber | string; // TODO: This probably shouldn't be a BigNumber
     channelNonce: BigNumber | string;
   };
   signatures: Record<string, any>; // FIXME

--- a/packages/xstate-wallet/src/store/types.ts
+++ b/packages/xstate-wallet/src/store/types.ts
@@ -136,12 +136,12 @@ export interface Message {
 }
 
 export type ChannelStoredData = {
-  stateVariables: Array<StateVariablesWithHash>;
+  stateVariables: Array<SignedStateWithHash>;
   channelConstants: Omit<ChannelConstants, 'challengeDuration' | 'channelNonce'> & {
     challengeDuration: BigNumber | string;
     channelNonce: BigNumber | string;
   };
-  signatures: Record<string, Array<SignatureEntry>>;
+  signatures: Record<string, any>; // FIXME
   funding: Funding | undefined;
   applicationSite: string | undefined;
   myIndex: number;

--- a/packages/xstate-wallet/src/ui/confirm-create-channel-workflow.tsx
+++ b/packages/xstate-wallet/src/ui/confirm-create-channel-workflow.tsx
@@ -17,7 +17,7 @@ export const ConfirmCreateChannel = (props: Props) => {
       <Button.Text onClick={() => send('USER_REJECTS')}>No</Button.Text>
     </div>
   );
-  if (current.value.toString() === 'waitForUserConfirmation') {
+  if (current?.value.toString() === 'waitForUserConfirmation') {
     return prompt;
   } else {
     return <div></div>;

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -329,7 +329,6 @@ export const workflow = (
       return channelId;
     },
     invokeClosingProtocol: (context: ChannelIdExists) =>
-      // TODO: Close machine needs to accept new store
       ConcludeChannel.machine(store).withContext({channelId: context.channelId}),
     invokeCreateChannelAndFundProtocol: (_, event: DoneInvokeEvent<CreateAndFund.Init>) =>
       CreateAndFund.machine(store, event.data),

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -339,8 +339,7 @@ export const workflow = (
     },
     invokeClosingProtocol: (context: ChannelIdExists) =>
       ConcludeChannel.machine(store).withContext({channelId: context.channelId}),
-    invokeCreateChannelAndFundProtocol: (_, event: DoneInvokeEvent<CreateAndFund.Init>) =>
-      CreateAndFund.machine(store, event.data),
+    invokeCreateChannelAndFundProtocol: CreateAndFund.machine(store),
     invokeCreateChannelConfirmation: CCC.workflow({})
   };
 

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -88,10 +88,7 @@ export type WorkflowServices = {
   invokeClosingProtocol: (
     context: ChannelIdExists
   ) => StateMachine<ConcludeChannel.Init, any, any, any>;
-  invokeCreateChannelAndFundProtocol: (
-    context,
-    event: DoneInvokeEvent<CreateAndFund.Init>
-  ) => StateMachine<any, any, any, any>;
+  invokeCreateChannelAndFundProtocol: StateMachine<any, any, any, any>;
   invokeCreateChannelConfirmation: CCC.WorkflowMachine;
 };
 interface WorkflowStateSchema extends StateSchema<WorkflowContext> {

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -320,7 +320,7 @@ export const workflow = (
         turnNum: bigNumberify(0),
         isFinal: false
       };
-      const {channelId} = await store.createChannel(
+      const {channelId: targetChannelId} = await store.createChannel(
         participants,
         bigNumberify(challengeDuration),
         stateVars,
@@ -331,10 +331,10 @@ export const workflow = (
       // Create a open channel objective so we can coordinate with all participants
       await store.addObjective({
         type: 'OpenChannel',
-        data: {targetChannelId: channelId, fundingStrategy},
-        participants
+        data: {targetChannelId, fundingStrategy},
+        participants: [participants[1]]
       });
-      return channelId;
+      return targetChannelId;
     },
     invokeClosingProtocol: (context: ChannelIdExists) =>
       ConcludeChannel.machine(store).withContext({channelId: context.channelId}),

--- a/packages/xstate-wallet/src/workflows/create-and-fund.ts
+++ b/packages/xstate-wallet/src/workflows/create-and-fund.ts
@@ -12,7 +12,6 @@ import _ from 'lodash';
 import {isVirtuallyFund, StateVariables, Outcome} from '../store/types';
 
 import {
-  MachineFactory,
   add,
   isSimpleEthAllocation,
   simpleEthAllocation,
@@ -174,8 +173,7 @@ const options = (store: Store) => ({
   }
 });
 
-export const machine: MachineFactory<Init, any> = (store: Store, init: Init) =>
-  Machine(config).withConfig(options(store), init);
+export const machine = (store: Store) => Machine(config).withConfig(options(store));
 
 const getObjective = (store: Store) => (ctx: Init): Promise<VirtualFundingAsLeaf.Init> =>
   store.objectiveFeed

--- a/packages/xstate-wallet/src/workflows/tests/application.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/application.test.ts
@@ -122,6 +122,7 @@ describe('Channel setup, JOIN_CHANNEL role', () => {
     service.send(joinEvent);
     expect(spy).toHaveBeenCalledTimes(2);
     expect(spy).toHaveBeenCalledWith(context, joinEvent, expect.any(Object));
+    expect(spy).toHaveBeenCalledWith(expectations.siteSet);
 
     // It invokes confirmingWithUser
     await waitForExpect(async () => {
@@ -131,8 +132,7 @@ describe('Channel setup, JOIN_CHANNEL role', () => {
     service.state.children.invokeCreateChannelConfirmation.send({type: 'USER_APPROVES'});
 
     expect(spy).toHaveBeenCalledTimes(3);
-    expect(spy).toHaveBeenLastCalledWith(expectations.channelFunded);
-    expect(spy).toHaveBeenLastCalledWith(expectations.siteSet);
+    expect(spy).toHaveBeenCalledWith(expectations.channelFunded);
     await waitForExpect(() => expect(service.state.value).toEqual('running'));
   });
 });

--- a/packages/xstate-wallet/src/workflows/tests/application.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/application.test.ts
@@ -90,12 +90,17 @@ describe('Channel setup, JOIN_CHANNEL role', () => {
 
     const spy = jest.fn(x => x);
 
+    const enum expectations {
+      channelFunded = 'Channel was funded',
+      siteSet = 'applicationSite was set'
+    }
     const service = interpret<any, any, any>(
       Application.workflow(store, messagingService, context).withConfig({
         actions: {sendJoinChannelResponse: spy, sendUpdateChannelResponse: spy},
         services: {
           invokeCreateChannelAndFundProtocol: () =>
-            new Promise(resolve => spy('Channel was funded') && resolve())
+            new Promise(resolve => spy(expectations.channelFunded) && resolve()),
+          setApplicationSite: () => new Promise(resolve => spy(expectations.siteSet) && resolve())
         }
       })
     );
@@ -115,8 +120,8 @@ describe('Channel setup, JOIN_CHANNEL role', () => {
     };
 
     service.send(joinEvent);
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenLastCalledWith(context, joinEvent, expect.any(Object));
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledWith(context, joinEvent, expect.any(Object));
 
     // It invokes confirmingWithUser
     await waitForExpect(async () => {
@@ -125,8 +130,9 @@ describe('Channel setup, JOIN_CHANNEL role', () => {
 
     service.state.children.invokeCreateChannelConfirmation.send({type: 'USER_APPROVES'});
 
-    expect(spy).toHaveBeenCalledTimes(2);
-    expect(spy).toHaveBeenLastCalledWith('Channel was funded');
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy).toHaveBeenLastCalledWith(expectations.channelFunded);
+    expect(spy).toHaveBeenLastCalledWith(expectations.siteSet);
     await waitForExpect(() => expect(service.state.value).toEqual('running'));
   });
 });

--- a/packages/xstate-wallet/src/workflows/tests/store.ts
+++ b/packages/xstate-wallet/src/workflows/tests/store.ts
@@ -26,7 +26,6 @@ export class TestStore extends XstateStore implements Store {
       channelConstants: signedState,
       myIndex,
       stateVariables: [{...signedState, stateHash}],
-      signatures: {[stateHash]: signedState.signatures},
       funding,
       applicationSite
     });


### PR DESCRIPTION
With these changes, I was able to virtually fund a web3torrent channel:

```
$ state-channels-monorepo
❯ yarn start:shared-ganache

$ xstate-wallet
❯ CLEAR_STORAGE_ON_START=true USE_INDEXED_DB=true  ADD_LOGS=true yarn start

$ simple-hub
❯ FIREBASE_PREFIX=web3t-andrew  NODE_ENV=development yarn hub:watch

$ web3-torrent
❯ REACT_APP_FIREBASE_PREFIX=web3t-andrew REACT_APP_AUTO_FUND_LEDGER=true yarn start
```

TODO:
`CLEAR_STORAGE_ON_START=true` and `REACT_APP_AUTO_FUND_LEDGER=true` seem to be necessary because on reload, the chain does not fetch the data from the adjudicator's current state.