### PR TITLE
More robust integration test

### DIFF
--- a/packages/e2e-tests/puppeteer/__tests__/web3torrent/seed-download.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/web3torrent/seed-download.test.ts
@@ -2,11 +2,19 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable jest/expect-expect */
 import {Page, Browser} from 'puppeteer';
-import {setUpBrowser, loadDapp, waitAndOpenChannel, waitForClosingChannel} from '../../helpers';
-import {uploadFile, startDownload, cancelDownload} from '../../scripts/web3torrent';
 import {JEST_TIMEOUT, HEADLESS, USES_VIRTUAL_FUNDING} from '../../constants';
 
-jest.setTimeout(JEST_TIMEOUT);
+import {
+  setUpBrowser,
+  loadDapp,
+  waitAndOpenChannel,
+  waitForClosingChannel,
+  waitForNthState
+} from '../../helpers';
+
+import {uploadFile, startDownload, cancelDownload} from '../../scripts/web3torrent';
+
+jest.setTimeout(HEADLESS ? JEST_TIMEOUT : 1_000_000);
 
 let browserA: Browser;
 let browserB: Browser;
@@ -61,7 +69,7 @@ describe('Web3-Torrent Integration Tests', () => {
 
     // Let the download cointinue for some time
     console.log('Downloading');
-    await web3tTabB.waitFor(1000);
+    await waitForNthState(web3tTabB, 10);
 
     console.log('B cancels download');
     await cancelDownload(web3tTabB);

--- a/packages/e2e-tests/puppeteer/__tests__/web3torrent/seed-download.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/web3torrent/seed-download.test.ts
@@ -43,7 +43,7 @@ describe('Web3-Torrent Integration Tests', () => {
 
     console.log('Loading dapps');
     await loadDapp(web3tTabA, 0, true);
-    await loadDapp(web3tTabB, 0, true);
+    await loadDapp(web3tTabB, 1, true);
 
     await web3tTabA.goto('http://localhost:3000/upload', {waitUntil: 'load'});
   });

--- a/packages/e2e-tests/puppeteer/__tests__/web3torrent/seed-download.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/web3torrent/seed-download.test.ts
@@ -49,11 +49,10 @@ describe('Web3-Torrent Integration Tests', () => {
   });
 
   afterAll(async () => {
-    if (browserA) {
-      await browserA.close();
-    }
-    if (browserB) {
-      await browserB.close();
+    if (HEADLESS) {
+      await Promise.all(
+        [browserA, browserB].map(async browser => browser && (await browser.close()))
+      );
     }
   });
 

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -14,6 +14,7 @@ export async function loadDapp(
   const web3JsFile = fs.readFileSync(path.resolve(__dirname, 'web3/web3.min.js'), 'utf8');
   await page.evaluateOnNewDocument(web3JsFile);
   await page.evaluateOnNewDocument(`
+    localStorage.debug = "web3torrent:*";
     window.web3 = new Web3("http://localhost:8547");
     window.ethereum = window.web3.currentProvider;
     window.ethereum.enable = () => new Promise(r => {
@@ -124,10 +125,28 @@ export async function waitAndApproveBudget(page: Page): Promise<void> {
 
 interface Window {
   channelProvider: import('@statechannels/channel-provider').ChannelProviderInterface;
-  channelRunning(): void;
+  done(): void;
 }
 declare let window: Window;
 
+let doneFuncCounter = 0;
+const doneWhen = (page: Page, done: string): Promise<void> => {
+  const doneFunc = `done${doneFuncCounter++}`;
+  return new Promise(resolve =>
+    page.exposeFunction(doneFunc, resolve).then(() =>
+      page.evaluate(
+        `
+    window.channelProvider.on('ChannelUpdated', channelStatus => {
+      if (${done}) {
+        window.${doneFunc}();
+        window.channelProvider.off('ChannelUpdated');
+      }
+    });
+    `
+      )
+    )
+  );
+};
 export const waitAndOpenChannel = (usingVirtualFunding: boolean) => async (
   page: Page
 ): Promise<void> => {
@@ -139,17 +158,11 @@ export const waitAndOpenChannel = (usingVirtualFunding: boolean) => async (
     const walletIFrame = page.frames()[1];
     await waitForAndClickButton(page, walletIFrame, createChannelButton);
   } else {
-    return new Promise(resolve =>
-      page.exposeFunction('channelRunning', resolve).then(() =>
-        page.evaluate(() => {
-          window.channelProvider.on('ChannelUpdated', () => {
-            window.channelRunning();
-            window.channelProvider.off('ChannelUpdated');
-          });
-        })
-      )
-    );
+    return doneWhen(page, 'true');
   }
+};
+export const waitForNthState = async (page: Page, n = 50): Promise<void> => {
+  return doneWhen(page, `parseInt(channelStatus.turnNum) > ${n}`);
 };
 
 export async function waitForClosingChannel(page: Page): Promise<void> {

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -14,7 +14,7 @@ export async function loadDapp(
   const web3JsFile = fs.readFileSync(path.resolve(__dirname, 'web3/web3.min.js'), 'utf8');
   await page.evaluateOnNewDocument(web3JsFile);
   await page.evaluateOnNewDocument(`
-    localStorage.debug = "web3torrent:*";
+    // localStorage.debug = "web3torrent:*";
     window.web3 = new Web3("http://localhost:8547");
     window.ethereum = window.web3.currentProvider;
     window.ethereum.enable = () => new Promise(r => {

--- a/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
+++ b/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import {waitAndApproveBudget} from '../helpers';
 
 function prepareUploadFile(path: string): void {
-  const content = 'web3torrent\n'.repeat(100000);
+  const content = 'web3torrent\n'.repeat(1000000);
   const buf = Buffer.from(content);
   fs.writeFile(path, buf, err => {
     if (err) {

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -173,8 +173,9 @@ export class PaymentChannelClient {
   }
 
   updateChannelCache(channelState: ChannelState) {
-    this.channelCache[channelState.channelId] && // only update an existing key
-      (this.channelCache[channelState.channelId] = channelState);
+    // TODO: This implementation is identical to insertIntoChannelCache because of joinChannel
+    // never resolving
+    this.channelCache[channelState.channelId] = channelState;
   }
 
   // Accepts an payment-channel-friendly callback, performs the necessary encoding, and subscribes to the channelClient with an appropriate, API-compliant callback

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -167,7 +167,9 @@ export class PaymentChannelClient {
   }
 
   insertIntoChannelCache(channelState: ChannelState) {
-    this.channelCache = {...this.channelCache, [channelState.channelId]: channelState};
+    // TODO: The joinChannel promise never resolves, meaning this function is not called
+    // by the leecher.
+    this.channelCache[channelState.channelId] = channelState;
   }
 
   updateChannelCache(channelState: ChannelState) {

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -283,16 +283,12 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
         log(`Channel updated to turnNum ${channelState.turnNum}`);
         if (this.paymentChannelClient.shouldSendSpacerState(channelState)) {
           // send "spacer" state
-          await this.paymentChannelClient.acceptChannelUpdate(
-            this.paymentChannelClient.channelCache[channelState.channelId]
-          );
+          await this.paymentChannelClient.acceptChannelUpdate(channelState);
           log('sent spacer state, now sending STOP');
           wire.paidStreamingExtension.stop(); // prompt peer for a payment
         } else if (this.paymentChannelClient.isPaymentToMe(channelState)) {
           // Accepting payment, refilling buffer and unblocking
-          await this.paymentChannelClient.acceptChannelUpdate(
-            this.paymentChannelClient.channelCache[channelState.channelId]
-          );
+          await this.paymentChannelClient.acceptChannelUpdate(channelState);
           await this.refillBuffer(
             torrent.infoHash,
             wire.paidStreamingExtension.peerAccount,

--- a/packages/xstate-wallet/src/workflows/conclude-channel.ts
+++ b/packages/xstate-wallet/src/workflows/conclude-channel.ts
@@ -1,4 +1,4 @@
-import {Machine, StateNodeConfig, ActionFunction} from 'xstate';
+import {Machine, StateNodeConfig} from 'xstate';
 import {Store} from '../store';
 import {SupportState, VirtualDefundingAsLeaf} from '.';
 import {getDataAndInvoke} from '../utils';
@@ -7,7 +7,6 @@ import {outcomesEqual} from '../store/state-utils';
 import {State} from '../store/types';
 import {map} from 'rxjs/operators';
 import {ParticipantIdx} from './virtual-funding-as-leaf';
-import {ETH_ASSET_HOLDER_ADDRESS} from '../constants';
 
 const WORKFLOW = 'conclude-channel';
 
@@ -69,7 +68,6 @@ const getRole = (store: Store) => (ctx: Init) => async cb => {
 
 const virtualDefunding = {
   initial: 'gettingRole',
-  entry: ['releaseFunds'],
   states: {
     gettingRole: {invoke: {src: getRole.name}, on: {AmHub: 'asHub', AmLeaf: 'asLeaf'}},
     asLeaf: {
@@ -112,12 +110,7 @@ const services = (store: Store) => ({
   virtualDefundingAsLeaf: VirtualDefundingAsLeaf.machine(store)
 });
 
-const releaseFunds = (store: Store): ActionFunction<Init, any> => context => {
-  store.releaseFunds(ETH_ASSET_HOLDER_ADDRESS, context.channelId);
-};
-
 const options = (store: Store) => ({
-  services: services(store),
-  actions: {releaseFunds: releaseFunds(store)}
+  services: services(store)
 });
 export const machine = (store: Store) => Machine(config).withConfig(options(store));


### PR DESCRIPTION
- Add a `waitForNthState` e2e helper, and use in the test. This ensures we are testing that some data is actually being transferred
- Fixes an issue in web3torrent where the `channelCache` may be undefined when it's used
- Adds a hack to `updateChannelCache` to always set the channel cache, even when the channel is unknown (see https://github.com/statechannels/monorepo/issues/1438#issuecomment-614159943)