### PR TITLE
Channel update callbacks

### DIFF
--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -249,7 +249,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
       }
     });
 
-    this.paymentChannelClient.onChannelUpdated(async (channelState: ChannelState) => {
+    this.paymentChannelClient.onChannelStateReceived(async (channelState: ChannelState) => {
       if (
         channelState.channelId === wire.paidStreamingExtension.pseChannelId ||
         channelState.channelId === wire.paidStreamingExtension.peerChannelId


### PR DESCRIPTION
Ensure that onChannelStateReceived callbacks happen after channelCache is updated

And, log the channel result and converted channel state, to help debug a
flickering integration test.