### PR TITLE
ChannelStoreData/Entry does not have a signatures field

### DIFF
--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -186,7 +186,7 @@ export function logTransition(
   id?: string,
   logger = console
 ): void {
-  const to = JSON.stringify(state.value);
+  const to = JSON.stringify(state.value, null, 2);
   if (!state.history) {
     logger.log(`${id || ''} - STARTED ${state.configuration[0].id} TRANSITIONED TO ${to}`);
   } else {

--- a/packages/xstate-wallet/src/serde/wire-format/serialize.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/serialize.ts
@@ -24,14 +24,19 @@ function bigNumberToUint256(bigNumber: BigNumber): string {
 }
 
 export function serializeState(state: SignedState): SignedStateWire {
+  const {appData, appDefinition, isFinal, chainId, participants} = state;
   return {
-    ...state,
     challengeDuration: bigNumberToUint256(state.challengeDuration),
     channelNonce: bigNumberToUint256(state.channelNonce),
     turnNum: bigNumberToUint256(state.turnNum),
     outcome: serializeOutcome(state.outcome),
     channelId: calculateChannelId(state),
-    signatures: state.signatures.map(s => s.signature)
+    signatures: state.signatures.map(s => s.signature),
+    appData,
+    appDefinition,
+    isFinal,
+    chainId,
+    participants
   };
 }
 

--- a/packages/xstate-wallet/src/store/channel-store-entry.ts
+++ b/packages/xstate-wallet/src/store/channel-store-entry.ts
@@ -158,7 +158,7 @@ export class ChannelStoreEntry {
     };
   }
 
-  addState(stateVars: StateVariables, signatureEntry: SignatureEntry) {
+  addState(stateVars: StateVariables, signatureEntry: SignatureEntry): SignedState {
     const state = {...stateVars, ...this.channelConstants};
     const stateHash = hashState(state);
     // TODO: This check could be more efficient
@@ -180,6 +180,12 @@ export class ChannelStoreEntry {
     this.signatures[stateHash] = signatures;
 
     this.clearOldStates();
+
+    return this.state({...stateVars, signatures});
+  }
+
+  private state(stateVars: SignedStateVariables): SignedState {
+    return {...this.channelConstants, ...stateVars};
   }
 
   private clearOldStates() {

--- a/packages/xstate-wallet/src/store/channel-store-entry.ts
+++ b/packages/xstate-wallet/src/store/channel-store-entry.ts
@@ -177,7 +177,7 @@ export class ChannelStoreEntry {
       throw new Error('State not signed by a participant of this channel');
     }
 
-    entry.signatures.push(signatureEntry);
+    entry.signatures = _.uniq(_.concat(entry.signatures, signatureEntry));
 
     this.clearOldStates();
 

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -205,7 +205,6 @@ export class XstateStore implements Store {
     const data: ChannelStoredData = {
       channelConstants: state,
       stateVariables: [{...state, stateHash: hashState(state), signatures: []}],
-      signatures: {},
       myIndex,
       funding: undefined,
       applicationSite

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -204,7 +204,7 @@ export class XstateStore implements Store {
 
     const data: ChannelStoredData = {
       channelConstants: state,
-      stateVariables: [{...state, stateHash: hashState(state)}],
+      stateVariables: [{...state, stateHash: hashState(state), signatures: []}],
       signatures: {},
       myIndex,
       funding: undefined,

--- a/packages/xstate-wallet/src/store/types.ts
+++ b/packages/xstate-wallet/src/store/types.ts
@@ -77,9 +77,11 @@ interface Signed {
 interface Hashed {
   stateHash: string;
 }
-export interface SignedState extends State, Signed {}
+export type SignedState = State & Signed;
 export type SignedStateWithHash = SignedState & Hashed;
-export interface SignedStateVariables extends StateVariables, Signed {}
+
+export type SignedStateVariables = StateVariables & Signed;
+export type SignedStateVarsWithHash = SignedStateVariables & Hashed;
 
 type _Objective<Name, Data> = {
   participants: Participant[];
@@ -141,7 +143,6 @@ export type ChannelStoredData = {
     challengeDuration: BigNumber | string; // TODO: This probably shouldn't be a BigNumber
     channelNonce: BigNumber | string;
   };
-  signatures: Record<string, any>; // FIXME
   funding: Funding | undefined;
   applicationSite: string | undefined;
   myIndex: number;

--- a/packages/xstate-wallet/src/store/types.ts
+++ b/packages/xstate-wallet/src/store/types.ts
@@ -138,7 +138,7 @@ export interface Message {
 export type ChannelStoredData = {
   stateVariables: Array<SignedStateWithHash>;
   channelConstants: Omit<ChannelConstants, 'challengeDuration' | 'channelNonce'> & {
-    challengeDuration: BigNumber | string;
+    challengeDuration: BigNumber | string; // TODO: This probably shouldn't be a BigNumber
     channelNonce: BigNumber | string;
   };
   signatures: Record<string, any>; // FIXME

--- a/packages/xstate-wallet/src/store/types.ts
+++ b/packages/xstate-wallet/src/store/types.ts
@@ -136,12 +136,12 @@ export interface Message {
 }
 
 export type ChannelStoredData = {
-  stateVariables: Array<StateVariablesWithHash>;
+  stateVariables: Array<SignedStateWithHash>;
   channelConstants: Omit<ChannelConstants, 'challengeDuration' | 'channelNonce'> & {
     challengeDuration: BigNumber | string;
     channelNonce: BigNumber | string;
   };
-  signatures: Record<string, Array<SignatureEntry>>;
+  signatures: Record<string, any>; // FIXME
   funding: Funding | undefined;
   applicationSite: string | undefined;
   myIndex: number;

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -329,7 +329,6 @@ export const workflow = (
       return channelId;
     },
     invokeClosingProtocol: (context: ChannelIdExists) =>
-      // TODO: Close machine needs to accept new store
       ConcludeChannel.machine(store).withContext({channelId: context.channelId}),
     invokeCreateChannelAndFundProtocol: (_, event: DoneInvokeEvent<CreateAndFund.Init>) =>
       CreateAndFund.machine(store, event.data),

--- a/packages/xstate-wallet/src/workflows/tests/store.ts
+++ b/packages/xstate-wallet/src/workflows/tests/store.ts
@@ -26,7 +26,6 @@ export class TestStore extends XstateStore implements Store {
       channelConstants: signedState,
       myIndex,
       stateVariables: [{...signedState, stateHash}],
-      signatures: {[stateHash]: signedState.signatures},
       funding,
       applicationSite
     });


### PR DESCRIPTION
Instead, the signatures are stored along with the state variables and the hash.

The type `T = Record<string, S>` type is dangerous, because if if I have a `signatureStore: T` variable, then the compiler will thin that `signatureStore['whatever random string I want']` has type `S`.

This happened to me, leading to a browser runtime error that could have been prevented by stronger typings.

Since we don't want to store signatures without the associated state variables anyway, we might as well store them with the state variables.

This resolves https://github.com/statechannels/monorepo/issues/1365