### PR TITLE
Add prefundsetup check to ledger funding

### DIFF
--- a/packages/xstate-wallet/src/serde/wire-format/serialize.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/serialize.ts
@@ -47,8 +47,7 @@ function serializeOutcome(outcome: Outcome): OutcomeWire {
     case 'MixedAllocation':
       return outcome.simpleAllocations.map(serializeSimpleAllocation);
     case 'SimpleGuarantee':
-      // TODO
-      return [];
+      throw 'TODO'; // TODO
   }
 }
 

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -246,6 +246,7 @@ export class XstateStore implements Store {
 
   public async releaseChannelLock(status: ChannelLock): Promise<void> {
     if (!status.lock) throw new Error('Invalid lock');
+
     const {channelId, lock} = status;
     const currentStatus = this._channelLocks[channelId];
     if (!currentStatus) return;

--- a/packages/xstate-wallet/src/workflows/tests/ledger-funding.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/ledger-funding.test.ts
@@ -76,12 +76,14 @@ beforeEach(async () => {
   bStore = new TestStore(chain);
   await bStore.initialize([wallet2.privateKey]);
 
-  [aStore, bStore].forEach(async (store: TestStore) => {
-    await store.createEntry(allSignState(firstState(outcome, targetChannel)));
-    await store.setLedgerByEntry(
-      await store.createEntry(allSignState(firstState(outcome, ledgerChannel)))
-    );
-  });
+  await Promise.all(
+    [aStore, bStore].map(async (store: TestStore) => {
+      await store.createEntry(allSignState(firstState(outcome, targetChannel)));
+      await store.setLedgerByEntry(
+        await store.createEntry(allSignState(firstState(outcome, ledgerChannel)))
+      );
+    })
+  );
 
   subscribeToMessages({
     [participants[0].participantId]: aStore,

--- a/packages/xstate-wallet/src/workflows/virtual-funding-as-leaf.ts
+++ b/packages/xstate-wallet/src/workflows/virtual-funding-as-leaf.ts
@@ -49,7 +49,7 @@ export type Init = {
 type Deductions = {deductions: AllocationItem[]};
 type WithDeductions = Init & Deductions;
 
-const getObjective = (store: Store) => async (ctx: Init): Promise<FundGuarantor> => {
+const getFundGuarantorObjective = (store: Store) => async (ctx: Init): Promise<FundGuarantor> => {
   const {jointChannelId, targetChannelId} = ctx;
   const entry = await store.getEntry(jointChannelId);
   const {participants: jointParticipants} = entry.channelConstants;
@@ -68,6 +68,8 @@ const getObjective = (store: Store) => async (ctx: Init): Promise<FundGuarantor>
       ...participants.map(p => p.destination)
     )
   });
+
+  // TODO: We never actually check that the guarantor channel's state is supported.
 
   return {
     type: 'FundGuarantor',
@@ -254,11 +256,11 @@ export const options = (
 
   const services: Record<Services, ServiceConfig<Init>> = {
     getDeductions: getDeductions(store),
-    supportState: SupportState.machine(store as any),
+    supportState: SupportState.machine(store),
     ledgerFunding: LedgerFunding.machine(store),
     waitForFirstJointState: waitForFirstJointState(store),
     jointChannelUpdate: jointChannelUpdate(store),
-    fundGuarantor: getObjective(store),
+    fundGuarantor: getFundGuarantorObjective(store),
     updateJointChannelFunding: updateJointChannelFunding(store)
   };
 


### PR DESCRIPTION
While working on virtual funding puppeteer tests with @snario, we found the reason why the simple-hub was not able to read messages: during serialization, guarantee outcomes are stripped: https://github.com/statechannels/monorepo/commit/7c6aeb79662cb5bc759b1b9ef78b12efbccf2b5b.

This lead me to realize that the virtual-funding workflows create the guarantor channels, then move to the next step before that channel has a supported "prefund setup" state.

This PR adds a defensive "checking target" state for validating the state of the target channel when ledger funding. (The virtual funding bug will be fixed in a later PR.)