### PR TITLE
Assign Request Id for joiner in application workflow

### DIFF
--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -167,15 +167,12 @@ export class PaymentChannelClient {
   }
 
   insertIntoChannelCache(channelState: ChannelState) {
-    // TODO: The joinChannel promise never resolves, meaning this function is not called
-    // by the leecher.
-    this.channelCache[channelState.channelId] = channelState;
+    this.channelCache = {...this.channelCache, [channelState.channelId]: channelState};
   }
 
   updateChannelCache(channelState: ChannelState) {
-    // TODO: This implementation is identical to insertIntoChannelCache because of joinChannel
-    // never resolving
-    this.channelCache[channelState.channelId] = channelState;
+    this.channelCache[channelState.channelId] && // only update an existing key
+      (this.channelCache[channelState.channelId] = channelState);
   }
 
   // Accepts an payment-channel-friendly callback, performs the necessary encoding, and subscribes to the channelClient with an appropriate, API-compliant callback

--- a/packages/xstate-wallet/src/messaging.ts
+++ b/packages/xstate-wallet/src/messaging.ts
@@ -91,6 +91,9 @@ export class MessagingService implements MessagingServiceInterface {
   }
 
   public async sendResponse(id: number, result: Response['result']) {
+    if (!id) {
+      throw new Error(`No id provided for the response`);
+    }
     const response: Response = {id, jsonrpc: '2.0', result};
     this.eventEmitter.emit('SendMessage', response);
   }

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -196,7 +196,7 @@ const generateConfig = (
 
     //This could handled by another workflow instead of the application workflow
     closing: {
-      entry: actions.displayUi,
+      entry: [actions.displayUi, actions.assignRequestId],
       exit: actions.hideUi,
       invoke: {
         id: 'closing-protocol',
@@ -308,7 +308,9 @@ export const workflow = (
           return unreachable(event);
       }
     }),
-    assignRequestId: assign((context, event: JoinChannelEvent) => ({requestId: event.requestId})),
+    assignRequestId: assign((context, event: JoinChannelEvent | PlayerRequestConclude) => ({
+      requestId: event.requestId
+    })),
     updateStoreWithPlayerState: async (context: ChannelIdExists, event: PlayerStateUpdate) => {
       if (context.channelId === event.channelId) {
         const existingState = await (await store.getEntry(event.channelId)).latest;

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -308,9 +308,7 @@ export const workflow = (
           return unreachable(event);
       }
     }),
-    assignRequestId: assign((context, event: JoinChannelEvent) => {
-      return {requestId: event.requestId};
-    }),
+    assignRequestId: assign((context, event: JoinChannelEvent) => ({requestId: event.requestId})),
     updateStoreWithPlayerState: async (context: ChannelIdExists, event: PlayerStateUpdate) => {
       if (context.channelId === event.channelId) {
         const existingState = await (await store.getEntry(event.channelId)).latest;

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -254,7 +254,7 @@ export const workflow = (
     sendCloseChannelResponse: async (context: ChannelIdExists, event: any) => {
       const entry = await store.getEntry(context.channelId);
       if (context.requestId) {
-        messagingService.sendResponse(event.requestId, await convertToChannelResult(entry));
+        messagingService.sendResponse(context.requestId, await convertToChannelResult(entry));
       }
     },
 

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -69,6 +69,7 @@ export interface WorkflowActions {
   sendCreateChannelResponse: Action<RequestIdExists & ChannelIdExists, any>;
   sendJoinChannelResponse: Action<RequestIdExists & ChannelIdExists, any>;
   assignChannelId: Action<WorkflowContext, any>;
+  assignRequestId: Action<WorkflowContext, any>;
   displayUi: Action<WorkflowContext, any>;
   hideUi: Action<WorkflowContext, any>;
   sendChannelUpdatedNotification: Action<WorkflowContext, any>;
@@ -135,7 +136,7 @@ const generateConfig = (
             ],
             JOIN_CHANNEL: {
               target: 'settingSite',
-              actions: [actions.sendJoinChannelResponse]
+              actions: [actions.assignRequestId, actions.sendJoinChannelResponse]
             }
           }
         },
@@ -299,15 +300,16 @@ export const workflow = (
       if (context.channelId) return context;
       switch (event.type) {
         case 'PLAYER_STATE_UPDATE':
-          return {channelId: event.channelId};
         case 'JOIN_CHANNEL':
-          // TODO: Might be better to split set request Id in it's own action
-          return {channelId: event.channelId, requestId: event.requestId};
+          return {channelId: event.channelId};
         case 'done.invoke.createChannel':
           return {channelId: event.data};
         default:
           return unreachable(event);
       }
+    }),
+    assignRequestId: assign((context, event: JoinChannelEvent) => {
+      return {requestId: event.requestId};
     }),
     updateStoreWithPlayerState: async (context: ChannelIdExists, event: PlayerStateUpdate) => {
       if (context.channelId === event.channelId) {
@@ -414,7 +416,8 @@ const mockActions: Record<keyof WorkflowActions, string> = {
   hideUi: 'hideUi',
   displayUi: 'displayUi',
   spawnObservers: 'spawnObservers',
-  updateStoreWithPlayerState: 'updateStoreWithPlayerState'
+  updateStoreWithPlayerState: 'updateStoreWithPlayerState',
+  assignRequestId: 'assignRequestId'
 };
 
 export const config = generateConfig(mockActions as any, mockGuards);

--- a/packages/xstate-wallet/src/workflows/tests/application.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/application.test.ts
@@ -81,7 +81,8 @@ describe('Channel setup, JOIN_CHANNEL role', () => {
       fundingStrategy: 'Direct',
       channelId,
       type: 'JOIN_CHANNEL',
-      applicationSite: 'localhost'
+      applicationSite: 'localhost',
+      requestId: 5
     };
 
     const store = new XstateStore();
@@ -107,10 +108,9 @@ describe('Channel setup, JOIN_CHANNEL role', () => {
 
     service.start();
 
-    await waitForExpect(
-      async () => expect(service.state.value).toEqual({joiningChannel: 'joining'}),
-      2000
-    );
+    await waitForExpect(async () => {
+      expect(service.state.value).toEqual({joiningChannel: 'joining'});
+    }, 2000);
 
     const joinEvent: JoinChannelEvent = {
       type: 'JOIN_CHANNEL',


### PR DESCRIPTION
Fixes #1438 .

We weren't assigning the `requestId` as the joiner, which meant that the `JoinChannel` response would not contain an id and thus the `channel-provider` would never resolve the `joinChannel` call.