### PR TITLE
fix tracker check, add logs

### DIFF
--- a/packages/web3torrent/src/utils/checkTorrentInTracker.ts
+++ b/packages/web3torrent/src/utils/checkTorrentInTracker.ts
@@ -5,7 +5,7 @@ import debug from 'debug';
 const log = debug('web3torrent:tracker-check');
 
 export async function checkTorrentInTracker(infoHash: string) {
-  log(`Scrapping tracker for torrent ${infoHash}`);
+  log(`Scraping tracker for torrent ${infoHash}`);
   const trackerClient: Client = new Client({
     ...defaultTrackerOpts,
     infoHash: [infoHash]

--- a/packages/web3torrent/src/utils/checkTorrentInTracker.ts
+++ b/packages/web3torrent/src/utils/checkTorrentInTracker.ts
@@ -1,33 +1,33 @@
 import {Client} from 'bittorrent-tracker';
 import {defaultTrackerOpts} from '../constants';
 import {TorrentTestResult} from '../library/types';
+import debug from 'debug';
+const log = debug('web3torrent:tracker-check');
 
 export async function checkTorrentInTracker(infoHash: string) {
+  log(`Scrapping tracker for torrent ${infoHash}`);
   const trackerClient: Client = new Client({
     ...defaultTrackerOpts,
     infoHash: [infoHash]
   });
-  let completePeers;
-  const gotAWire: Promise<boolean> = new Promise(resolve => {
-    const updateIfSeederFound = data => {
-      completePeers = data.complete;
-    };
-    trackerClient.once('peer', function() {
-      resolve(true);
-    });
-    trackerClient.once('update', updateIfSeederFound);
-    trackerClient.start();
+  const trackerScrape: Promise<number> = new Promise(resolve => {
+    trackerClient.once('scrape', data => resolve(data.complete));
+    setTimeout(() => trackerClient.scrape(), 2500); // waits ~2 seconds as that's the tracker update tick
   });
   const timer: Promise<undefined> = new Promise((resolve, _) => setTimeout(resolve, 5000));
-  const raceResult = await Promise.race([gotAWire, timer]);
-  trackerClient.stop();
-  trackerClient.destroy();
-  if (raceResult) {
-    return TorrentTestResult.SEEDERS_FOUND; // Could connect to a peer
+
+  const raceResult = await Promise.race([trackerScrape, timer]);
+  trackerClient.stop(); // cleanup
+  trackerClient.destroy(); // cleanup
+
+  if (Number.isInteger(raceResult)) {
+    if (raceResult > 0) {
+      log(`Test Result: SEEDERS_FOUND (${raceResult})`);
+      return TorrentTestResult.SEEDERS_FOUND; // Found seeders (peers with the complete torrent)
+    }
+    log('Test Result: NO_SEEDERS_FOUND');
+    return TorrentTestResult.NO_SEEDERS_FOUND; // was able to connect, but no seeders found
   }
-  if (Number.isInteger(completePeers)) {
-    // was able to connect to the tracker, but couldn't connect to a peer
-    return TorrentTestResult.NO_SEEDERS_FOUND;
-  }
+  log('Test Result: NO_CONNECTION');
   return TorrentTestResult.NO_CONNECTION; // wasn't able to get a response from the tracker
 }


### PR DESCRIPTION
should fix #1472 
To understand the change of this PR, taking a look at the [bittorrent-tracker docs](https://github.com/webtorrent/bittorrent-tracker#client) its advisable.

The previous implementation of the check was a deeper emulation of the web torrent's tracker client behaviour, but it seems that emulating that and suddenly stopping and destroying the tracker client is problematic.

So basically, what this does, is that the [tracker client waits for a couple of seconds](https://github.com/statechannels/monorepo/compare/sp/tracker-check-fix?expand=1#diff-54c06577239cf26700fa05ec63e79884R15), and then scraps the tracker server for information. This way, the tracker server gives us a more accurate response. The implementation gets simpler too.

I also added some logs for the test so it gets easier to see in the CI.