### PR TITLE
Get integration tests passing

### DIFF
--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -17,13 +17,17 @@ export async function loadDapp(
     // localStorage.debug = "web3torrent:*";
     window.web3 = new Web3("http://localhost:8547");
     window.ethereum = window.web3.currentProvider;
+    
+
     window.ethereum.enable = () => new Promise(r => {
       console.log("[puppeteer] window.ethereum.enable() was called");
-      return r();
-    });
-    web3.eth.getAccounts().then(lst => {
-      web3.eth.defaultAccount = lst[${ganacheAccountIndex}];
-      window.ethereum.selectedAddress = web3.eth.defaultAccount;
+      web3.eth.getAccounts().then(lst => {
+        web3.eth.defaultAccount = lst[${ganacheAccountIndex}];
+        window.ethereum.selectedAddress = web3.eth.defaultAccount;
+        r([window.ethereum.selectedAddress]);
+    });    
+    
+      
     });
     window.ethereum.networkVersion = 9001;
     window.ethereum.on = () => {};
@@ -40,7 +44,6 @@ export async function loadDapp(
     console.log('Page console log: ', msg.text());
   });
 }
-
 // waiting for a css selector, and then clicking that selector is more robust than waiting for
 // an XPath and then calling .click() on the resolved handle. We do not use the return value from the
 // waitForSelector promise, so we avoid any errors where that return value loses its meaning
@@ -68,7 +71,6 @@ export async function waitForAndClickButton(
     throw error;
   }
 }
