### PR TITLE
W3T torrent check refactor

### DIFF
--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -11,7 +11,7 @@ import './File.scss';
 import {TorrentTestResult} from '../../library/web3torrent-lib';
 import _ from 'lodash';
 import {Flash} from 'rimble-ui';
-import {checkTorrentInTracker} from '../../utils/checkTorrentInTracker';
+import {checkTorrentInTracker} from '../../utils/check-torrent-in-tracker';
 import {getUserFriendlyError} from '../../utils/error';
 
 async function checkTorrent(infoHash: string) {

--- a/packages/web3torrent/src/utils/check-torrent-in-tracker.ts
+++ b/packages/web3torrent/src/utils/check-torrent-in-tracker.ts
@@ -4,7 +4,7 @@ import {TorrentTestResult} from '../library/types';
 import {logger} from '../logger';
 const log = logger.child({module: 'tracker-check'});
 
-export async function checkTorrentInTracker(infoHash: string) {
+export async function checkTorrentInTracker(infoHash: string): Promise<TorrentTestResult> {
   log.info(`Scraping tracker for torrent ${infoHash}`);
 
   const client = new Client({...defaultTrackerOpts, infoHash: [infoHash]});
@@ -13,6 +13,7 @@ export async function checkTorrentInTracker(infoHash: string) {
     setTimeout(() => client.scrape(), 2500); // waits ~2 seconds as that's the tracker update tick
     setTimeout(() => resolve(-1), 5000); // returns -1 if there was no answer from the tracker(s) for ~2.5 seconds
   });
+
   const scrapeResult = await trackerScrape;
   client.stop();
   client.destroy();

--- a/packages/web3torrent/src/utils/checkTorrentInTracker.ts
+++ b/packages/web3torrent/src/utils/checkTorrentInTracker.ts
@@ -7,18 +7,15 @@ const log = logger.child({module: 'tracker-check'});
 export async function checkTorrentInTracker(infoHash: string) {
   log.info(`Scraping tracker for torrent ${infoHash}`);
 
-  const trackerClient: Client = new Client({
-    ...defaultTrackerOpts,
-    infoHash: [infoHash]
-  });
+  const client = new Client({...defaultTrackerOpts, infoHash: [infoHash]});
   const trackerScrape: Promise<number> = new Promise(resolve => {
-    trackerClient.once('scrape', data => resolve(data.complete));
-    setTimeout(() => trackerClient.scrape(), 2500); // waits ~2 seconds as that's the tracker update tick
+    client.once('scrape', data => resolve(data.complete));
+    setTimeout(() => client.scrape(), 2500); // waits ~2 seconds as that's the tracker update tick
     setTimeout(() => resolve(-1), 5000); // returns -1 if there was no answer from the tracker(s) for ~2.5 seconds
   });
   const scrapeResult = await trackerScrape;
-  trackerClient.stop();
-  trackerClient.destroy();
+  client.stop();
+  client.destroy();
 
   if (scrapeResult > 0) {
     log.info(`Test Result: SEEDERS_FOUND (${scrapeResult})`);

--- a/packages/web3torrent/src/utils/checkTorrentInTracker.ts
+++ b/packages/web3torrent/src/utils/checkTorrentInTracker.ts
@@ -11,7 +11,7 @@ export async function checkTorrentInTracker(infoHash: string) {
     ...defaultTrackerOpts,
     infoHash: [infoHash]
   });
-  const trackerScrape: Promise<number> = new Promise((resolve, reject) => {
+  const trackerScrape: Promise<number> = new Promise(resolve => {
     trackerClient.once('scrape', data => resolve(data.complete));
     setTimeout(() => trackerClient.scrape(), 2500); // waits ~2 seconds as that's the tracker update tick
     setTimeout(() => resolve(-1), 5000); // returns -1 if there was no answer from the tracker(s) for ~2.5 seconds


### PR DESCRIPTION
This PR adds support for the Pino logs that @andrewgordstewart implemented last week, and reactors the checkTorrentInTracker function so that it becomes more readable.

I tried removing the entire logic behind the previous _timer_ promise, but as the tracker client is event-based, the clean up after running the function because there's a lot of possible results and you end up repeating code. 
I think that it's better to clean the function and just remove the promise race while maintaining the timer logic.