### PR TITLE
Dump store to logs in circle

### DIFF
--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -705,13 +705,6 @@
       ],
       "type": "object"
     },
-    "ErrorCode": {
-      "enum": [
-        200,
-        100
-      ],
-      "type": "number"
-    },
     "ErrorResponse": {
       "anyOf": [
         {

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -111,7 +111,7 @@ export class ChannelWallet {
         this.getWorkflow(this.calculateWorkflowId(request)).service.send(request);
         break;
       case 'APPROVE_BUDGET_AND_FUND': {
-        const workflow = this.startWorkflow(
+        this.startWorkflow(
           ApproveBudgetAndFund.machine(this.store, this.messagingService, {
             player: request.player,
             hub: request.hub,
@@ -122,7 +122,6 @@ export class ChannelWallet {
           true // devtools
         );
 
-        workflow.service.send(request);
         break;
       }
       case 'CLOSE_AND_WITHDRAW': {

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -14,7 +14,7 @@ import {ApproveBudgetAndFund, CloseLedgerAndWithdraw, Application} from './workf
 import {ethereumEnableWorkflow} from './workflows/ethereum-enable';
 import {AppRequestEvent} from './event-types';
 import {serializeChannelEntry} from './serde/app-messages/serialize';
-import {ADD_LOGS} from './constants';
+import {ADD_LOGS, IS_PRODUCTION} from './constants';
 import {logger} from './logger';
 
 export interface Workflow {
@@ -152,6 +152,9 @@ export class ChannelWallet {
     const service = interpret(machine, {devTools})
       .onTransition((state, event) => ADD_LOGS && logTransition(state, event, workflowId))
       .onDone(() => (this.workflows = this.workflows.filter(w => w.id !== workflowId)))
+      .onStop(async () => {
+        if (!IS_PRODUCTION) logger.info({store: await this.store.dumpBackend()});
+      })
       .start();
     // TODO: Figure out how to resolve rendering priorities
     this.renderUI(service);

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -158,7 +158,7 @@ export class ChannelWallet {
       )
       .onDone(() => (this.workflows = this.workflows.filter(w => w.id !== workflowId)))
       .onStop(
-        async () =>
+        () =>
           service.state.value === 'done' ||
           logger.error('Service finished prematurely in %s', service.state.value)
       )

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -154,6 +154,9 @@ export class ChannelWallet {
       .onDone(() => (this.workflows = this.workflows.filter(w => w.id !== workflowId)))
       .onStop(async () => {
         if (!IS_PRODUCTION) logger.info({store: await this.store.dumpBackend()});
+        if (service.state.value !== 'done') {
+          logger.error('Service finished prematurely in %s', service.state.value);
+        }
       })
       .start();
     // TODO: Figure out how to resolve rendering priorities

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -145,11 +145,11 @@ export class ChannelWallet {
       }
     }
   }
-  private startWorkflow(machineConfig: any, workflowId: string, devTools = false): Workflow {
+  private startWorkflow(machine: any, workflowId: string, devTools = false): Workflow {
     if (this.isWorkflowIdInUse(workflowId)) {
       throw new Error(`There is already a workflow running with id ${workflowId}`);
     }
-    const service = interpret(machineConfig, {devTools})
+    const service = interpret(machine, {devTools})
       .onTransition((state, event) => ADD_LOGS && logTransition(state, event, workflowId))
       .onDone(() => (this.workflows = this.workflows.filter(w => w.id !== workflowId)))
       .start();

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -153,7 +153,9 @@ export class ChannelWallet {
       .onTransition((state, event) => ADD_LOGS && logTransition(state, event, workflowId))
       .onDone(() => (this.workflows = this.workflows.filter(w => w.id !== workflowId)))
       .onStop(async () => {
-        if (!IS_PRODUCTION) logger.info({store: await this.store.dumpBackend()});
+        if (!IS_PRODUCTION) {
+          logger.info({workflowId, store: await this.store.dumpBackend()}, 'Done workflow');
+        }
         if (service.state.value !== 'done') {
           logger.error('Service finished prematurely in %s', service.state.value);
         }

--- a/packages/xstate-wallet/src/constants.ts
+++ b/packages/xstate-wallet/src/constants.ts
@@ -59,3 +59,6 @@ export const USE_INDEXED_DB = getBool(process.env.USE_INDEXED_DB);
 
 export const LOG_DESTINATION = process.env.LOG_DESTINATION;
 export const ADD_LOGS = !!LOG_DESTINATION;
+
+export const IS_PRODUCTION =
+  process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'prod';

--- a/packages/xstate-wallet/src/integration-tests/funding.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/funding.test.ts
@@ -57,7 +57,6 @@ it('allows for two wallets to fund an app', async () => {
   expect(playerB.channelWallet.getWorkflow(expectedId).id).toEqual(expectedId);
 
   playerB.channelWallet.pushMessage(generateJoinChannelRequest(channelId), 'localhost');
-  playerB.channelWallet.workflows[0].service.send({type: 'USER_APPROVES'});
 
   await Promise.all(
     [playerA, playerB].map(player =>

--- a/packages/xstate-wallet/src/store/memory-backend.ts
+++ b/packages/xstate-wallet/src/store/memory-backend.ts
@@ -21,6 +21,11 @@ export class MemoryBackend implements DBBackend {
       this._budgets = {};
     }
   }
+
+  public async dump(): Promise<object> {
+    throw 'Unimplemented'; // I don't think we need this
+  }
+
   // Generic Getters
 
   public async privateKeys() {

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -123,6 +123,7 @@ export interface Store {
   chain: Chain;
 
   initialize(privateKeys?: string[], cleanSlate?: boolean): Promise<void>;
+  dumpBackend(): Promise<object>;
 }
 
 export type ChannelLock = {
@@ -552,6 +553,10 @@ export class XstateStore implements Store {
         console.error(e);
         throw e;
       });
+  }
+
+  public async dumpBackend() {
+    return await this.backend.dump();
   }
 }
 

--- a/packages/xstate-wallet/src/store/types.ts
+++ b/packages/xstate-wallet/src/store/types.ts
@@ -170,4 +170,6 @@ export interface DBBackend {
   setObjective(key: number, value: Objective): Promise<Objective>;
   getObjective(key: number): Promise<Objective | undefined>;
   setReplaceObjectives(values: Objective[]): Promise<Objective[]>;
+
+  dump(): Promise<object>;
 }

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -33,6 +33,7 @@ import {
 import {FundingStrategy} from '@statechannels/client-api-schema';
 import _ from 'lodash';
 import {serializeChannelEntry} from '../serde/app-messages/serialize';
+import {IS_PRODUCTION} from '../constants';
 
 export interface WorkflowContext {
   applicationSite: string;
@@ -121,6 +122,7 @@ const generateConfig = (
   actions: WorkflowActions,
   guards: WorkflowGuards
 ): MachineConfig<WorkflowContext, WorkflowStateSchema, WorkflowEvent> => ({
+  strict: !IS_PRODUCTION,
   id: 'application-workflow',
   initial: 'joiningChannel',
   on: {CHANNEL_UPDATED: {actions: [actions.sendChannelUpdatedNotification]}},

--- a/packages/xstate-wallet/src/workflows/approve-budget-and-fund.ts
+++ b/packages/xstate-wallet/src/workflows/approve-budget-and-fund.ts
@@ -13,7 +13,7 @@ import {SiteBudget, Participant, SimpleAllocation, AssetBudget} from '../store/t
 import _ from 'lodash';
 import {BigNumber, bigNumberify} from 'ethers/utils';
 import {Store, State as ChannelState} from '../store';
-import {CHALLENGE_DURATION, ETH_ASSET_HOLDER_ADDRESS} from '../constants';
+import {CHALLENGE_DURATION, ETH_ASSET_HOLDER_ADDRESS, IS_PRODUCTION} from '../constants';
 import {
   checkThat,
   exists,
@@ -22,6 +22,7 @@ import {
   hideUI,
   displayUI
 } from '../utils';
+
 import {MessagingServiceInterface} from '../messaging';
 import {serializeSiteBudget} from '../serde/app-messages/serialize';
 import {filter, map, first} from 'rxjs/operators';
@@ -108,6 +109,7 @@ export const machine = (
   context: Initial
 ): StateMachine<Context, Schema, Event, Typestate> =>
   createMachine<Context, Event, Typestate>({
+    strict: !IS_PRODUCTION,
     id: 'approve-budget-and-fund',
     context,
     initial: 'waitForUserApproval',

--- a/packages/xstate-wallet/src/workflows/approve-budget-and-fund.ts
+++ b/packages/xstate-wallet/src/workflows/approve-budget-and-fund.ts
@@ -206,8 +206,7 @@ interface LedgerInitRetVal {
 const createBudgetAndLedger = (store: Store) => async (
   context: Initial
 ): Promise<LedgerInitRetVal> => {
-  // create budget
-  store.createBudget(context.budget);
+  await store.createBudget(context.budget);
 
   // create ledger
   const initialOutcome = convertPendingBudgetToAllocation(context);

--- a/packages/xstate-wallet/src/workflows/create-and-fund.ts
+++ b/packages/xstate-wallet/src/workflows/create-and-fund.ts
@@ -21,7 +21,7 @@ import {
 import {Store} from '../store';
 
 import {SupportState, VirtualFundingAsLeaf, Depositing} from '.';
-import {CHALLENGE_DURATION, HUB, ETH_ASSET_HOLDER_ADDRESS} from '../constants';
+import {CHALLENGE_DURATION, HUB, ETH_ASSET_HOLDER_ADDRESS, IS_PRODUCTION} from '../constants';
 import {bigNumberify} from 'ethers/utils';
 
 const PROTOCOL = 'create-and-fund';
@@ -137,6 +137,7 @@ const postFundSetup = getDataAndInvoke<Init, Service>(
 );
 
 export const config: MachineConfig<Init, any, any> = {
+  strict: !IS_PRODUCTION,
   key: PROTOCOL,
   initial: 'preFundSetup',
 


### PR DESCRIPTION
Aiming to reproduce https://github.com/statechannels/monorepo/issues/1478, I wrote code to dump the store on command.

While I attempt to [reproduce the issue on circle](https://github.com/statechannels/monorepo/commit/7d109642599dd77f8aeab3a946ff53ea7f4dc5a2) (I have been unable to locally) I think this code will be useful in `master`.

```
❯ cat seed-download.e2e.log | grep '"store":' | jq .store.ledgers
{}
{
  "firebase:simple-hub": "0x3d59eb841d26f1e7c5be21c1043bc3902b6b991581c22982772f2511c419b274"
}
{}
{
  "firebase:simple-hub": "0x71ea10595d1bbee25a7cb4c3b2cdf89752cb9ad0e47a86df22050e617256d32c"
}
```

[This artifact](https://19680-209829093-gh.circle-artifacts.com/0/tmp/seed-download.pino.log) is still under 1MB, so it does not seem to generate very large logs