### PR TITLE
remove global network check, add initial  torrent check

### DIFF
--- a/packages/web3torrent/src/App.tsx
+++ b/packages/web3torrent/src/App.tsx
@@ -1,6 +1,5 @@
 import ConnectionBanner from '@rimble/connection-banner';
-import {Flash} from 'rimble-ui';
-import React, {useState, useContext, useEffect} from 'react';
+import React, {useState, useEffect} from 'react';
 import {Route, Switch, BrowserRouter} from 'react-router-dom';
 import './App.scss';
 import {LayoutFooter, LayoutHeader} from './components/layout';
@@ -9,12 +8,9 @@ import Welcome from './pages/welcome/Welcome';
 import File from './pages/file/File';
 import Upload from './pages/upload/Upload';
 import {RoutePath} from './routes';
-import {Web3TorrentContext} from './clients/web3torrent-client';
-import {TorrentClientCapabilities} from './library/types';
 import {requiredNetwork} from './constants';
 
 const App: React.FC = () => {
-  const Web3Torrent = useContext(Web3TorrentContext);
   const [currentNetwork, setCurrentNetwork] = useState(
     window.ethereum ? Number(window.ethereum.networkVersion) : undefined
   );
@@ -31,16 +27,9 @@ const App: React.FC = () => {
   }, []);
 
   const ready = currentNetwork === requiredNetwork;
