### PR TITLE
Set site in approve budget

### DIFF
--- a/packages/xstate-wallet/src/workflows/approve-budget-and-fund.ts
+++ b/packages/xstate-wallet/src/workflows/approve-budget-and-fund.ts
@@ -228,6 +228,7 @@ const createLedger = (store: Store) => async (context: Initial): Promise<LedgerI
   const ledgerId = entry.channelId;
   await store.setFunding(entry.channelId, {type: 'Direct'});
   await store.setLedger(entry.channelId);
+  await store.setApplicationSite(ledgerId, context.budget.domain);
   await store.addObjective({
     type: 'FundLedger',
     participants: participants,


### PR DESCRIPTION
Sets the application site for the ledger channel in approve budget. This addresses the error when trying to `releaseFunds` in `CloserLedgerAndWithdraw`

 fixes #1500 