### PR TITLE
Fix flickering integration test

### DIFF
--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -38,7 +38,7 @@
     "lint:write": "eslint \"**/*.ts\" --fix",
     "precommit": "lint-staged --quiet",
     "puppeteer:dev": "ts-node -O '{\"module\":\"commonjs\",\"noUnusedLocals\":false}' ./puppeteer/scripts/rps.ts",
-    "test": "wait-on http://localhost:3000 http://localhost:3055 && jest",
+    "test": "wait-on http://localhost:3000 http://localhost:3055 && jest --runInBand ",
     "test:show": "HEADLESS=false yarn run test"
   }
 }

--- a/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
+++ b/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
@@ -22,7 +22,7 @@ export async function uploadFile(page: Page, handleBudgetPrompt: boolean): Promi
 
   // Generate a /tmp file with deterministic data for upload testing
   const fileToUpload = `/tmp/web3torrent-tests-stub-${Date.now()}`;
-  console.log(`fileToUpload ${fileToUpload}`);
+
   prepareUploadFile(fileToUpload);
 
   // https://pub.dev/documentation/puppeteer/latest/puppeteer/FileChooser-class.html

--- a/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
+++ b/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
@@ -21,7 +21,7 @@ export async function uploadFile(page: Page, handleBudgetPrompt: boolean): Promi
   await page.waitForSelector('input[type=file]');
 
   // Generate a /tmp file with deterministic data for upload testing
-  const fileToUpload = '/tmp/web3torrent-tests-stub';
+  const fileToUpload = `/tmp/web3torrent-tests-stub-${Date.now()}`;
   prepareUploadFile(fileToUpload);
 
   // https://pub.dev/documentation/puppeteer/latest/puppeteer/FileChooser-class.html

--- a/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
+++ b/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
@@ -22,6 +22,7 @@ export async function uploadFile(page: Page, handleBudgetPrompt: boolean): Promi
 
   // Generate a /tmp file with deterministic data for upload testing
   const fileToUpload = `/tmp/web3torrent-tests-stub-${Date.now()}`;
+  console.log(`fileToUpload ${fileToUpload}`);
   prepareUploadFile(fileToUpload);
 
   // https://pub.dev/documentation/puppeteer/latest/puppeteer/FileChooser-class.html

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -17,6 +17,7 @@ import * as firebase from 'firebase/app';
 import 'firebase/database';
 import debug from 'debug';
 import _ from 'lodash';
+import {bigNumberify} from 'ethers/utils';
 const log = debug('web3torrent:payment-channel');
 const hexZeroPad = utils.hexZeroPad;
 
@@ -24,8 +25,7 @@ function sanitizeMessageForFirebase(message) {
   return JSON.parse(JSON.stringify(message));
 }
 
-const bigNumberify = utils.bigNumberify;
-const FINAL_SETUP_STATE = utils.bigNumberify(3); // for a 2 party ForceMove channel
+const FINAL_SETUP_STATE = bigNumberify(3); // for a 2 party ForceMove channel
 const APP_DATA = constants.HashZero; // unused in the SingleAssetPaymentApp
 export interface ChannelState {
   channelId: string;


### PR DESCRIPTION
Hopefully fixes #1456 🤞 

Adds a timestamp to the file name so the `close-withdraw` test doesn't interact with the `seed-download` test.