-  const showNetworkWarning = Web3Torrent.clientCapability === TorrentClientCapabilities.NOT_CAPABLE;
   return (
     <BrowserRouter>
       <main>
-        {showNetworkWarning && (
-          <Flash variant="danger">
-            Looks like you do not have an internet connection or are behind a firewall. Web3Torrent
-            may not work on some public wifi networks.
-          </Flash>
-        )}
         <ConnectionBanner
           currentNetwork={currentNetwork}
           requiredNetwork={requiredNetwork}

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -17,11 +17,17 @@ export const BUFFER_REFILL_RATE = utils.bigNumberify(WEI_PER_BYTE.mul(BLOCK_LENG
 
 export const INITIAL_SEEDER_BALANCE = utils.bigNumberify(0); // needs to be zero so that depositing works correctly (unidirectional payment channel)
 
-const VERSION_STR = '0.7.2'.replace(/\d*./g, v => `0${Number(v) % 100}`.slice(-2)).slice(0, 4);
+const randomNumberGenerator = (length: number) => {
+  // Programatic way of getting fixed length number, based of https://stackoverflow.com/a/21816636/6569950
+  const base = Math.pow(10, length - 1);
+  return Math.floor(base + Math.random() * 9 * base);
+};
+
 export function generateRandomPeerId() {
-  return Buffer.from(
-    `-WW${VERSION_STR}-` + btoa((Math.random() * 99999999999).toFixed(0).slice(0, 9))
-  ).toString('hex');
+  // based of webtorrent's way of generating random peerId's
+  // https://github.com/webtorrent/webtorrent/blob/ed2809159585d2611dff24a48f25748baf78e8fb/index.js#L52
+  const randomNumber = String(randomNumberGenerator(9));
+  return Buffer.from(`-WW0007-${btoa(randomNumber)}`).toString('hex');
 }
 
 // firebase setup

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -85,13 +85,15 @@ export const preSeededTorrents: Array<Partial<Torrent>> = [
 ];
 
 // Welcome Page Tracker creation options
-export const welcomePageTrackerOpts = {
+export const defaultTrackerOpts = {
   infoHash: [preSeededTorrents[0].infoHash],
   announce: defaultTrackers,
-  peerId: '2d5757303030372d37454e613073307937495630', // random
+  peerId: generateRandomPeerId(), // random
   port: 6881,
   getAnnounceOpts: () => ({
     pseAccount: '0x7F0126D6c4270498b6514Cb934a3274898f68777',
+    // the pseAccount is only used to allow the client on the tracker server, see
+    // https://github.com/statechannels/monorepo/blob/d0c6b1be3a637c88880c0c937d9a6ebc8078799c/packages/web3torrent/tracker/index.js#L16
     uploaded: 0,
     downloaded: 0
   }) // dummy pseAccount, but it works

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -77,7 +77,11 @@ export const welcomePageTrackerOpts = {
   announce: defaultTrackers,
   peerId: '2d5757303030372d37454e613073307937495630', // random
   port: 6881,
-  getAnnounceOpts: () => ({pseAccount: '0x7F0126D6c4270498b6514Cb934a3274898f68777'}) // dummy pseAccount, but it works
+  getAnnounceOpts: () => ({
+    pseAccount: '0x7F0126D6c4270498b6514Cb934a3274898f68777',
+    uploaded: 0,
+    downloaded: 0
+  }) // dummy pseAccount, but it works
 };
 
 export const testTorrent = {

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -17,6 +17,13 @@ export const BUFFER_REFILL_RATE = utils.bigNumberify(WEI_PER_BYTE.mul(BLOCK_LENG
 
 export const INITIAL_SEEDER_BALANCE = utils.bigNumberify(0); // needs to be zero so that depositing works correctly (unidirectional payment channel)
 
+const VERSION_STR = '0.7.2'.replace(/\d*./g, v => `0${Number(v) % 100}`.slice(-2)).slice(0, 4);
+export function generateRandomPeerId() {
+  return Buffer.from(
+    `-WW${VERSION_STR}-` + btoa((Math.random() * 99999999999).toFixed(0).slice(0, 9))
+  ).toString('hex');
+}
+
 // firebase setup
 export const HUB = {
   signingAddress: '0xaaaa84838319627Fa056fC3FC29ab94d479B8502',

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -8,8 +8,7 @@ export enum ClientEvents {
   CLIENT_RESET = 'client_reset',
   TORRENT_DONE = 'torrent_done',
   TORRENT_ERROR = 'torrent_error',
-  TORRENT_NOTICE = 'torrent_notice',
-  CLIENT_CAPABILITY_TEST = 'client_capability_test'
+  TORRENT_NOTICE = 'torrent_notice'
 }
 
 export enum TorrentEvents {
@@ -45,12 +44,6 @@ export type PaidStreamingExtendedHandshake = {
   pseAccount: string;
   outcomeAddress: string;
 };
-
-export enum TorrentClientCapabilities {
-  CAPABLE = 'CAPABLE',
-  NOT_CAPABLE = 'NOT_CAPABLE',
-  NOT_TESTED = 'NOT_TESTED'
-}
 
 export type PaidStreamingWire = Omit<Wire, 'requests'> &
   {
@@ -189,11 +182,6 @@ declare module 'webtorrent' {
         command: PaidStreamingExtensionNotices;
         data: any;
       }) => void
-    ): this;
-
-    on(
-      event: ClientEvents.CLIENT_CAPABILITY_TEST,
-      callback: (status: TorrentClientCapabilities) => void
     ): this;
   }
 

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -19,6 +19,12 @@ export enum TorrentEvents {
   ERROR = 'error'
 }
 
+export enum TorrentTestResult {
+  NO_SEEDERS_FOUND,
+  SEEDERS_FOUND,
+  NO_CONNECTION
+}
+
 export enum WireEvents {
   DOWNLOAD = 'download',
   FIRST_REQUEST = 'first_request',

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -169,7 +169,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     trackerClient.stop();
     trackerClient.destroy();
     if (raceResult) {
-      return TorrentTestResult.SEEDERS_FOUND; // Could connect connect to a peer
+      return TorrentTestResult.SEEDERS_FOUND; // Could connect to a peer
     }
     if (Number.isInteger(completePeers)) {
       // was able to connect to the tracker, but couldn't connect to a peer

--- a/packages/web3torrent/src/pages/file/File.scss
+++ b/packages/web3torrent/src/pages/file/File.scss
@@ -9,6 +9,9 @@ section.fill.download {
     margin: 10px auto;
     font-size: 14px;
   }
+  .warning-wrapper {
+    margin-top: 20px;
+  }
 }
 
 button,

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -14,7 +14,7 @@ import _ from 'lodash';
 import {Flash} from 'rimble-ui';
 import {checkTorrentInTracker} from '../../utils/checkTorrentInTracker';
 
-const checkTorrent = async infoHash => {
+async function checkTorrent(infoHash: string) {
   const testResult = await checkTorrentInTracker(infoHash);
   switch (testResult) {
     case TorrentTestResult.NO_CONNECTION:
@@ -24,7 +24,7 @@ const checkTorrent = async infoHash => {
     default:
       return '';
   }
-};
+}
 
 function getLiveData(
   web3Torrent: WebTorrentPaidStreamingClient,

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -17,7 +17,7 @@ const checkTorrent = async (web3Torrent, infoHash) => {
   const testResult = await web3Torrent.checkTorrentInTracker(infoHash);
   switch (testResult) {
     case TorrentTestResult.NO_CONNECTION:
-      return `Your connection to the tracker may be limited, you might have unexpected functionality`;
+      return 'Your connection to the tracker may be limited, you might have unexpected functionality';
     case TorrentTestResult.NO_SEEDERS_FOUND:
       return "Seems like the torrent doesn't have any seeders. You can give it a try nonetheless.";
     default:

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -21,7 +21,7 @@ const checkTorrent = async (web3Torrent, infoHash) => {
     case TorrentTestResult.NO_SEEDERS_FOUND:
       return `Seems like the torrent doesn't have any seeders. You can give it a try nonetheless.`;
     default:
-      return ``;
+      return '';
   }
 };
 

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -19,7 +19,7 @@ const checkTorrent = async (web3Torrent, infoHash) => {
     case TorrentTestResult.NO_CONNECTION:
       return `Your connection to the tracker may be limited, you might have unexpected functionality`;
     case TorrentTestResult.NO_SEEDERS_FOUND:
-      return `Seems like the torrent doesn't have any seeders. You can give it a try nonetheless.`;
+      return "Seems like the torrent doesn't have any seeders. You can give it a try nonetheless.";
     default:
       return '';
   }

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -12,9 +12,10 @@ import './File.scss';
 import WebTorrentPaidStreamingClient, {TorrentTestResult} from '../../library/web3torrent-lib';
 import _ from 'lodash';
 import {Flash} from 'rimble-ui';
+import {checkTorrentInTracker} from '../../utils/checkTorrentInTracker';
 
-const checkTorrent = async (web3Torrent, infoHash) => {
-  const testResult = await web3Torrent.checkTorrentInTracker(infoHash);
+const checkTorrent = async infoHash => {
+  const testResult = await checkTorrentInTracker(infoHash);
   switch (testResult) {
     case TorrentTestResult.NO_CONNECTION:
       return 'Your connection to the tracker may be limited, you might have unexpected functionality';
@@ -50,15 +51,14 @@ const File: React.FC<Props> = props => {
 
   useEffect(() => {
     const testResult = async () => {
-      const torrentCheckResult = await checkTorrent(web3Torrent, infoHash);
+      const torrentCheckResult = await checkTorrent(infoHash);
       setWarning(torrentCheckResult);
     };
 
     if (infoHash) {
       testResult();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [infoHash]);
 
   useEffect(() => {
     if (torrent.infoHash) {

--- a/packages/web3torrent/src/pages/welcome/Welcome.tsx
+++ b/packages/web3torrent/src/pages/welcome/Welcome.tsx
@@ -3,7 +3,7 @@ import React, {useState, useEffect} from 'react';
 import {useHistory} from 'react-router-dom';
 import {FormButton} from '../../components/form';
 import {ShareList} from '../../components/share-list/ShareList';
-import {preSeededTorrents, welcomePageTrackerOpts} from '../../constants';
+import {preSeededTorrents, defaultTrackerOpts} from '../../constants';
 import {RoutePath} from '../../routes';
 import './Welcome.scss';
 import {Client} from 'bittorrent-tracker';
@@ -16,7 +16,7 @@ interface Props {
 
 const Welcome: React.FC<Props> = props => {
   const history = useHistory();
-  const [trackerClient] = useState(new Client(welcomePageTrackerOpts));
+  const [trackerClient] = useState(new Client(defaultTrackerOpts));
   const [torrents, setTorrents] = useState({
     [preSeededTorrents[0].infoHash]: false
   }); // do not display by default

--- a/packages/web3torrent/src/utils/checkTorrentInTracker.ts
+++ b/packages/web3torrent/src/utils/checkTorrentInTracker.ts
@@ -1,0 +1,33 @@
+import {Client} from 'bittorrent-tracker';
+import {defaultTrackerOpts} from '../constants';
+import {TorrentTestResult} from '../library/types';
+
+export async function checkTorrentInTracker(infoHash: string) {
+  const trackerClient: Client = new Client({
+    ...defaultTrackerOpts,
+    infoHash: [infoHash]
+  });
+  let completePeers;
+  const gotAWire: Promise<boolean> = new Promise(resolve => {
+    const updateIfSeederFound = data => {
+      completePeers = data.complete;
+    };
+    trackerClient.once('peer', function() {
+      resolve(true);
+    });
+    trackerClient.once('update', updateIfSeederFound);
+    trackerClient.start();
+  });
+  const timer: Promise<undefined> = new Promise((resolve, _) => setTimeout(resolve, 5000));
+  const raceResult = await Promise.race([gotAWire, timer]);
+  trackerClient.stop();
+  trackerClient.destroy();
+  if (raceResult) {
+    return TorrentTestResult.SEEDERS_FOUND; // Could connect to a peer
+  }
+  if (Number.isInteger(completePeers)) {
+    // was able to connect to the tracker, but couldn't connect to a peer
+    return TorrentTestResult.NO_SEEDERS_FOUND;
+  }
+  return TorrentTestResult.NO_CONNECTION; // wasn't able to get a response from the tracker
+}


### PR DESCRIPTION
Adds status checks for individual torrents (closes #1423 ) . The status check test consists of a separate tracker client than the one on the web3torrent client. This tracker looks up the torrent on web3torrent's tracker server, with 3 possible results:
- **Seeders found:** the tracker client had responses from the server, and was able to find an active peer. The warning is not shown at all.
- **No seeders found:** the tracker client got responses from the tracker but wasn't able to find an active peer. Might mean that the torrent doesn't have seeders, but it could also mean that the tracker is slow, or the seeder has a slow connection.
- **No connection:** there was no answer at all from the tracker server, which might mean network connections.

_Warnings don't disable any buttons or anything like that._

## Screenshots
![image](https://user-images.githubusercontent.com/10502605/79433834-fda3f900-7fa3-11ea-9908-d23b3f9dd01b.png)


It works for seeders too! (if they can't connect to the tracker)
![Screenshot 2020-04-16 05:36:00](https://user-images.githubusercontent.com/10502605/79434066-3e9c0d80-7fa4-11ea-9d7a-64bd8da5d750.png)
