### PR TITLE
[W3T] Fix small torrents payments with big (>1) trust overpayment

### DIFF
--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -195,7 +195,11 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
         const knownPeerAccount = this.peersList[torrent.infoHash][peerAccount];
 
         if (!knownPeerAccount) {
-          log(`>> wire first_request of ${peerAccount} with outcomeAddress ${peerOutcomeAddress}`);
+          log(
+            `>> wire first_request of ${peerAccount} with outcomeAddress ${peerOutcomeAddress} and leecherBalance ${WEI_PER_BYTE.mul(
+              torrent.length
+            )}`
+          );
           const {channelId} = await this.paymentChannelClient.createChannel(
             this.pseAccount, // seeder
             peerAccount, // leecher
@@ -378,32 +382,35 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     const {peerChannelId, peerAccount} = wire.paidStreamingExtension;
     let amountToPay = BUFFER_REFILL_RATE.sub(
       WEI_PER_BYTE.mul(BLOCK_LENGTH).mul(PEER_TRUST - wire.requests.length)
-    ).toString();
-    log(`<< STOP ${peerAccount} - About to pay`, torrent, amountToPay);
+    );
 
     // On each wire, the algorithm tries to download the uneven piece (which is always the last piece)
-    if (torrent.downloaded === 0 && this.isLastPieceIsReservedToWire(torrent, peerAccount)) {
-      amountToPay = BUFFER_REFILL_RATE.sub(
-        WEI_PER_BYTE.mul(BLOCK_LENGTH - torrent.store.store.lastChunkLength)
-      ).toString();
-      log(`<< STOP ${peerAccount} - LAST PIECE`, amountToPay);
+    if (this.isAboutToPayForLastPiece(torrent, peerAccount)) {
+      const diffBetweenStandardSizeAndTheLastPieceSize = WEI_PER_BYTE.mul(
+        BLOCK_LENGTH - torrent.store.store.lastChunkLength
+      );
+      amountToPay = amountToPay.sub(diffBetweenStandardSizeAndTheLastPieceSize);
     }
-
-    await this.paymentChannelClient.makePayment(peerChannelId, amountToPay);
+    log(`<< STOP ${peerAccount} - About to pay ${amountToPay.toString()}`);
+    await this.paymentChannelClient.makePayment(peerChannelId, amountToPay.toString());
 
     const balance =
       this.paymentChannelClient.channelCache[peerChannelId] &&
-      this.paymentChannelClient.channelCache[peerChannelId].beneficiaryBalance;
+      bigNumberify(
+        this.paymentChannelClient.channelCache[peerChannelId].beneficiaryBalance
+      ).toString();
     log(`<< Payment - Peer ${peerAccount} Balance: ${balance} Downloaded ${wire.downloaded}`);
   }
 
-  private isLastPieceIsReservedToWire(torrent: PaidStreamingTorrent, peerAccount: string) {
+  private isAboutToPayForLastPiece(torrent: PaidStreamingTorrent, peerAccount: string) {
     const lastPieceReservations: PaidStreamingWire[] =
       torrent._reservations[torrent.pieces.length - 1];
     if (!lastPieceReservations || !lastPieceReservations.length) return false;
-    return lastPieceReservations.find(
+
+    const lastPieceIsReservedToThisWire = lastPieceReservations.some(
       wire => wire && wire.paidStreamingExtension.peerAccount === peerAccount
     );
+    return torrent.downloaded === 0 && lastPieceIsReservedToThisWire;
   }
   /**
    * Close any channels that I am downloading from (that my peer opened)


### PR DESCRIPTION
There was an issue where torrents having a size smaller than the number of requests in trust_ would get overpaid because an oversight that I made in the calculations of how much to pay.

Basically, I assumed erroneously that the initial amount of requests is always the máximum amount in trust, and I did not account for small torrents. So if I had, say, TRUST set to 4, a torrent of 30kb would pay for 4 requests minus the difference between the last piece size, and the standard request size.
This PR fixes that. And it also makes it clearer to read. And fixes a log message that for some reason was showing the balance in hexadecimal format.