### PR TITLE
[web3torrent] Clean up File component

### DIFF
--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -12,14 +12,14 @@ import './File.scss';
 import WebTorrentPaidStreamingClient from '../../library/web3torrent-lib';
 import _ from 'lodash';
 
-const getLiveData: (
+function getLiveData(
   web3Torrent: WebTorrentPaidStreamingClient,
   setTorrent: React.Dispatch<React.SetStateAction<Torrent>>,
   torrent: Torrent
-) => void = (web3Torrent, setTorrent, torrent) => {
+): void {
   const liveTorrent = torrentStatusChecker(web3Torrent, torrent, torrent.infoHash);
   setTorrent(liveTorrent);
-};
+}
 
 interface Props {
   ready: boolean;
@@ -46,41 +46,33 @@ const File: React.FC<Props> = props => {
     (torrent.status !== Status.Idle || !!torrent.originalSeed) && 1000
   );
 
+  const {channelCache, budgetCache, mySigningAddress: me} = web3Torrent.paymentChannelClient;
+  // TODO: We shouldn't have to check all these different conditions
+  const showBudget =
+    !!budgetCache &&
+    !_.isEmpty(budgetCache) &&
+    !!budgetCache.budgets &&
+    budgetCache.budgets.length > 0;
+
   return (
     <section className="section fill download">
       <div className="jumbotron-upload">
         <h1>{torrent.originalSeed ? 'Upload a File' : 'Download a File'}</h1>
       </div>
-      <Web3TorrentContext.Consumer>
-        {web3Torrent => {
-          const {
-            channelCache,
-            budgetCache,
-            mySigningAddress: me
-          } = web3Torrent.paymentChannelClient;
-          // TODO: We shouldn't have to check all these different conditions
-          const showBudget =
-            !!budgetCache &&
-            !_.isEmpty(budgetCache) &&
-            !!budgetCache.budgets &&
-            budgetCache.budgets.length > 0;
-          return (
-            <>
-              <TorrentInfo torrent={torrent} channelCache={channelCache} mySigningAddress={me} />
-              <br />
-              {showBudget ? (
-                <SiteBudgetTable
-                  budgetCache={budgetCache}
-                  channelCache={channelCache}
-                  mySigningAddress={me}
-                />
-              ) : (
-                false
-              )}
-            </>
-          );
-        }}
-      </Web3TorrentContext.Consumer>
+      <>
+        <TorrentInfo torrent={torrent} channelCache={channelCache} mySigningAddress={me} />
+        <br />
+        {showBudget ? (
+          <SiteBudgetTable
+            budgetCache={budgetCache}
+            channelCache={channelCache}
+            mySigningAddress={me}
+          />
+        ) : (
+          false
+        )}
+      </>
+      }
       {torrent.status === Status.Idle ? (
         <>
           <FormButton

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -59,21 +59,16 @@ const File: React.FC<Props> = props => {
       <div className="jumbotron-upload">
         <h1>{torrent.originalSeed ? 'Upload a File' : 'Download a File'}</h1>
       </div>
-      <>
-        <TorrentInfo torrent={torrent} channelCache={channelCache} mySigningAddress={me} />
-        <br />
-        {showBudget ? (
-          <SiteBudgetTable
-            budgetCache={budgetCache}
-            channelCache={channelCache}
-            mySigningAddress={me}
-          />
-        ) : (
-          false
-        )}
-      </>
-      }
-      {torrent.status === Status.Idle ? (
+      <TorrentInfo torrent={torrent} channelCache={channelCache} mySigningAddress={me} />
+      <br />
+      {showBudget && (
+        <SiteBudgetTable
+          budgetCache={budgetCache}
+          channelCache={channelCache}
+          mySigningAddress={me}
+        />
+      )}
+      {torrent.status === Status.Idle && (
         <>
           <FormButton
             name="download"
@@ -125,8 +120,6 @@ const File: React.FC<Props> = props => {
             </p>
           </div>
         </>
-      ) : (
-        false
       )}
     </section>
   );

--- a/packages/web3torrent/src/utils/torrent-status-checker.ts
+++ b/packages/web3torrent/src/utils/torrent-status-checker.ts
@@ -1,4 +1,5 @@
 import {Status, Torrent} from '../types';
+import WebTorrentPaidStreamingClient from '../library/web3torrent-lib';
 
 export const getStatus = (torrent: Torrent, pseAccount: string): Status => {
   const {uploadSpeed, downloadSpeed, progress, uploaded, paused, done, createdBy} = torrent;
@@ -50,7 +51,11 @@ export const getPeerStatus = (torrent, wire) => {
   return Object.keys(torrent._peers).includes(peerId);
 };
 
-export const torrentStatusChecker = (web3Torrent, previousData: Torrent, infoHash): Torrent => {
+export function torrentStatusChecker(
+  web3Torrent: WebTorrentPaidStreamingClient,
+  previousData: Torrent,
+  infoHash: string
+): Torrent {
   if (!infoHash) {
     // torrent in magnet form
     return {...previousData, status: Status.Idle};
@@ -79,4 +84,4 @@ export const torrentStatusChecker = (web3Torrent, previousData: Torrent, infoHas
       originalSeed: live.createdBy === web3Torrent.pseAccount
     }
   };
-};
+}


### PR DESCRIPTION
- Use `function` syntax when possible. I am finding a constant that defines a function (with Typescript types sprinkled in there) pretty hard to parse. If others agree, please use `function` syntax going forward (when possible).
- `File` component has a `useContext` hook now, so we can remove `Web3TorrentContext.Consumer`. In general, I might be a good idea to minimize the logic inside jsx and instead use jsx primarily to describe UI.