### PR TITLE
W3T Start-storybook fix

### DIFF
--- a/packages/web3torrent/.storybook/web3torrent-client.mock.js
+++ b/packages/web3torrent/.storybook/web3torrent-client.mock.js
@@ -16,4 +16,4 @@ const web3Torrent = mockWeb3TorrentClient();
 
 const Web3TorrentContext = React.createContext(web3Torrent);
 
-module.exports = {Web3TorrentContext,web3Torrent};
+module.exports = {Web3TorrentContext, web3Torrent};

--- a/packages/web3torrent/.storybook/web3torrent-client.mock.js
+++ b/packages/web3torrent/.storybook/web3torrent-client.mock.js
@@ -6,11 +6,11 @@ function mockWeb3TorrentClient() {
   const torrent = utils.createMockTorrentUI({
     numPeers: Object.keys(_peers).length,
     _peers,
-    wires: Array.from(_peers, ({ wire }) => wire)
+    wires: Array.from(_peers, ({wire}) => wire)
   });
 
-  return { torrents: [torrent], paymentChannelClient: {challengeChannel:(id)=>{}} };
-};
+  return {torrents: [torrent], paymentChannelClient: {challengeChannel: _ => {}}};
+}
 
 const web3Torrent = mockWeb3TorrentClient();
 

--- a/packages/web3torrent/.storybook/web3torrent-client.mock.js
+++ b/packages/web3torrent/.storybook/web3torrent-client.mock.js
@@ -1,22 +1,19 @@
 const React = require('react');
 const utils = require('./../src/utils/test-utils');
 
-const mockWeb3TorrentClient = () => {
+function mockWeb3TorrentClient() {
   const _peers = utils.createMockTorrentPeers();
-  const torrent = utils.createMockTorrent({
+  const torrent = utils.createMockTorrentUI({
     numPeers: Object.keys(_peers).length,
     _peers,
     wires: Array.from(_peers, ({ wire }) => wire)
   });
 
-  return { torrents: [torrent] };
+  return { torrents: [torrent], paymentChannelClient: {challengeChannel:(id)=>{}} };
 };
 
 const web3Torrent = mockWeb3TorrentClient();
 
 const Web3TorrentContext = React.createContext(web3Torrent);
 
-module.exports = {
-  Web3TorrentContext,
-  web3Torrent
-};
+module.exports = {Web3TorrentContext,web3Torrent};

--- a/packages/web3torrent/src/components/share-list/share-file/ShareFile.stories.tsx
+++ b/packages/web3torrent/src/components/share-list/share-file/ShareFile.stories.tsx
@@ -1,29 +1,24 @@
 import {withActions} from '@storybook/addon-actions';
-import {number, text, withKnobs} from '@storybook/addon-knobs';
+import {withKnobs} from '@storybook/addon-knobs';
 import {storiesOf} from '@storybook/react';
 import React from 'react';
 import '../../../App.scss';
 import '../ShareList.scss';
 import {ShareFile} from './ShareFile';
 import './ShareFile.scss';
+import {createMockTorrentUI} from '../../../utils/test-utils';
+import {MemoryRouter} from 'react-router-dom';
+import {RoutePath} from '../../../routes';
 
 // todo: fix after type refactor
 storiesOf('Web3Torrent', module)
   .addDecorator(withKnobs())
   .addDecorator(withActions('click'))
+  .addDecorator(story => <MemoryRouter initialEntries={[RoutePath.Root]}>{story()}</MemoryRouter>)
   .add('ShareFile', () => (
     <table className="share-list">
       <tbody>
-        {/*         <ShareFile
-          key="1"
-          file={{
-            name: text('File name', 'Once-Upon-A-Time.zip', 'File data'),
-            length: number('File size (in Mb)', 172, {step: 0.01}, 'File data'),
-            numPeers: number('Number of peers', 17, {step: 1}, 'File data'),
-            magnetURI: text('Magnet link', '', 'File data')
-          }}
-        ></ShareFile>
- */}
+        <ShareFile key="1" file={createMockTorrentUI()}></ShareFile>
       </tbody>
     </table>
   ));


### PR DESCRIPTION
This PR fixes a global storybook issue where missing function, and a missing property in the mocked context was making the start-storybook script fail. And it uncomments and fixes the ShareFile story.

The bug reported in #1205 is still present though.