### PR TITLE
Generate at most one random private key

### DIFF
--- a/packages/xstate-wallet/src/index.ts
+++ b/packages/xstate-wallet/src/index.ts
@@ -1,5 +1,3 @@
-import {ethers} from 'ethers';
-
 import {ChannelWallet} from './channel-wallet';
 import {MessagingService} from './messaging';
 import {ChainWatcher} from './chain';
@@ -10,13 +8,12 @@ import * as constants from './constants';
 import Url from 'url-parse';
 
 (async function() {
-  const {privateKey} = ethers.Wallet.createRandom();
   const chain = new ChainWatcher();
 
   const backend = constants.USE_INDEXED_DB ? new IndexedDBBackend() : new MemoryBackend();
   const store = new XstateStore(chain, backend);
 
-  await store.initialize([privateKey], constants.CLEAR_STORAGE_ON_START);
+  await store.initialize([], constants.CLEAR_STORAGE_ON_START);
   const messagingService = new MessagingService(store);
   const channelWallet = new ChannelWallet(store, messagingService);
 

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -147,8 +147,8 @@ export class XstateStore implements Store {
         const wallet = new Wallet(key);
         await this.backend.setPrivateKey(wallet.address, wallet.privateKey);
       });
-    } else {
-      // generate a new key
+    } else if (!(await this.getAddress())) {
+      // generate the first private key
       const wallet = Wallet.createRandom();
       await this.backend.setPrivateKey(wallet.address, wallet.privateKey);
     }


### PR DESCRIPTION
We do not have any plans for how to manage multiple private keys. Limiting the number of stored private keys to one reduces the number of things that can (and are) going wrong.

This change, in particular, will mean that the wallet will use a consistent `participantId` across sessions. This invariant lets the wallet re-use a ledger channel from the indexedDB store from a previous session.