### PR TITLE
simple-hub: do not crash out on errors

### DIFF
--- a/packages/simple-hub/manual-test/firebase-feeder.ts
+++ b/packages/simple-hub/manual-test/firebase-feeder.ts
@@ -1,12 +1,11 @@
+import '../env';
+
 import * as firebase from 'firebase';
-import {configureEnvVariables} from '@statechannels/devtools';
 import {cFirebasePrefix} from '../src/constants';
 import {Message} from '@statechannels/wire-format';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const messages: Array<Message> = require('./message-sequence2.json');
-
-configureEnvVariables(true);
 
 const config = {
   apiKey: process.env.FIREBASE_API_KEY,
@@ -34,7 +33,9 @@ async function sendMessage(message: Message) {
 }
 
 async function readAndFeedMessages() {
-  await Promise.all(messages.map(sendMessage));
+  await Promise.all(messages.map(sendMessage)).catch(reason => {
+    throw reason;
+  });
   getFirebaseApp().delete();
 }
 

--- a/packages/simple-hub/package.json
+++ b/packages/simple-hub/package.json
@@ -13,6 +13,7 @@
     "ethers": "4.0.45",
     "firebase": "7.11.0",
     "pino": "5.16.0",
+    "rxfire": "^3.11.2",
     "rxjs": "6.5.4"
   },
   "devDependencies": {

--- a/packages/simple-hub/src/message/firebase-relay.ts
+++ b/packages/simple-hub/src/message/firebase-relay.ts
@@ -5,7 +5,7 @@ import {cFirebasePrefix, cHubParticipantId} from '../constants';
 import {logger} from '../logger';
 import {Message as WireMessage} from '@statechannels/wire-format';
 import {map} from 'rxjs/operators';
-import {deserializeMessage, Message, serializeMessage} from '../wallet/xstate-wallet-internals';
+import {Message, serializeMessage} from '../wallet/xstate-wallet-internals';
 import * as _ from 'lodash/fp';
 import {notContainsHubParticipantId} from '../utils';
 
@@ -40,7 +40,7 @@ export function fbObservable() {
   return stateChanges(hubRef, [ListenEvent.added]).pipe(
     map(change => ({
       snapshotKey: change.snapshot.key,
-      message: deserializeMessage(change.snapshot.val())
+      messageObj: change.snapshot.val()
     }))
   );
 }

--- a/packages/simple-hub/src/server.ts
+++ b/packages/simple-hub/src/server.ts
@@ -14,6 +14,8 @@ import {map, tap, retryWhen} from 'rxjs/operators';
 import {logger} from './logger';
 import {depositsToMake} from './wallet/deposit';
 import {Blockchain} from './blockchain/eth-asset-holder';
+import {deserializeMessage} from './wallet/xstate-wallet-internals';
+import {validateMessage} from '@statechannels/wire-format';
 
 const log = logger();
 
@@ -21,6 +23,10 @@ export async function startServer() {
   fbObservable()
     .pipe(
       tap(({snapshotKey}) => deleteIncomingMessage(snapshotKey)),
+      map(({snapshotKey, messageObj}) => ({
+        snapshotKey,
+        message: deserializeMessage(validateMessage(messageObj))
+      })),
       map(({snapshotKey, message}) => ({
         snapshotKey,
         messageToSend: respondToMessage(message)

--- a/yarn.lock
+++ b/yarn.lock
@@ -29511,6 +29511,13 @@ rustbn.js@~0.2.0:
   resolved "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz#8082cb886e707155fd1cb6f23bd591ab8d55d0ca"
   integrity sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==
 
+rxfire@^3.11.2:
+  version "3.11.2"
+  resolved "https://registry.npmjs.org/rxfire/-/rxfire-3.11.2.tgz#1974005b0eff0c486bb472c4378c322ca18610e8"
+  integrity sha512-hWVL1It7GloqXbuRNNGTmzXdc5+pCfe09Bq3Ojn9D6yd+KYdNDf8gwttmwkb9fGajhHRpaTGTNOSQRYE24n29Q==
+  dependencies:
+    tslib "1.11.1"
+
 rxjs@6.5.4, rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.5.4:
   version "6.5.4"
   resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"


### PR DESCRIPTION
Fixes https://github.com/statechannels/monorepo/issues/1374 and removes the short-term fix of https://github.com/statechannels/monorepo/pull/1373.

[`respondToMessage`](https://github.com/statechannels/monorepo/blob/6ddd4e39affc104f982ee8848dfb97b33b458159/packages/simple-hub/src/server.ts#L26) and [`depositsToMake`](https://github.com/statechannels/monorepo/blob/6ddd4e39affc104f982ee8848dfb97b33b458159/packages/simple-hub/src/server.ts#L31) are pure functions that can throw errors. To address errors:
- delete the firebase entry as the first operation. If the firebase entry is not deleted, when `fbObservable` is re-subscribed (via `retryWhen` operator), the observable will emit the message that caused the error. This leads to an infinite loop.
- log error before re-subscribing to the fbObservable.