### PR TITLE
[web3torrent] torrent type revamp

### DIFF
--- a/packages/web3torrent/src/clients/web3torrent-client.ts
+++ b/packages/web3torrent/src/clients/web3torrent-client.ts
@@ -1,7 +1,7 @@
 import React from 'react';
-import {WebTorrentAddInput, WebTorrentSeedInput} from '../library/types';
+import {WebTorrentAddInput, WebTorrentSeedInput, ExtendedTorrent} from '../library/types';
 import WebTorrentPaidStreamingClient from '../library/web3torrent-lib';
-import {Status, Torrent} from '../types';
+import {Status} from '../types';
 import {paymentChannelClient} from './payment-channel-client';
 import {defaultTrackers} from '../constants';
 
@@ -14,7 +14,7 @@ export const Web3TorrentContext = React.createContext(web3torrent);
 
 export const getTorrentPeers = infoHash => web3torrent.peersList[infoHash];
 
-export const download: (torrent: WebTorrentAddInput) => Promise<Torrent> = torrentData => {
+export const download: (torrent: WebTorrentAddInput) => Promise<ExtendedTorrent> = torrentData => {
   return new Promise(resolve =>
     web3torrent.enable().then(() => {
       web3torrent.add(torrentData, (torrent: any) =>
@@ -24,7 +24,7 @@ export const download: (torrent: WebTorrentAddInput) => Promise<Torrent> = torre
   );
 };
 
-export const upload: (input: WebTorrentSeedInput) => Promise<Torrent> = input => {
+export const upload: (input: WebTorrentSeedInput) => Promise<ExtendedTorrent> = input => {
   return new Promise(resolve =>
     web3torrent.enable().then(() => {
       web3torrent.seed(input, {...torrentNamer(input)}, (torrent: any) => {

--- a/packages/web3torrent/src/components/torrent-info/TorrentInfo.test.tsx
+++ b/packages/web3torrent/src/components/torrent-info/TorrentInfo.test.tsx
@@ -3,8 +3,8 @@ import Adapter from 'enzyme-adapter-react-16';
 import prettier from 'prettier-bytes';
 import React from 'react';
 import {TorrentPeers} from '../../library/types';
-import {Status, Torrent} from '../../types';
-import {createMockTorrent, createMockTorrentPeers} from '../../utils/test-utils';
+import {Status, TorrentUI} from '../../types';
+import {createMockTorrentUI, createMockTorrentPeers} from '../../utils/test-utils';
 import {DownloadInfo, DownloadInfoProps} from './download-info/DownloadInfo';
 import {MagnetLinkButton} from './magnet-link-button/MagnetLinkButton';
 import {TorrentInfo, TorrentInfoProps} from './TorrentInfo';
@@ -15,7 +15,7 @@ Enzyme.configure({adapter: new Adapter()});
 
 type MockTorrentInfo = {
   torrentInfoWrapper: ReactWrapper<TorrentInfoProps>;
-  torrent: Partial<Torrent>;
+  torrent: Partial<TorrentUI>;
   peers: TorrentPeers;
   sectionElement: ReactWrapper;
   fileNameElement: ReactWrapper;
@@ -27,11 +27,11 @@ type MockTorrentInfo = {
   uploadInfoElement: ReactWrapper<UploadInfoProps>;
 };
 
-const mockTorrentInfo = (torrentProps?: Partial<Torrent>): MockTorrentInfo => {
-  const torrent = createMockTorrent(torrentProps);
+const mockTorrentInfo = (torrentProps?: Partial<TorrentUI>): MockTorrentInfo => {
+  const torrent = createMockTorrentUI(torrentProps);
   const peers = createMockTorrentPeers();
   const torrentInfoWrapper = mount(
-    <TorrentInfo torrent={torrent as Torrent} channelCache={{}} mySigningAddress="0x0" />
+    <TorrentInfo torrent={torrent} channelCache={{}} mySigningAddress="0x0" />
   );
 
   return {

--- a/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.stories.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.stories.tsx
@@ -3,7 +3,7 @@ import {boolean, number, optionsKnob, text, withKnobs} from '@storybook/addon-kn
 import {storiesOf} from '@storybook/react';
 import React from 'react';
 import '../../../App.scss';
-import {Status, Torrent} from '../../../types';
+import {Status, TorrentUI} from '../../../types';
 import {DownloadInfo} from './DownloadInfo';
 import './DownloadInfo.scss';
 import {ChannelState} from '../../../clients/payment-channel-client';
@@ -59,7 +59,7 @@ storiesOf('Web3Torrent', module)
               downloaded: 333
             }
           ]
-        } as unknown) as Torrent
+        } as unknown) as TorrentUI
       }
       channelCache={{
         [c1]: {

--- a/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.test.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.test.tsx
@@ -3,8 +3,8 @@ import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
 import {TorrentFile} from 'webtorrent';
 import * as Web3TorrentClient from '../../../clients/web3torrent-client';
-import {Torrent} from '../../../types';
-import {createMockTorrent} from '../../../utils/test-utils';
+import {TorrentUI} from '../../../types';
+import {createMockTorrentUI} from '../../../utils/test-utils';
 import {getFormattedETA} from '../../../utils/torrent-status-checker';
 import {DownloadInfo, DownloadInfoProps} from './DownloadInfo';
 import {ProgressBar, ProgressBarProps} from './progress-bar/ProgressBar';
@@ -13,18 +13,17 @@ Enzyme.configure({adapter: new Adapter()});
 
 type MockDownloadInfo = {
   downloadInfoWrapper: ReactWrapper<DownloadInfoProps>;
-  torrentProps: Partial<Torrent>;
+  torrentProps: Partial<TorrentUI>;
   downloadInfoContainer: ReactWrapper;
   progressBarElement: ReactWrapper<ProgressBarProps>;
   textElement: ReactWrapper;
   cancelButton: ReactWrapper;
 };
 
-const mockDownloadInfo = (torrentProps?: Partial<Torrent>): MockDownloadInfo => {
-  const torrent = createMockTorrent(torrentProps);
-  torrent.parsedTimeRemaining = getFormattedETA(torrent.done, torrent.timeRemaining);
+const mockDownloadInfo = (torrentProps?: Partial<TorrentUI>): MockDownloadInfo => {
+  const torrent = createMockTorrentUI(torrentProps);
   const downloadInfoWrapper = mount(
-    <DownloadInfo torrent={torrent as Torrent} channelCache={{}} mySigningAddress="0x0" />
+    <DownloadInfo torrent={torrent} channelCache={{}} mySigningAddress="0x0" />
   );
 
   return {
@@ -42,7 +41,7 @@ describe('<DownloadInfo />', () => {
 
   beforeEach(() => {
     downloadInfo = mockDownloadInfo({
-      timeRemaining: 3000,
+      parsedTimeRemaining: getFormattedETA(false, 3000),
       numPeers: 3,
       downloadSpeed: 10240,
       uploadSpeed: 5124

--- a/packages/web3torrent/src/components/torrent-info/download-link/DownloadLink.stories.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-link/DownloadLink.stories.tsx
@@ -3,7 +3,7 @@ import {text, withKnobs} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import React from 'react';
 import {TorrentFile} from 'webtorrent';
-import {Torrent} from '../../../types';
+import {TorrentUI} from '../../../types';
 import {DownloadLink} from './DownloadLink';
 
 storiesOf('Web3Torrent', module)
@@ -16,7 +16,7 @@ storiesOf('Web3Torrent', module)
           name: text('File name', 'Once-Upon-A-Time.zip'),
           done: true,
           files: [({getBlobURL: resolve => resolve(null, 'blob')} as unknown) as TorrentFile]
-        } as Torrent
+        } as TorrentUI
       }
     ></DownloadLink>
   ));

--- a/packages/web3torrent/src/components/torrent-info/download-link/DownloadLink.test.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-link/DownloadLink.test.tsx
@@ -3,13 +3,13 @@ import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
 import {act} from 'react-dom/test-utils';
 import {TorrentFile} from 'webtorrent';
-import {createMockTorrent} from '../../../utils/test-utils';
+import {createMockTorrentUI} from '../../../utils/test-utils';
 import {DownloadLink} from './DownloadLink';
 import {mockMetamask} from '../../../library/testing/test-utils';
 
 Enzyme.configure({adapter: new Adapter()});
 
-const mockTorrent = createMockTorrent({
+const mockTorrent = createMockTorrentUI({
   downloaded: 128913,
   done: true,
   files: [({getBlobURL: resolve => resolve(null, 'blob')} as unknown) as TorrentFile]
@@ -21,7 +21,7 @@ describe('<DownloadLink />', () => {
   beforeAll(() => {
     mockMetamask();
     document.execCommand = jest.fn(() => true);
-    component = mount(<DownloadLink torrent={createMockTorrent()} />);
+    component = mount(<DownloadLink torrent={createMockTorrentUI()} />);
   });
 
   it('by default should be hidden', () => {

--- a/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.stories.tsx
+++ b/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.stories.tsx
@@ -3,7 +3,7 @@ import {withKnobs} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import React from 'react';
 import '../../../App.scss';
-import {Torrent} from '../../../types';
+import {TorrentUI} from '../../../types';
 import {UploadInfo} from './UploadInfo';
 import './UploadInfo.scss';
 import {ChannelState} from '../../../clients/payment-channel-client';
@@ -41,7 +41,7 @@ storiesOf('Web3Torrent', module)
               uploaded: 333
             }
           ]
-        } as unknown) as Torrent
+        } as unknown) as TorrentUI
       }
       channelCache={{
         [c1]: {

--- a/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.test.tsx
+++ b/packages/web3torrent/src/components/torrent-info/upload-info/UploadInfo.test.tsx
@@ -2,14 +2,14 @@ import Enzyme, {mount, ReactWrapper} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
 import {TorrentPeers} from '../../../library/types';
-import {Torrent} from '../../../types';
-import {createMockTorrent, createMockTorrentPeers, testSelector} from '../../../utils/test-utils';
+import {TorrentUI} from '../../../types';
+import {createMockTorrentUI, createMockTorrentPeers, testSelector} from '../../../utils/test-utils';
 import {UploadInfo, UploadInfoProps} from './UploadInfo';
 
 Enzyme.configure({adapter: new Adapter()});
 
 type MockUploadInfo = {
-  torrent: Partial<Torrent>;
+  torrent: Partial<TorrentUI>;
   peers: TorrentPeers;
   uploadInfoWrapper: ReactWrapper<UploadInfoProps>;
   uploadingSectionElement: ReactWrapper;
@@ -18,10 +18,10 @@ type MockUploadInfo = {
 
 const mockUploadInfo = (noPeers = false): MockUploadInfo => {
   const peers = noPeers ? {} : createMockTorrentPeers();
-  const torrent = createMockTorrent({
+  const torrent = createMockTorrentUI({
     numPeers: Object.keys(peers).length,
     originalSeed: true
-  }) as Torrent;
+  });
 
   const uploadInfoWrapper = mount(
     <UploadInfo torrent={torrent} channelCache={{}} mySigningAddress="0x0" />

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -1,4 +1,4 @@
-import {Status, Torrent, TorrentUI} from './types';
+import {Status, TorrentUI} from './types';
 import {ChannelState} from './clients/payment-channel-client';
 import {utils} from 'ethers';
 
@@ -54,22 +54,6 @@ export const defaultTrackers = [
 ];
 
 export const requiredNetwork = Number(process.env.REACT_APP_CHAIN_NETWORK_ID);
-
-// Default Torrent Data
-export const EmptyTorrent = ({
-  name: 'unknown',
-  magnetURI: '',
-  infoHash: '',
-  length: 0,
-  done: false,
-  ready: false,
-  downloadSpeed: 0,
-  uploadSpeed: 0,
-  status: Status.Idle,
-  downloaded: 0,
-  files: [],
-  wires: []
-} as unknown) as Torrent;
 
 export const EmptyTorrentUI: TorrentUI = {
   files: [],

--- a/packages/web3torrent/src/pages/file/File.test.tsx
+++ b/packages/web3torrent/src/pages/file/File.test.tsx
@@ -3,13 +3,13 @@ import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
 import {act} from 'react-dom/test-utils';
 import {MemoryRouter as Router} from 'react-router-dom';
-import {EmptyTorrent} from '../../constants';
-import {WebTorrentAddInput} from '../../library/types';
-import {Status, Torrent, TorrentStaticData} from '../../types';
-import {testSelector} from '../../utils/test-utils';
+import {WebTorrentAddInput, ExtendedTorrent} from '../../library/types';
+import {TorrentStaticData} from '../../types';
+import {testSelector, createMockExtendedTorrent, createMockTorrentUI} from '../../utils/test-utils';
 import * as TorrentStatus from '../../utils/torrent-status-checker';
 import * as Web3TorrentClient from './../../clients/web3torrent-client';
 import File from './File';
+import WebTorrentPaidStreamingClient from '../../library/web3torrent-lib';
 
 Enzyme.configure({adapter: new Adapter()});
 
@@ -17,12 +17,12 @@ jest.mock('@statechannels/channel-client');
 
 describe('<File />', () => {
   let component: Enzyme.ReactWrapper;
-  let torrentFile: jest.SpyInstance<Promise<Torrent>, [WebTorrentAddInput]>;
+  let torrentFile: jest.SpyInstance<Promise<ExtendedTorrent>, [WebTorrentAddInput]>;
 
   beforeEach(() => {
     torrentFile = jest
       .spyOn(Web3TorrentClient, 'download')
-      .mockImplementation(_pD => Promise.resolve({...EmptyTorrent, status: Status.Connecting}));
+      .mockImplementation(_pD => Promise.resolve(createMockExtendedTorrent()));
 
     component = mount(
       <Router>
@@ -53,7 +53,9 @@ describe('<File />', () => {
   it('should run checker function if the File Button is clicked', async () => {
     const torrentStatusChecker = jest
       .spyOn(TorrentStatus, 'getTorrentUI')
-      .mockImplementation((_w3t: any, _staticData: TorrentStaticData) => EmptyTorrent);
+      .mockImplementation((_w3t: WebTorrentPaidStreamingClient, _staticData: TorrentStaticData) =>
+        createMockTorrentUI()
+      );
 
     await act(async () => {
       await component.find(testSelector('download-button')).simulate('click');

--- a/packages/web3torrent/src/pages/upload/Upload.test.tsx
+++ b/packages/web3torrent/src/pages/upload/Upload.test.tsx
@@ -3,19 +3,19 @@ import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
 import {act} from 'react-dom/test-utils';
 import {MemoryRouter as Router} from 'react-router-dom';
-import {WebTorrentSeedInput} from '../../library/types';
-import {Status, Torrent} from '../../types';
+import {WebTorrentSeedInput, ExtendedTorrent} from '../../library/types';
+import {Status} from '../../types';
 import * as Web3TorrentClient from './../../clients/web3torrent-client';
 import Upload from './Upload';
 import {mockMetamask} from '../../library/testing/test-utils';
-import {createMockTorrent} from '../../utils/test-utils';
+import {createMockExtendedTorrent} from '../../utils/test-utils';
 Enzyme.configure({adapter: new Adapter()});
-const mockTorrent = createMockTorrent();
+
+const mockTorrent = createMockExtendedTorrent();
 
 describe('<Upload />', () => {
   let component: Enzyme.ReactWrapper;
-  let torrentUpload: jest.SpyInstance<Promise<Torrent>, [WebTorrentSeedInput]>;
-  createMockTorrent;
+  let torrentUpload: jest.SpyInstance<Promise<ExtendedTorrent>, [WebTorrentSeedInput]>;
   beforeAll(() => {
     mockMetamask();
   });

--- a/packages/web3torrent/src/pages/upload/Upload.tsx
+++ b/packages/web3torrent/src/pages/upload/Upload.tsx
@@ -26,7 +26,8 @@ const Upload: React.FC<{ready: boolean}> = ({ready}) => {
           onChange={async event => {
             if (event.target.files && event.target.files[0]) {
               setSpinner(true);
-              history.push(generateURL(await upload(event.target.files)));
+              const {infoHash, length, name} = await upload(event.target.files);
+              history.push(generateURL({infoHash, length, name}));
             }
           }}
         ></input>

--- a/packages/web3torrent/src/types.ts
+++ b/packages/web3torrent/src/types.ts
@@ -18,15 +18,8 @@ export const DownloadingStatuses = [
 export const UploadingStatuses = [Status.Seeding];
 export const IdleStatuses = [Status.Idle, Status.Completed];
 
-export type Torrent = ExtendedTorrent & {
-  parsedTimeRemaining?: string;
-  numSeeds?: number;
-  status: Status;
-  originalSeed?: boolean;
-};
-
 export type TorrentUI = Pick<
-  Torrent,
+  ExtendedTorrent,
   | 'files'
   | 'done'
   | 'downloaded'
@@ -36,15 +29,16 @@ export type TorrentUI = Pick<
   | 'magnetURI'
   | 'name'
   | 'numPeers'
-  | 'originalSeed'
-  | 'parsedTimeRemaining'
   | 'paused'
   | 'ready'
-  | 'status'
   | 'uploaded'
   | 'uploadSpeed'
   | 'wires'
->;
+> & {
+  originalSeed?: boolean;
+  parsedTimeRemaining?: string;
+  status: Status;
+};
 
 export interface TorrentStaticData {
   infoHash: string;

--- a/packages/web3torrent/src/utils/test-utils.ts
+++ b/packages/web3torrent/src/utils/test-utils.ts
@@ -1,15 +1,32 @@
-import {EmptyTorrent} from '../constants';
-import {TorrentPeers} from '../library/types';
-import {Torrent} from '../types';
+import {TorrentPeers, ExtendedTorrent} from '../library/types';
+import {TorrentUI} from '../types';
+import {EmptyTorrentUI} from '../constants';
 
 export const infoHash = '0303b8f867f4377ef4a25eba8836cc5f7fdd992b';
+export const pseAccount = 'pse123';
 
 export function testSelector(name: string): string {
   return `[data-test-selector='${name}']`;
 }
-export function createMockTorrent(props?: Partial<Torrent>): Torrent {
+
+export function createMockExtendedTorrent(props?: Partial<ExtendedTorrent>): ExtendedTorrent {
   return {
-    ...EmptyTorrent,
+    ...EmptyTorrentUI,
+    createdBy: pseAccount,
+    infoHash,
+    magnetURI:
+      'magnet:?xt=urn%3Abtih%3A0303b8f867f4377ef4a25eba8836cc5f7fdd992b&dn=on-the-shortness-of-life-1.jpg&xl=128864&cost=0',
+    name: 'on-the-shortness-of-life-1.jpg',
+    downloaded: 0,
+    length: 128913,
+    ready: true,
+    ...props
+  } as ExtendedTorrent;
+}
+
+export function createMockTorrentUI(props?: Partial<TorrentUI>): TorrentUI {
+  return {
+    ...EmptyTorrentUI,
     infoHash,
     magnetURI:
       'magnet:?xt=urn%3Abtih%3A0303b8f867f4377ef4a25eba8836cc5f7fdd992b&dn=on-the-shortness-of-life-1.jpg&xl=128864&cost=0',

--- a/packages/web3torrent/src/utils/url.test.ts
+++ b/packages/web3torrent/src/utils/url.test.ts
@@ -1,9 +1,9 @@
 import {RoutePath} from '../routes';
 import {generateURL} from './url';
-import {createMockTorrent} from './test-utils';
+import {createMockTorrentUI} from './test-utils';
 import {getStaticTorrentUI} from '../constants';
 
-const mockTorrent = createMockTorrent();
+const mockTorrent = createMockTorrentUI();
 const mockOptionalParams = ({name, xl}) =>
   new URLSearchParams(
     `?${name !== undefined ? 'name=' + name : ''}` + `${xl !== undefined ? '&length=' + xl : ''}`

--- a/packages/web3torrent/src/utils/url.ts
+++ b/packages/web3torrent/src/utils/url.ts
@@ -1,6 +1,6 @@
 import {RoutePath} from '../routes';
-import {TorrentUI} from '../types';
 import {useLocation} from 'react-router-dom';
+import {ExtendedTorrent} from '../library/types';
 
 /**
  * Custom Hook that retrieves the queryParams of the URL.
@@ -12,6 +12,10 @@ export const useQuery = () => {
   return new URLSearchParams(useLocation().search);
 };
 
-export function generateURL({infoHash, length, name}: TorrentUI): string {
+export function generateURL({
+  infoHash,
+  length,
+  name
+}: Pick<ExtendedTorrent, 'infoHash' | 'length' | 'name'>): string {
   return `${RoutePath.File}${infoHash}?name=${encodeURIComponent(name)}&length=${length}`;
 }


### PR DESCRIPTION
There are currently 4 Typescript types for torrent objects:
- `Webtorrent.Torrent` from the WebTorrent project.
- `ExtendedTorrent` used in web3torrent for additional information for the web3 extension to webtorrent.
- `Torrent` that extends `ExtendedTorrent` with `parsedTimeRemaining`, `numSeeds`, `status`, and `originalSeed` fields.
- `TorrentUI` that is used to populate React components.

I propose removing the `Torrent` type for the following reasons:
- `parsedTimeRemaining` is derived from `WebTorrent.Torrent`'s `timeRemaining` and `done`, so it does not need to be stored.
- `orginalSeed` is derived from `done` and the web3torrent client `pseAccount`, so it does not need to be stored. Same logic applies for `status`.
- `numSeeds` doesn't appear to be used anywhere in the project.

Going forward, I propose avoiding type assertions (aka the `as` keyword) unless this is not possible. This PR removes type assertions for the 3 torrent interfaces (`Webtorrent.Torrent`, `ExtendedTorrent`,  `TorrentUI`) described above in non-test logic.
