### PR TITLE
Add simple valid transition check in support

### DIFF
--- a/packages/xstate-wallet/src/store/channel-store-entry.ts
+++ b/packages/xstate-wallet/src/store/channel-store-entry.ts
@@ -84,12 +84,27 @@ export class ChannelStoreEntry {
     return this._support.map(s => ({...s, ...this.channelConstants}));
   }
 
-  private get _support(): Array<SignedStateWithHash> {
-    const support: Array<SignedStateWithHash> = [];
+  // This is a simple check
+  private validChain(firstState: SignedState, secondState: SignedState): boolean {
+    return (
+      firstState.turnNum.add(1).eq(secondState.turnNum) &&
+      (firstState.isFinal === secondState.isFinal || secondState.isFinal)
+    );
+  }
 
-    const participantsWhoHaveNotSigned = new Set(this.participants.map(p => p.signingAddress));
+  private get _support(): Array<SignedStateWithHash> {
+    let support: Array<SignedStateWithHash> = [];
+
+    let participantsWhoHaveNotSigned = new Set(this.participants.map(p => p.signingAddress));
+    let previousState;
 
     for (const signedState of this.signedStates.reverse()) {
+      // If there is not a valid transition we know there cannot be a valid support
+      // so we clear out what we have and start at the current signed state
+      if (previousState && !this.validChain(signedState, previousState)) {
+        support = [];
+        participantsWhoHaveNotSigned = new Set(this.participants.map(p => p.signingAddress));
+      }
       const moverIndex = signedState.turnNum.mod(this.nParticipants()).toNumber();
       const moverForThisTurn = this.participants[moverIndex].signingAddress;
 
@@ -104,6 +119,7 @@ export class ChannelStoreEntry {
           }
         }
       }
+      previousState = signedState;
     }
     return [];
   }

--- a/packages/xstate-wallet/src/store/tests/channel-store-entry.test.ts
+++ b/packages/xstate-wallet/src/store/tests/channel-store-entry.test.ts
@@ -1,0 +1,91 @@
+import {ChannelStoreEntry} from '../channel-store-entry';
+import {ChannelStoredData} from '../types';
+import {appState, wallet1, wallet2} from '../../workflows/tests/data';
+import {hashState, createSignatureEntry} from '../state-utils';
+
+describe('isSupported', () => {
+  it('returns false when there is an invalid transition due to turnnum', () => {
+    const firstSupportState = {...appState(0), stateHash: hashState(appState(0))};
+    const secondSupportState = {...appState(3), stateHash: hashState(appState(3))};
+    const signatures = {
+      [firstSupportState.stateHash]: [createSignatureEntry(firstSupportState, wallet1.privateKey)],
+      [secondSupportState.stateHash]: [createSignatureEntry(firstSupportState, wallet2.privateKey)]
+    };
+    const channelStoreData: ChannelStoredData = {
+      stateVariables: [firstSupportState, secondSupportState],
+      channelConstants: firstSupportState,
+      myIndex: 0,
+      funding: undefined,
+      signatures,
+      applicationSite: 'localhost'
+    };
+    const entry = new ChannelStoreEntry(channelStoreData);
+    expect(entry.isSupported).toBe(false);
+  });
+
+  it('returns true when there a valid chain of signed states', () => {
+    const firstSupportState = {...appState(0), stateHash: hashState(appState(0))};
+    const secondSupportState = {...appState(1), stateHash: hashState(appState(1))};
+    const signatures = {
+      [firstSupportState.stateHash]: [createSignatureEntry(firstSupportState, wallet1.privateKey)],
+      [secondSupportState.stateHash]: [createSignatureEntry(secondSupportState, wallet2.privateKey)]
+    };
+    const channelStoreData: ChannelStoredData = {
+      stateVariables: [firstSupportState, secondSupportState],
+      channelConstants: firstSupportState,
+      myIndex: 0,
+      funding: undefined,
+      signatures,
+      applicationSite: 'localhost'
+    };
+    const entry = new ChannelStoreEntry(channelStoreData);
+    expect(entry.isSupported).toBe(true);
+  });
+
+  it('returns true when there a state signed by everyone', () => {
+    const supportState = {...appState(0), stateHash: hashState(appState(0))};
+
+    const signatures = {
+      [supportState.stateHash]: [
+        createSignatureEntry(supportState, wallet1.privateKey),
+        createSignatureEntry(supportState, wallet2.privateKey)
+      ]
+    };
+    const channelStoreData: ChannelStoredData = {
+      stateVariables: [supportState],
+      channelConstants: supportState,
+      myIndex: 0,
+      funding: undefined,
+      signatures,
+      applicationSite: 'localhost'
+    };
+    const entry = new ChannelStoreEntry(channelStoreData);
+    expect(entry.isSupported).toBe(true);
+  });
+
+  it('returns the correct support when there are unsupported states', () => {
+    const firstSupportState = {...appState(0), stateHash: hashState(appState(0))};
+    const secondSupportState = {...appState(1), stateHash: hashState(appState(1))};
+    const thirdUnsupportedState = {...appState(3), stateHash: hashState(appState(3))};
+    const signatures = {
+      [firstSupportState.stateHash]: [createSignatureEntry(firstSupportState, wallet1.privateKey)],
+      [secondSupportState.stateHash]: [
+        createSignatureEntry(secondSupportState, wallet2.privateKey)
+      ],
+      [thirdUnsupportedState.stateHash]: [
+        createSignatureEntry(thirdUnsupportedState, wallet1.privateKey)
+      ]
+    };
+    const channelStoreData: ChannelStoredData = {
+      stateVariables: [firstSupportState, secondSupportState, thirdUnsupportedState],
+      channelConstants: firstSupportState,
+      myIndex: 0,
+      funding: undefined,
+      signatures,
+      applicationSite: 'localhost'
+    };
+    const entry = new ChannelStoreEntry(channelStoreData);
+    expect(entry.isSupported).toBe(true);
+    expect(entry.supported).toMatchObject(secondSupportState);
+  });
+});


### PR DESCRIPTION
Fixes #1366

Adds a simplistic validTransition check when calculating the support and some basic tests.

We will probably want to replace this with a proper check at some point(#1186)