### PR TITLE
Ledger safety + Virtual funding fix

### DIFF
--- a/packages/xstate-wallet/src/serde/wire-format/serialize.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/serialize.ts
@@ -47,7 +47,7 @@ function serializeOutcome(outcome: Outcome): OutcomeWire {
     case 'MixedAllocation':
       return outcome.simpleAllocations.map(serializeSimpleAllocation);
     case 'SimpleGuarantee':
-      throw 'TODO'; // TODO
+      return [outcome];
   }
 }
 

--- a/packages/xstate-wallet/src/serde/wire-format/serialize.ts
+++ b/packages/xstate-wallet/src/serde/wire-format/serialize.ts
@@ -47,8 +47,7 @@ function serializeOutcome(outcome: Outcome): OutcomeWire {
     case 'MixedAllocation':
       return outcome.simpleAllocations.map(serializeSimpleAllocation);
     case 'SimpleGuarantee':
-      // TODO
-      return [];
+      throw 'TODO'; // TODO
   }
 }
 

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -246,6 +246,7 @@ export class XstateStore implements Store {
 
   public async releaseChannelLock(status: ChannelLock): Promise<void> {
     if (!status.lock) throw new Error('Invalid lock');
+
     const {channelId, lock} = status;
     const currentStatus = this._channelLocks[channelId];
     if (!currentStatus) return;

--- a/packages/xstate-wallet/src/workflows/ledger-funding.ts
+++ b/packages/xstate-wallet/src/workflows/ledger-funding.ts
@@ -1,4 +1,6 @@
 import {Machine, MachineConfig, ServiceConfig, assign, DoneInvokeEvent} from 'xstate';
+import {filter, first, map} from 'rxjs/operators';
+import {ChannelLock} from '../store/store';
 
 import {SupportState} from '.';
 import {Store, Errors as StoreErrors, Funding} from '../store';
@@ -26,6 +28,7 @@ const enum Services {
   getTargetOutcome = 'getTargetOutcome',
   updateFunding = 'updateFunding',
   supportState = 'supportState',
+  checkTarget = 'checkTarget',
   acquireLock = 'acquireLock',
   releaseLock = 'releaseLock'
 }
@@ -33,7 +36,8 @@ const enum Services {
 export const enum Errors {
   underfunded = 'Ledger channel is underfunded',
   underallocated = 'Ledger channel is underallocated',
-  finalized = 'Ledger channel is finalized'
+  finalized = 'Ledger channel is finalized',
+  unSupportedTargetChannel = 'Target channel has no supported state: '
 }
 
 const FAILURE = `#${WORKFLOW}.failure`;
@@ -45,13 +49,21 @@ const fundingTarget = getDataAndInvoke(
   'releasingLock'
 );
 
+const checkTarget = (store: Store) => async (ctx: Init) => {
+  const {isSupported} = await store.getEntry(ctx.targetChannelId);
+  if (!isSupported) throw Error(Errors.unSupportedTargetChannel + ctx.targetChannelId);
+};
+
 export const config: MachineConfig<any, any, any> = {
   key: WORKFLOW,
   initial: 'acquiringLock',
   states: {
     acquiringLock: {
-      invoke: {src: Services.acquireLock, onDone: 'fundingTarget'},
+      invoke: {src: Services.acquireLock, onDone: 'checkingTarget'},
       exit: assign<WithLock>({lock: (_, event: DoneInvokeEvent<ChannelLock>) => event.data})
+    },
+    checkingTarget: {
+      invoke: {src: Services.checkTarget, onDone: 'fundingTarget', onError}
     },
     fundingTarget,
     failure: {
@@ -66,8 +78,6 @@ export const config: MachineConfig<any, any, any> = {
   }
 };
 
-import {filter, first, map} from 'rxjs/operators';
-import {ChannelLock} from '../store/store';
 const acquireLock = (store: Store) => async (ctx: Init): Promise<ChannelLock> => {
   try {
     return await store.acquireChannelLock(ctx.ledgerChannelId);
@@ -121,6 +131,7 @@ const updateFunding = (store: Store) => async ({targetChannelId, ledgerChannelId
 };
 
 const services = (store: Store): Record<Services, ServiceConfig<Init>> => ({
+  checkTarget: checkTarget(store),
   getTargetOutcome: getTargetOutcome(store),
   updateFunding: updateFunding(store),
   supportState: SupportState.machine(store),

--- a/packages/xstate-wallet/src/workflows/tests/ledger-funding.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/ledger-funding.test.ts
@@ -76,12 +76,14 @@ beforeEach(async () => {
   bStore = new TestStore(chain);
   await bStore.initialize([wallet2.privateKey]);
 
-  [aStore, bStore].forEach(async (store: TestStore) => {
-    await store.createEntry(allSignState(firstState(outcome, targetChannel)));
-    await store.setLedgerByEntry(
-      await store.createEntry(allSignState(firstState(outcome, ledgerChannel)))
-    );
-  });
+  await Promise.all(
+    [aStore, bStore].map(async (store: TestStore) => {
+      await store.createEntry(allSignState(firstState(outcome, targetChannel)));
+      await store.setLedgerByEntry(
+        await store.createEntry(allSignState(firstState(outcome, ledgerChannel)))
+      );
+    })
+  );
 
   subscribeToMessages({
     [participants[0].participantId]: aStore,

--- a/packages/xstate-wallet/src/workflows/tests/ledger-funding.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/ledger-funding.test.ts
@@ -4,7 +4,7 @@ import {add, checkThat, isSimpleEthAllocation} from '../../utils';
 
 import {Init, machine, Errors} from '../ledger-funding';
 
-import {Store} from '../../store';
+import {Store, SignedState} from '../../store';
 import {bigNumberify} from 'ethers/utils';
 import _ from 'lodash';
 import {firstState, calculateChannelId, createSignatureEntry} from '../../store/state-utils';
@@ -70,130 +70,173 @@ const allSignState = (state: State) => ({
   signatures: [wallet1, wallet2].map(({privateKey}) => createSignatureEntry(state, privateKey))
 });
 
-beforeEach(async () => {
-  aStore = new TestStore(chain);
-  await aStore.initialize([wallet1.privateKey]);
-  bStore = new TestStore(chain);
-  await bStore.initialize([wallet2.privateKey]);
+describe('success', () => {
+  beforeEach(async () => {
+    aStore = new TestStore(chain);
+    await aStore.initialize([wallet1.privateKey]);
+    bStore = new TestStore(chain);
+    await bStore.initialize([wallet2.privateKey]);
 
-  await Promise.all(
-    [aStore, bStore].map(async (store: TestStore) => {
-      await store.createEntry(allSignState(firstState(outcome, targetChannel)));
-      await store.setLedgerByEntry(
-        await store.createEntry(allSignState(firstState(outcome, ledgerChannel)))
-      );
-    })
-  );
-
-  subscribeToMessages({
-    [participants[0].participantId]: aStore,
-    [participants[1].participantId]: bStore
-  });
-});
-
-test('happy path', async () => {
-  const _chain = new FakeChain();
-  _chain.depositSync(ledgerChannelId, '0', amounts.reduce(add).toHexString());
-  [aStore, bStore].forEach((store: Store) => (store.chain = _chain));
-
-  const aService = interpret(machine(aStore).withContext(context));
-
-  const bService = interpret(machine(bStore).withContext(context));
-  [aService, bService].map(s => s.start());
-
-  await waitForExpect(async () => {
-    expect(bService.state.value).toEqual('success');
-    expect(aService.state.value).toEqual('success');
-
-    const {supported: supportedState} = await aStore.getEntry(ledgerChannelId);
-    const outcome = checkThat(supportedState.outcome, isSimpleEthAllocation);
-
-    expect(outcome.allocationItems).toMatchObject(
-      [0, 1]
-        .map(i => ({
-          destination: destinations[i],
-          amount: amounts[i].sub(deductionAmounts[i])
-        }))
-        .concat([{destination: targetChannelId as any, amount: deductionAmounts.reduce(add)}])
+    await Promise.all(
+      [aStore, bStore].map(async (store: TestStore) => {
+        await store.createEntry(allSignState(firstState(outcome, targetChannel)));
+        await store.setLedgerByEntry(
+          await store.createEntry(allSignState(firstState(outcome, ledgerChannel)))
+        );
+      })
     );
 
-    expect((await aStore.getEntry(targetChannelId)).funding).toMatchObject({
-      type: 'Indirect',
-      ledgerId: ledgerChannelId
+    subscribeToMessages({
+      [participants[0].participantId]: aStore,
+      [participants[1].participantId]: bStore
     });
-  }, EXPECT_TIMEOUT);
-});
-
-test('locks', async () => {
-  const _chain = new FakeChain();
-  _chain.depositSync(ledgerChannelId, '0', amounts.reduce(add).toHexString());
-  [aStore, bStore].forEach((store: TestStore) => ((store as any).chain = _chain));
-
-  const aService = interpret(machine(aStore).withContext(context));
-  const bService = interpret(machine(bStore).withContext(context));
-  // Note: We need player B to block on the lock since technically
-  // if player B signs state 1 then state 1 is supported and it won't block
-  // waiting for player A
-  const status = await bStore.acquireChannelLock(context.ledgerChannelId);
-  expect(status).toEqual({
-    channelId: context.ledgerChannelId,
-    lock: expect.any(Guid)
   });
 
-  [aService, bService].map(s => s.start());
+  test('happy path', async () => {
+    const _chain = new FakeChain();
+    _chain.depositSync(ledgerChannelId, '0', amounts.reduce(add).toHexString());
+    [aStore, bStore].forEach((store: Store) => (store.chain = _chain));
 
-  await waitForExpect(async () => {
-    expect(bService.state.value).toEqual('acquiringLock');
-    expect(aService.state.value).toEqual({fundingTarget: 'supportState'});
-  }, EXPECT_TIMEOUT);
+    const aService = interpret(machine(aStore).withContext(context));
 
-  aService.onTransition(s => {
-    if (_.isEqual(s.value, {fundTarget: 'getTargetOutcome'})) {
-      expect((s.context as any).lock).toBeDefined();
-      expect((s.context as any).lock).not.toEqual(status.lock);
+    const bService = interpret(machine(bStore).withContext(context));
+    [aService, bService].map(s => s.start());
+
+    await waitForExpect(async () => {
+      expect(bService.state.value).toEqual('success');
+      expect(aService.state.value).toEqual('success');
+
+      const {supported: supportedState} = await aStore.getEntry(ledgerChannelId);
+      const outcome = checkThat(supportedState.outcome, isSimpleEthAllocation);
+
+      expect(outcome.allocationItems).toMatchObject(
+        [0, 1]
+          .map(i => ({
+            destination: destinations[i],
+            amount: amounts[i].sub(deductionAmounts[i])
+          }))
+          .concat([{destination: targetChannelId as any, amount: deductionAmounts.reduce(add)}])
+      );
+
+      expect((await aStore.getEntry(targetChannelId)).funding).toMatchObject({
+        type: 'Indirect',
+        ledgerId: ledgerChannelId
+      });
+    }, EXPECT_TIMEOUT);
+  });
+
+  test('locks', async () => {
+    const _chain = new FakeChain();
+    _chain.depositSync(ledgerChannelId, '0', amounts.reduce(add).toHexString());
+    [aStore, bStore].forEach((store: TestStore) => ((store as any).chain = _chain));
+
+    const aService = interpret(machine(aStore).withContext(context));
+    const bService = interpret(machine(bStore).withContext(context));
+    // Note: We need player B to block on the lock since technically
+    // if player B signs state 1 then state 1 is supported and it won't block
+    // waiting for player A
+    const status = await bStore.acquireChannelLock(context.ledgerChannelId);
+    expect(status).toEqual({
+      channelId: context.ledgerChannelId,
+      lock: expect.any(Guid)
+    });
+
+    [aService, bService].map(s => s.start());
+
+    await waitForExpect(async () => {
+      expect(bService.state.value).toEqual('acquiringLock');
+      expect(aService.state.value).toEqual({fundingTarget: 'supportState'});
+    }, EXPECT_TIMEOUT);
+
+    aService.onTransition(s => {
+      if (_.isEqual(s.value, {fundTarget: 'getTargetOutcome'})) {
+        expect((s.context as any).lock).toBeDefined();
+        expect((s.context as any).lock).not.toEqual(status.lock);
+      }
+    });
+    await bStore.releaseChannelLock(status);
+
+    await waitForExpect(async () => {
+      expect(aService.state.value).toEqual('success');
+    }, EXPECT_TIMEOUT);
+
+    expect(bStore._channelLocks[context.ledgerChannelId]).toBeUndefined();
+  });
+});
+
+describe('failure modes', () => {
+  type Data = {
+    ledgerOutcome?: Outcome;
+    initialTargetState?: SignedState;
+    chainInfo?: {amount: string; finalized: boolean};
+  };
+  const oneWeiDeposited: Data = {
+    ledgerOutcome: outcome,
+    chainInfo: {amount: '1', finalized: false}
+  };
+  const fiveTotalAllocated: Data = {
+    ledgerOutcome: {
+      type: 'SimpleAllocation',
+      assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS,
+      allocationItems: [0, 1].map(i => ({
+        destination: destinations[i],
+        amount: deductionAmounts[i].sub(1)
+      }))
     }
+  };
+
+  const finalizedLedger: Data = {chainInfo: {finalized: true, amount: '12'}};
+  const unsupportedTarget: Data = {
+    initialTargetState: {...firstState(outcome, targetChannel), signatures: []}
+  };
+
+  test.each`
+    description             | data                  | error
+    ${'underfunded'}        | ${oneWeiDeposited}    | ${Errors.underfunded}
+    ${'underallocated'}     | ${fiveTotalAllocated} | ${Errors.underallocated}
+    ${'finalized'}          | ${finalizedLedger}    | ${Errors.finalized}
+    ${'unsupported target'} | ${unsupportedTarget}  | ${Errors.unSupportedTargetChannel + targetChannelId}
+  `('failure mode: $description', async ({error, data}: {error: string; data: Data}) => {
+    const ledgerOutcome = data.ledgerOutcome ?? outcome;
+    const initialTargetState =
+      data.initialTargetState ?? allSignState(firstState(outcome, targetChannel));
+    const chainInfo = data.chainInfo ?? {amount: '12', finalized: false};
+
+    aStore = new TestStore(chain);
+    await aStore.initialize([wallet1.privateKey]);
+    bStore = new TestStore(chain);
+    await bStore.initialize([wallet2.privateKey]);
+
+    const initialLedgerState = allSignState(firstState(ledgerOutcome, ledgerChannel));
+    await Promise.all(
+      [aStore, bStore].map(async (store: TestStore) => {
+        await store.createEntry(initialTargetState);
+        await store.setLedgerByEntry(await store.createEntry(initialLedgerState));
+      })
+    );
+
+    subscribeToMessages({
+      [participants[0].participantId]: aStore,
+      [participants[1].participantId]: bStore
+    });
+
+    const _chain = new FakeChain();
+    _chain.depositSync(ledgerChannelId, '0', chainInfo.amount);
+    chainInfo.finalized && _chain.finalizeSync(ledgerChannelId);
+    (aStore as any).chain = _chain;
+
+    aStore.createEntry(
+      allSignState({...firstState(ledgerOutcome, ledgerChannel), turnNum: bigNumberify(1)})
+    );
+    aStore.chain.initialize();
+
+    const aService = interpret(machine(aStore).withContext(context), {
+      parent: {send: () => undefined} as any // Consumes uncaught errors
+    }).start();
+
+    await waitForExpect(async () => {
+      expect(aService.state.value).toEqual('failure');
+      expect(aService.state.context).toMatchObject({error});
+    }, EXPECT_TIMEOUT);
   });
-  await bStore.releaseChannelLock(status);
-
-  await waitForExpect(async () => {
-    expect(aService.state.value).toEqual('success');
-  }, EXPECT_TIMEOUT);
-
-  expect(bStore._channelLocks[context.ledgerChannelId]).toBeUndefined();
-});
-
-const twelveTotalAllocated = outcome;
-const fiveTotalAllocated: Outcome = {
-  type: 'SimpleAllocation',
-  assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS,
-  allocationItems: [0, 1].map(i => ({
-    destination: destinations[i],
-    amount: deductionAmounts[i].sub(1)
-  }))
-};
-
-test.each`
-  description         | ledgerOutcome           | chainInfo            | error
-  ${'underfunded'}    | ${twelveTotalAllocated} | ${{amount: '1'}}     | ${Errors.underfunded}
-  ${'underallocated'} | ${fiveTotalAllocated}   | ${undefined}         | ${Errors.underallocated}
-  ${'finalized'}      | ${twelveTotalAllocated} | ${{finalized: true}} | ${Errors.finalized}
-`('failure mode: $description', async ({ledgerOutcome, error, chainInfo}) => {
-  const _chain = new FakeChain();
-  _chain.depositSync(ledgerChannelId, '0', chainInfo?.amount || '12');
-  chainInfo?.finalized && _chain.finalizeSync(ledgerChannelId);
-  (aStore as any).chain = _chain;
-
-  aStore.createEntry(
-    allSignState({...firstState(ledgerOutcome, ledgerChannel), turnNum: bigNumberify(1)})
-  );
-  aStore.chain.initialize();
-
-  const aService = interpret(machine(aStore).withContext(context), {
-    parent: {send: () => undefined} as any // Consumes uncaught errors
-  }).start();
-
-  await waitForExpect(async () => {
-    expect(aService.state.value).toEqual('failure');
-    expect(aService.state.context).toMatchObject({error});
-  }, EXPECT_TIMEOUT);
 });

--- a/packages/xstate-wallet/src/workflows/tests/virtual-funding.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/virtual-funding.test.ts
@@ -57,6 +57,11 @@ const outcome: Outcome = simpleEthAllocation([
 ]);
 
 const context: VirtualFundingAsLeaf.Init = {targetChannelId, jointChannelId};
+const hubContext: VirtualFundingAsHub.Init = {
+  ...context,
+  [ParticipantIdx.A]: {},
+  [ParticipantIdx.B]: {}
+};
 
 const ledgerAmounts = [4, 4].map(bigNumberify);
 const depositAmount = ledgerAmounts.reduce(add).toHexString();
@@ -76,7 +81,7 @@ beforeEach(async () => {
 });
 
 test('virtual funding with smart hub', async () => {
-  const hubService = interpret(VirtualFundingAsHub.machine(hubStore).withContext(context));
+  const hubService = interpret(VirtualFundingAsHub.machine(hubStore).withContext(hubContext));
   const aService = interpret(VirtualFundingAsLeaf.machine(aStore).withContext(context));
   const bService = interpret(VirtualFundingAsLeaf.machine(bStore).withContext(context));
   const services = [aService, hubService, bService];
@@ -125,7 +130,6 @@ test('virtual funding with smart hub', async () => {
     expect(hubService.state.value).toEqual('success');
     expect(bService.state.value).toEqual('success');
     expect(aService.state.value).toEqual('success');
-
     const {supported: supportedState} = await aStore.getEntry(jointChannelId);
     const outcome = supportedState.outcome;
     const amount = bigNumberify(5);

--- a/packages/xstate-wallet/src/workflows/virtual-funding-as-hub.ts
+++ b/packages/xstate-wallet/src/workflows/virtual-funding-as-hub.ts
@@ -7,29 +7,36 @@ import {
   DoneInvokeEvent,
   ServiceConfig,
   assign,
-  spawn
+  spawn,
+  AssignAction
 } from 'xstate';
 import {filter, flatMap} from 'rxjs/operators';
 
-import {Store} from '../store';
-import {LedgerFunding, VirtualFundingAsLeaf} from '.';
+import {Store, State} from '../store';
+import {LedgerFunding, VirtualFundingAsLeaf, SupportState} from '.';
 import {checkThat, isSimpleEthAllocation} from '../utils';
 
 import {FundGuarantor, AllocationItem, isFundGuarantor, Participant} from '../store/types';
 
 import _ from 'lodash';
 import {ParticipantIdx, States, OutcomeIdx} from './virtual-funding-as-leaf';
+import {Observable} from 'rxjs';
 
-type Init = VirtualFundingAsLeaf.Init;
-
+type RoleData = {
+  ledgerId: string;
+  guarantorId: string;
+  guarantorState: State;
+};
 type Deductions = {
-  deductions: {
-    [ParticipantIdx.A]: AllocationItem[];
-    [ParticipantIdx.B]: AllocationItem[];
-  };
+  [ParticipantIdx.A]: AllocationItem[];
+  [ParticipantIdx.B]: AllocationItem[];
+};
+export type Init = VirtualFundingAsLeaf.Init & {
+  [ParticipantIdx.A]: Partial<RoleData>;
+  [ParticipantIdx.B]: Partial<RoleData>;
 };
 
-type WithDeductions = Init & Deductions;
+type WithDeductions = Init & {deductions: Deductions};
 
 type TEvent = AnyEventObject;
 
@@ -51,6 +58,18 @@ const enum Events {
   FundGuarantorWithB = 'FundGuarantorWithB'
 }
 
+type Objective = Pick<FundGuarantor, 'data' | 'participants'> & {state: State; type: Events};
+const assignObjectiveData = (
+  role: ParticipantIdx.A | ParticipantIdx.B
+): AssignAction<Init, Objective> =>
+  assign<Init>({
+    [role]: (_, {data, state}: Objective): RoleData => ({
+      guarantorId: data.guarantorId,
+      ledgerId: data.ledgerId,
+      guarantorState: state
+    })
+  });
+
 const waitThenFundGuarantor = (
   role: ParticipantIdx.A | ParticipantIdx.B
 ): StateNodeConfig<WithDeductions, any, any> => {
@@ -58,15 +77,26 @@ const waitThenFundGuarantor = (
   return {
     initial: 'waitForObjective',
     states: {
-      waitForObjective: {on: {[event]: 'runObjective'}},
+      waitForObjective: {
+        on: {[event]: {target: 'supportingGuarantorState', actions: assignObjectiveData(role)}}
+      },
+      supportingGuarantorState: {
+        invoke: {
+          src: Services.supportState,
+          data: (ctx: Init): SupportState.Init => ({state: (ctx[role] as RoleData).guarantorState}),
+          onDone: 'runObjective'
+        }
+      },
       runObjective: {
         invoke: {
           src: Services.ledgerFunding,
-          data: (ctx: WithDeductions, {data}: FundGuarantor): LedgerFunding.Init => ({
-            targetChannelId: data.guarantorId,
-            ledgerChannelId: data.ledgerId,
-            deductions: ctx.deductions[role]
-          }),
+          data: (ctx: WithDeductions): LedgerFunding.Init => {
+            // We know that the data has already been assigned in the
+            // transition out of waitForObjective
+            const {guarantorId: targetChannelId, ledgerId: ledgerChannelId} = ctx[role] as RoleData;
+            const deductions = ctx.deductions[role];
+            return {targetChannelId, ledgerChannelId, deductions};
+          },
           onDone: 'done'
         }
       },
@@ -99,26 +129,24 @@ const getDeductions = (store: Store) => async (ctx: Init): Promise<Deductions> =
   const {allocationItems} = checkThat(latestSupportedByMe.outcome, isSimpleEthAllocation);
 
   return {
-    deductions: {
-      [ParticipantIdx.A]: [
-        {
-          destination: allocationItems[OutcomeIdx.Hub].destination,
-          amount: allocationItems[OutcomeIdx.B].amount
-        },
-        allocationItems[OutcomeIdx.A]
-      ],
-      [ParticipantIdx.B]: [
-        {
-          destination: allocationItems[OutcomeIdx.Hub].destination,
-          amount: allocationItems[OutcomeIdx.A].amount
-        },
-        allocationItems[OutcomeIdx.B]
-      ]
-    }
+    [ParticipantIdx.A]: [
+      {
+        destination: allocationItems[OutcomeIdx.Hub].destination,
+        amount: allocationItems[OutcomeIdx.B].amount
+      },
+      allocationItems[OutcomeIdx.A]
+    ],
+    [ParticipantIdx.B]: [
+      {
+        destination: allocationItems[OutcomeIdx.Hub].destination,
+        amount: allocationItems[OutcomeIdx.A].amount
+      },
+      allocationItems[OutcomeIdx.B]
+    ]
   };
 };
 
-const watchObjectives = (store: Store) => (ctx: Init) =>
+const watchObjectives = (store: Store) => (ctx: Init): Observable<Objective> =>
   store.objectiveFeed.pipe(
     filter(isFundGuarantor),
     filter(o => o.data.jointChannelId === ctx.jointChannelId),
@@ -127,11 +155,13 @@ const watchObjectives = (store: Store) => (ctx: Init) =>
       const jointParticipants: Participant[] = await (await store.getEntry(ctx.jointChannelId))
         .channelConstants.participants;
 
+      const {latest} = await store.getEntry(o.data.guarantorId);
+
       switch (participant) {
         case jointParticipants[ParticipantIdx.A].participantId:
-          return {...o, type: Events.FundGuarantorWithA};
+          return {...o, type: Events.FundGuarantorWithA, state: latest};
         case jointParticipants[ParticipantIdx.B].participantId:
-          return {...o, type: Events.FundGuarantorWithB};
+          return {...o, type: Events.FundGuarantorWithB, state: latest};
         default:
           throw 'Participant not found';
       }
@@ -141,12 +171,9 @@ const watchObjectives = (store: Store) => (ctx: Init) =>
 export const options = (store: Store): Partial<MachineOptions<Init, TEvent>> => {
   const actions: Record<Actions, any> = {
     watchObjectives: assign<any>({watcher: (ctx: Init) => spawn(watchObjectives(store)(ctx))}),
-    [Actions.assignDeductions]: assign(
-      (ctx: Init, {data}: DoneInvokeEvent<Deductions>): WithDeductions => ({
-        ...ctx,
-        ...data
-      })
-    )
+    [Actions.assignDeductions]: assign({
+      deductions: (_, {data}: DoneInvokeEvent<Deductions>) => data
+    })
   };
 
   const leafServices = VirtualFundingAsLeaf.options(store).services;

--- a/packages/xstate-wallet/src/workflows/virtual-funding-as-leaf.ts
+++ b/packages/xstate-wallet/src/workflows/virtual-funding-as-leaf.ts
@@ -49,7 +49,7 @@ export type Init = {
 type Deductions = {deductions: AllocationItem[]};
 type WithDeductions = Init & Deductions;
 
-const getObjective = (store: Store) => async (ctx: Init): Promise<FundGuarantor> => {
+const getFundGuarantorObjective = (store: Store) => async (ctx: Init): Promise<FundGuarantor> => {
   const {jointChannelId, targetChannelId} = ctx;
   const entry = await store.getEntry(jointChannelId);
   const {participants: jointParticipants} = entry.channelConstants;
@@ -68,6 +68,8 @@ const getObjective = (store: Store) => async (ctx: Init): Promise<FundGuarantor>
       ...participants.map(p => p.destination)
     )
   });
+
+  // TODO: We never actually check that the guarantor channel's state is supported.
 
   return {
     type: 'FundGuarantor',
@@ -254,11 +256,11 @@ export const options = (
 
   const services: Record<Services, ServiceConfig<Init>> = {
     getDeductions: getDeductions(store),
-    supportState: SupportState.machine(store as any),
+    supportState: SupportState.machine(store),
     ledgerFunding: LedgerFunding.machine(store),
     waitForFirstJointState: waitForFirstJointState(store),
     jointChannelUpdate: jointChannelUpdate(store),
-    fundGuarantor: getObjective(store),
+    fundGuarantor: getFundGuarantorObjective(store),
     updateJointChannelFunding: updateJointChannelFunding(store)
   };
 


### PR DESCRIPTION
While working on virtual funding puppeteer tests with @snario, we found the reason why the simple-hub was not able to read messages: during serialization, guarantee outcomes are stripped: 7c6aeb7.

This lead me to realize that the virtual-funding workflows create the guarantor channels, then move to the next step before that channel has a supported "prefund setup" state.

This PR adds a defensive "checking target" state for validating the state of the target channel when ledger funding.

Virtual funding was then fixed to account for the missing step.