### PR TITLE
web3torrent: clean up ShareFIle click handling

### DIFF
--- a/packages/web3torrent/src/components/share-list/ShareList.tsx
+++ b/packages/web3torrent/src/components/share-list/ShareList.tsx
@@ -1,29 +1,18 @@
 import React from 'react';
-import {RoutePath} from '../../routes';
 import {Torrent} from '../../types';
 import {ShareFile} from './share-file/ShareFile';
 import './ShareList.scss';
-import {useHistory} from 'react-router-dom';
 
 export type ShareListProps = {torrents: Array<Partial<Torrent>>};
 
-const ShareList: React.FC<ShareListProps> = ({torrents}) => {
-  const history = useHistory();
+export const ShareList: React.FC<ShareListProps> = ({torrents}) => {
   return (
     <table className="share-list">
       <tbody>
-        {torrents.length
-          ? torrents.map(file => (
-              <ShareFile
-                file={file}
-                key={file.name}
-                goTo={hash => history.push(`${RoutePath.File}#${hash}`)}
-              />
-            ))
-          : false}
+        {torrents.map(file => (
+          <ShareFile file={file} key={file.name} />
+        ))}
       </tbody>
     </table>
   );
 };
-
-export {ShareList};

--- a/packages/web3torrent/src/components/share-list/share-file/ShareFile.stories.tsx
+++ b/packages/web3torrent/src/components/share-list/share-file/ShareFile.stories.tsx
@@ -1,4 +1,4 @@
-import {action, withActions} from '@storybook/addon-actions';
+import {withActions} from '@storybook/addon-actions';
 import {number, text, withKnobs} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import React from 'react';
@@ -21,7 +21,6 @@ storiesOf('Web3Torrent', module)
             numPeers: number('Number of peers', 17, {step: 1}, 'File data'),
             magnetURI: text('Magnet link', '', 'File data')
           }}
-          goTo={action('button-clicked')}
         ></ShareFile>
       </tbody>
     </table>

--- a/packages/web3torrent/src/components/share-list/share-file/ShareFile.tsx
+++ b/packages/web3torrent/src/components/share-list/share-file/ShareFile.tsx
@@ -4,17 +4,23 @@ import {FormButton} from '../../form';
 import './ShareFile.scss';
 import {prettyPrintWei, calculateWei} from '../../../utils/calculateWei';
 import prettier from 'prettier-bytes';
+import {RoutePath} from '../../../routes';
+import {useHistory} from 'react-router-dom';
 
-export type ShareFileProps = {file: Partial<Torrent>; goTo: (name: string) => void};
+export type ShareFileProps = {file: Partial<Torrent>};
 
-const ShareFile: React.FC<ShareFileProps> = ({file, goTo}: ShareFileProps) => {
+const ShareFile: React.FC<ShareFileProps> = ({file}: ShareFileProps) => {
+  const history = useHistory();
   return (
     <tr className={'share-file'}>
       <td className="name-cell">{file.name}</td>
       <td className="other-cell">{prettier(file.length)}</td>
       <td className="other-cell">{prettyPrintWei(calculateWei(file.length))}</td>
       <td className="button-cell">
-        <FormButton name="download" onClick={() => goTo(file.magnetURI || file.name || '')}>
+        <FormButton
+          name="download"
+          onClick={() => history.push(`${RoutePath.File}#${file.magnetURI || file.name || ''}`)}
+        >
           Download
         </FormButton>
       </td>


### PR DESCRIPTION
`ShareFile` has enough information to construct the click handler. So no need to pass the click handler as a prop.