-
 export async function setUpBrowser(headless: boolean, slowMo?: number): Promise<Browser> {
   const browser = await launch({
     headless,
@@ -115,6 +117,9 @@ export async function withdrawAndWait(page: Page): Promise<void> {
 }
 
 export async function waitAndApproveBudget(page: Page): Promise<void> {
+  console.log('Enabling Ethereum');
+  await waitForAndClickButton(page, page.frames()[1], '#approveEnable');
+
   console.log('Approving budget');
 
   const approveBudgetButton = '.approve-budget-button';

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -117,9 +117,6 @@ export async function withdrawAndWait(page: Page): Promise<void> {
 }
 
 export async function waitAndApproveBudget(page: Page): Promise<void> {
-  console.log('Enabling Ethereum');
-  await waitForAndClickButton(page, page.frames()[1], '#approveEnable');
-
   console.log('Approving budget');
 
   const approveBudgetButton = '.approve-budget-button';

--- a/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
+++ b/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
@@ -2,7 +2,7 @@
 import {Page} from 'puppeteer';
 import * as fs from 'fs';
 
-import {waitAndApproveBudget} from '../helpers';
+import {waitAndApproveBudget, waitForAndClickButton} from '../helpers';
 
 function prepareUploadFile(path: string): void {
   const content = 'web3torrent\n'.repeat(1000000);
@@ -14,7 +14,9 @@ function prepareUploadFile(path: string): void {
     }
   });
 }
-
+export async function enableEthereum(page: Page): Promise<void> {
+  await waitForAndClickButton(page, page.frames()[1], '#approveEnable');
+}
 export async function uploadFile(page: Page, handleBudgetPrompt: boolean): Promise<string> {
   await page.waitForSelector('input[type=file]');
 
@@ -30,6 +32,8 @@ export async function uploadFile(page: Page, handleBudgetPrompt: boolean): Promi
     // eslint-disable-next-line no-undef
     upload.dispatchEvent(new Event('change', {bubbles: true}));
   });
+  console.log('Enabling Ethereum');
+  await enableEthereum(page);
 
   if (handleBudgetPrompt) {
     await waitAndApproveBudget(page);
@@ -51,7 +55,8 @@ export async function startDownload(
   const downloadButton = '#download-button:not([disabled])';
   await page.waitForSelector(downloadButton);
   await page.click(downloadButton);
-
+  console.log('Enabling Ethereum');
+  await enableEthereum(page);
   if (handleBudgetPrompt) {
     await waitAndApproveBudget(page);
   }

--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -232,7 +232,7 @@ export class FakeChain implements Chain {
 export class ChainWatcher implements Chain {
   private _adjudicator?: Contract;
   private _assetHolders: Contract[];
-  public selectedAddress: string | null;
+  public selectedAddress: string | null = null;
 
   public async initialize() {
     const provider = getProvider();

--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -39,7 +39,7 @@ export interface ChannelChainInfo {
 export interface Chain {
   // Properties
   ethereumIsEnabled: boolean;
-  selectedAddress: string | undefined;
+  selectedAddress: string | null;
 
   // Feeds
   chainUpdatedFeed: (channelId: string) => Observable<ChannelChainInfo>;
@@ -232,7 +232,7 @@ export class FakeChain implements Chain {
 export class ChainWatcher implements Chain {
   private _adjudicator?: Contract;
   private _assetHolders: Contract[];
-  public selectedAddress: string | undefined;
+  public selectedAddress: string | null;
 
   public async initialize() {
     const provider = getProvider();

--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -241,6 +241,10 @@ export class ChainWatcher implements Chain {
     this._assetHolders = [new Contract(ETH_ASSET_HOLDER_ADDRESS, EthAssetHolderInterface, signer)]; // TODO allow for other asset holders, for now we use slot 0 only
 
     this._adjudicator = new Contract(NITRO_ADJUDICATOR_ADDRESS, NitroAdjudicatorInterface, signer);
+
+    if (this.ethereumIsEnabled) {
+      this.mySelectedAddress = window.ethereum.selectedAddress;
+    }
   }
 
   public async getBlockNumber() {
@@ -273,6 +277,7 @@ export class ChainWatcher implements Chain {
 
   public get ethereumIsEnabled(): boolean {
     if (window.ethereum) {
+      // window.ethereum.selectedAddress will be null if ethereum has not been enabled
       return !!window.ethereum.selectedAddress;
     } else {
       return false;

--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -232,7 +232,7 @@ export class FakeChain implements Chain {
 export class ChainWatcher implements Chain {
   private _adjudicator?: Contract;
   private _assetHolders: Contract[];
-  public selectedAddress: string | null = null;
+  private mySelectedAddress: string | null;
 
   public async initialize() {
     const provider = getProvider();
@@ -250,7 +250,7 @@ export class ChainWatcher implements Chain {
   public async ethereumEnable(): Promise<string> {
     if (window.ethereum) {
       try {
-        this.selectedAddress = (await window.ethereum.enable())[0];
+        this.mySelectedAddress = (await window.ethereum.enable())[0];
         if (typeof this.selectedAddress === 'string') {
           return this.selectedAddress;
         } else {
@@ -265,6 +265,10 @@ export class ChainWatcher implements Chain {
     } else {
       return Promise.reject('window.ethereum not found');
     }
+  }
+
+  public get selectedAddress(): string | null {
+    return this.mySelectedAddress || null;
   }
 
   public get ethereumIsEnabled(): boolean {

--- a/packages/xstate-wallet/src/ui/enable-ethereum-workflow.tsx
+++ b/packages/xstate-wallet/src/ui/enable-ethereum-workflow.tsx
@@ -22,7 +22,11 @@ export const EnableEthereum = (props: Props) => {
   const currentNetwork = networkVersion && Number(networkVersion);
 
   const metaMaskButton = (disabled, message) => (
-    <MetaMaskButton.Outline disabled={disabled} onClick={() => props.send('USER_APPROVES_ENABLE')}>
+    <MetaMaskButton.Outline
+      id="approveEnable"
+      disabled={disabled}
+      onClick={() => props.send('USER_APPROVES_ENABLE')}
+    >
       {message}
     </MetaMaskButton.Outline>
   );


### PR DESCRIPTION
based on / supersedes #1457

The integration tests were setting up `window.ethereum` and relying on specific wallet behaviour to skip the Enable Ethereum user prompt. When the `EnableEthereum` behavior changed this broke the integration tests.

This PR updates the integration tests to work with the latest changes in `EnableEthereum` and to click thru the enable ethereum prompt.