### PR TITLE
Add ReplaySubject to ChannelClient, use it on PaymentChannelClient

### DIFF
--- a/packages/channel-client/package.json
+++ b/packages/channel-client/package.json
@@ -21,6 +21,7 @@
     "eslint-plugin-prettier": "3.1.2",
     "lint-staged": "10.0.4",
     "prettier": "1.19.1",
+    "rxjs": "6.5.4",
     "ts-jest": "25.0.0",
     "typescript": "3.7.5"
   },

--- a/packages/channel-client/src/channel-client.ts
+++ b/packages/channel-client/src/channel-client.ts
@@ -36,9 +36,7 @@ export class ChannelClient implements ChannelClientInterface {
 
   constructor(readonly provider: ChannelProviderInterface) {
     this.channelState = new ReplaySubject(1);
-    this.provider.on('ChannelUpdated', result => {
-      this.channelState.next(result);
-    });
+    this.provider.on('ChannelUpdated', result => this.channelState.next(result));
   }
 
   onMessageQueued(

--- a/packages/channel-client/src/channel-client.ts
+++ b/packages/channel-client/src/channel-client.ts
@@ -16,10 +16,12 @@ import {
 } from '@statechannels/client-api-schema';
 import {HUB} from './constants';
 import {ETH_TOKEN_ADDRESS} from '../tests/constants';
+import {ReplaySubject} from 'rxjs';
 
 type TokenAllocations = Allocation[];
 
 export class ChannelClient implements ChannelClientInterface {
+  channelState: ReplaySubject<ChannelResult>;
   get signingAddress(): string | undefined {
     return this.provider.signingAddress;
   }
@@ -32,7 +34,12 @@ export class ChannelClient implements ChannelClientInterface {
     return this.provider.walletVersion;
   }
 
-  constructor(readonly provider: ChannelProviderInterface) {}
+  constructor(readonly provider: ChannelProviderInterface) {
+    this.channelState = new ReplaySubject(1);
+    this.provider.on('ChannelUpdated', result => {
+      this.channelState.next(result);
+    });
+  }
 
   onMessageQueued(
     callback: (result: MessageQueuedNotification['params']) => void

--- a/packages/channel-client/src/types.ts
+++ b/packages/channel-client/src/types.ts
@@ -8,6 +8,7 @@ import {
   FundingStrategy
 } from '@statechannels/client-api-schema';
 import {ChannelProviderInterface} from '@statechannels/channel-provider/src';
+import {ReplaySubject} from 'rxjs';
 
 export type UnsubscribeFunction = () => void;
 
@@ -22,7 +23,7 @@ export interface ChannelClientInterface {
   onBudgetUpdated: (callback: (result: SiteBudget) => void) => UnsubscribeFunction;
 
   provider: ChannelProviderInterface;
-
+  channelState: ReplaySubject<ChannelResult>;
   walletVersion?: string;
   signingAddress?: string;
   selectedAddress?: string;

--- a/packages/channel-client/tests/index.test.ts
+++ b/packages/channel-client/tests/index.test.ts
@@ -9,6 +9,7 @@ describe('ChannelClient', () => {
         enable: () => {
           /* do nothing */
         },
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         on: (_method, _callback) => {
           /* do nothing */
         }

--- a/packages/channel-client/tests/index.test.ts
+++ b/packages/channel-client/tests/index.test.ts
@@ -8,6 +8,9 @@ describe('ChannelClient', () => {
       new ChannelClient({
         enable: () => {
           /* do nothing */
+        },
+        on: (_method, _callback) => {
+          /* do nothing */
         }
       } as ChannelProviderInterface)
     ).toBeDefined();

--- a/packages/rps/package.json
+++ b/packages/rps/package.json
@@ -170,7 +170,7 @@
     "url-loader": "3.0.0",
     "workbox-webpack-plugin": "5.0.0",
     "yargs": "15.1.0",
-    "rxjs":"6.5.4"
+    "rxjs": "6.5.4"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/packages/rps/package.json
+++ b/packages/rps/package.json
@@ -169,7 +169,8 @@
     "uglifyjs-webpack-plugin": "2.2.0",
     "url-loader": "3.0.0",
     "workbox-webpack-plugin": "5.0.0",
-    "yargs": "15.1.0"
+    "yargs": "15.1.0",
+    "rxjs":"6.5.4"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
+++ b/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
@@ -9,7 +9,7 @@ import {encodeAppData, ChannelState} from '../../core';
 import {bigNumberify} from 'ethers/utils';
 import {RPS_ADDRESS} from '../../constants';
 import {SiteBudget} from '@statechannels/client-api-schema';
-
+import {ReplaySubject} from 'rxjs';
 const MOCK_ADDRESS = '0xAddress';
 const MOCK_CHANNEL_ID = '0xChannelId';
 const participants = [
@@ -59,6 +59,7 @@ class MockChannelClient implements ChannelClientInterface {
   onMessageQueued = jest.fn(function(callback) {
     return onMessageQueuedMockReturn;
   });
+  channelState = new ReplaySubject<ChannelResult>(1);
   onChannelUpdated = jest.fn(function(callback) {
     return onChannelUpdatedMockReturn;
   });

--- a/packages/web3torrent/package.json
+++ b/packages/web3torrent/package.json
@@ -26,6 +26,7 @@
     "react-icons": "3.9.0",
     "react-router-dom": "5.1.0",
     "react-scripts": "3.1.2",
+    "rxjs": "6.5.4",
     "webtorrent": "0.107.16"
   },
   "devDependencies": {

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -261,11 +261,11 @@ export class PaymentChannelClient {
 
       this.channelClient.channelState
         .pipe(
-          map((result: ChannelResult) => convertToChannelState(result)),
+          map(convertToChannelState),
           takeWhile((latestChannelState: ChannelState) => !readyToPay(latestChannelState), true),
           filter(readyToPay)
         )
-        .subscribe(channelState => resolve(channelState));
+        .subscribe(resolve);
     });
 
     const {payerBalance} = channelState;

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -16,6 +16,7 @@ import {AddressZero} from 'ethers/constants';
 import * as firebase from 'firebase/app';
 import 'firebase/database';
 import _ from 'lodash';
+import {takeWhile, map, filter, take} from 'rxjs/operators';
 import {logger} from '../logger';
 const log = logger.child({module: 'payment-channel-client'});
 const hexZeroPad = utils.hexZeroPad;
@@ -72,7 +73,7 @@ export class PaymentChannelClient {
   }
 
   constructor(private readonly channelClient: ChannelClientInterface) {
-    this.channelClient.onChannelUpdated(channelResult => {
+    this.channelClient.channelState.subscribe(channelResult => {
       this.updateChannelCache(convertToChannelState(channelResult));
     });
 
@@ -258,15 +259,13 @@ export class PaymentChannelClient {
         state.payer === this.mySigningAddress &&
         state.turnNum.mod(2).eq(Index.Payer);
 
-      const currentState = this.channelCache[channelId];
-      if (readyToPay(currentState)) resolve(currentState);
-
-      const unsubscribeListener = this.channelClient.onChannelUpdated(cu => {
-        if (readyToPay(convertToChannelState(cu))) {
-          unsubscribeListener();
-          resolve(convertToChannelState(cu));
-        }
-      });
+      this.channelClient.channelState
+        .pipe(
+          map((result: ChannelResult) => convertToChannelState(result)),
+          takeWhile((latestChannelState: ChannelState) => !readyToPay(latestChannelState), true),
+          filter(readyToPay)
+        )
+        .subscribe(channelState => resolve(channelState));
     });
 
     const {payerBalance} = channelState;

--- a/packages/web3torrent/src/pages/file/File.test.tsx
+++ b/packages/web3torrent/src/pages/file/File.test.tsx
@@ -13,9 +13,6 @@ import WebTorrentPaidStreamingClient from '../../library/web3torrent-lib';
 
 Enzyme.configure({adapter: new Adapter()});
 
-// this mock was making the entire test fail, and doesn't looks to be used anywhere
-// jest.mock('@statechannels/channel-client');
-
 describe('<File />', () => {
   let component: Enzyme.ReactWrapper;
   let torrentFile: jest.SpyInstance<Promise<ExtendedTorrent>, [WebTorrentAddInput]>;

--- a/packages/web3torrent/src/pages/file/File.test.tsx
+++ b/packages/web3torrent/src/pages/file/File.test.tsx
@@ -13,7 +13,8 @@ import WebTorrentPaidStreamingClient from '../../library/web3torrent-lib';
 
 Enzyme.configure({adapter: new Adapter()});
 
-jest.mock('@statechannels/channel-client');
+// this mock was making the entire test fail, and doesn't looks to be used anywhere
+// jest.mock('@statechannels/channel-client');
 
 describe('<File />', () => {
   let component: Enzyme.ReactWrapper;


### PR DESCRIPTION
The title is fairly straightforward.

This PR adds a subscribable ReplaySubject on the channelClient. This subject emits the last state to new subscribers, ensuring that no matter when the subscriber subscribes, it never loses the latest state of the channel.

See [here](https://www.learnrxjs.io/learn-rxjs/subjects) for more data about the ReplaySubject.