### PR TITLE
Fix multi-file Torrents naming

### DIFF
--- a/packages/web3torrent/src/clients/web3torrent-client.test.ts
+++ b/packages/web3torrent/src/clients/web3torrent-client.test.ts
@@ -63,7 +63,11 @@ describe('Web3TorrentClient', () => {
       seedSpy = jest
         .spyOn(web3torrent, 'seed')
         .mockImplementation(
-          (_: WebTorrentSeedInput, callback: TorrentOptions | TorrentCallback | undefined) => {
+          (
+            _: WebTorrentSeedInput,
+            __?: TorrentOptions | TorrentCallback,
+            callback?: TorrentCallback
+          ) => {
             return (callback as TorrentCallback)(torrent as PaidStreamingTorrent);
           }
         );

--- a/packages/web3torrent/src/clients/web3torrent-client.ts
+++ b/packages/web3torrent/src/clients/web3torrent-client.ts
@@ -51,11 +51,8 @@ export const cancel = (id: string = '') => {
 };
 
 const torrentNamer = (input: WebTorrentSeedInput) => {
-  if ((input as FileList).length) {
-    const files = input as FileList;
-    return {
-      name: files.length > 1 ? `various_${String(Date.now()).slice(-5)}.zip` : files[0].name
-    };
+  if ((input as FileList).length && (input as FileList).length > 1) {
+    return {name: `various.zip`};
   }
   return {};
 };

--- a/packages/web3torrent/src/clients/web3torrent-client.ts
+++ b/packages/web3torrent/src/clients/web3torrent-client.ts
@@ -24,10 +24,10 @@ export const download: (torrent: WebTorrentAddInput) => Promise<Torrent> = torre
   );
 };
 
-export const upload: (files: WebTorrentSeedInput) => Promise<Torrent> = files => {
+export const upload: (input: WebTorrentSeedInput) => Promise<Torrent> = input => {
   return new Promise(resolve =>
     web3torrent.enable().then(() => {
-      web3torrent.seed(files as FileList, (torrent: any) => {
+      web3torrent.seed(input, {...torrentNamer(input)}, (torrent: any) => {
         resolve({
           ...torrent,
           status: Status.Seeding,
@@ -48,4 +48,14 @@ export const cancel = (id: string = '') => {
       }
     })
   );
+};
+
+const torrentNamer = (input: WebTorrentSeedInput) => {
+  if ((input as FileList).length) {
+    const files = input as FileList;
+    return {
+      name: files.length > 1 ? `various_${String(Date.now()).slice(-5)}.zip` : files[0].name
+    };
+  }
+  return {};
 };

--- a/packages/web3torrent/src/components/torrent-info/download-link/DownloadLink.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-link/DownloadLink.tsx
@@ -12,7 +12,7 @@ export const DownloadLink: React.FC<DownloadLinkProps> = ({torrent}) => {
     if (torrent.done) {
       getFileSavingData(torrent.files, torrent.name).then(data => setFile(data));
     }
-  }, [torrent.done, torrent.files]);
+  }, [torrent.done, torrent.files, torrent.name]);
 
   return (
     <>

--- a/packages/web3torrent/src/components/torrent-info/download-link/DownloadLink.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-link/DownloadLink.tsx
@@ -10,7 +10,7 @@ export const DownloadLink: React.FC<DownloadLinkProps> = ({torrent}) => {
   const [file, setFile] = useState({} as SavingData);
   useEffect(() => {
     if (torrent.done) {
-      getFileSavingData(torrent.files).then(data => setFile(data));
+      getFileSavingData(torrent.files, torrent.name).then(data => setFile(data));
     }
   }, [torrent.done, torrent.files]);
 

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -104,17 +104,13 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     callback?: TorrentCallback
   ): PaidStreamingTorrent {
     this.ensureEnabled();
-    let torrent: PaidStreamingTorrent;
 
-    if (typeof optionsOrCallback === 'function') {
-      torrent = super.seed(
-        input,
-        {createdBy: this.pseAccount, announce: defaultTrackers} as TorrentOptions,
-        optionsOrCallback
-      ) as PaidStreamingTorrent;
-    } else {
-      torrent = super.seed(input, optionsOrCallback, callback) as PaidStreamingTorrent;
-    }
+    const options =
+      typeof optionsOrCallback === 'function'
+        ? {createdBy: this.pseAccount, announce: defaultTrackers}
+        : {createdBy: this.pseAccount, announce: defaultTrackers, ...optionsOrCallback};
+
+    const torrent = super.seed(input, options, callback) as PaidStreamingTorrent;
     this.setupTorrent(torrent);
 
     return torrent;

--- a/packages/web3torrent/src/utils/file-saver.ts
+++ b/packages/web3torrent/src/utils/file-saver.ts
@@ -11,7 +11,10 @@ export const getFileBlobURL: (file: TorrentFile) => Promise<string> = file => {
   return new Promise(resolve => file.getBlobURL((_, blob) => resolve(blob as string)));
 };
 
-export const getFileSavingData: (files: TorrentFile[]) => Promise<SavingData> = async files => {
+export const getFileSavingData: (
+  files: TorrentFile[],
+  fileName: string
+) => Promise<SavingData> = async (files, fileName) => {
   if (!files.length) {
     return Promise.reject();
   }
@@ -28,6 +31,6 @@ export const getFileSavingData: (files: TorrentFile[]) => Promise<SavingData> = 
     })
     .then(data => ({
       content: URL.createObjectURL(data),
-      name: 'torrent.zip'
+      name: fileName
     }));
 };


### PR DESCRIPTION
With Torrents that consisted of several files, the naming logic in WebTorrent was not working (at least on Linux), the name of the created torrent was simply one of the files selected, which is kind of misleading for the leecher.

This PR generates a name for the torrent if the torrent has multiple files. The name consists of `"various_"+ the last 5 digits of the Date.now() + ".zip"`.

Added to that, this also sets that name to the zip file when downloaded.
![image](https://user-images.githubusercontent.com/10502605/79165564-c540c700-7db9-11ea-95d0-1251dec195b2.png)
