### PR TITLE
Change the way solc is installed in the master docker image

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -16,13 +16,8 @@ RUN apt-get install -y \
     tar \
     zlib1g-dev
 
-# add ethereum ppa
-RUN add-apt-repository ppa:ethereum/ethereum
-RUN apt-get update
-
-# there doesn't appear to be any way to specify solc version num
-# https://launchpad.net/~ethereum/+archive/ubuntu/ethereum/+packages?field.name_filter=solc&field.status_filter=published&field.series_filter=
-RUN apt-get install solc --allow-unauthenticated -y
+RUN curl -o /usr/bin/solc -fL https://github.com/ethereum/solidity/releases/download/v0.6.6/solc-static-linux \
+    && chmod u+x /usr/bin/solc
 
 # install node 10.x and yarn 1.17.3
 RUN npm install -g yarn@1.17.3

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,9 +1,3 @@
 # Docker image for CircleCI
 
-In order to update this image in Docker, run the following:
-
-```sh
-docker build .
-docker tag [tagnumber] counterfactual/statechannels:latest
-docker push counterfactual/statechannels:latest
-```
+In order to update this image in Docker, run `./build-tag-push-docker.sh VERSION_NUMBER`

--- a/.circleci/build-tag-push-docker.sh
+++ b/.circleci/build-tag-push-docker.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -euf -o pipefail
+
+docker build -t counterfactual/statechannels:latest .
+docker push counterfactual/statechannels:latest

--- a/.circleci/build-tag-push-docker.sh
+++ b/.circleci/build-tag-push-docker.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -euf -o pipefail
 
-docker build -t counterfactual/statechannels:latest .
-docker push counterfactual/statechannels:latest
+docker build -t counterfactual/statechannels:${1} .
+docker push counterfactual/statechannels:${1}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ defaults: &defaults
   working_directory: /home/circleci/project
   resource_class: medium
   docker:
-    - image: counterfactual/statechannels:0.6.1 # Fast contract compilation with solc installed
+    - image: counterfactual/statechannels:0.6.6 # Fast contract compilation with solc installed
     - image: circleci/postgres:12.0-alpine
       environment:
         <<: *postgres_env_vars


### PR DESCRIPTION
Benefits:
- version pinning.
- I believe that ppa:ethereum/ethereum is Ubuntu specific, but our image is using Debian.
- I could not rebuild the image today with the ppa. Seeing:
```
> [7/8] RUN apt-get install solc --allow-unauthenticated -y:                            
#10 0.232 Reading package lists...                                                       
#10 1.014 Building dependency tree...                                                    
#10 1.179 Reading state information...                                                   
#10 1.236 Some packages could not be installed. This may mean that you have              
#10 1.236 requested an impossible situation or if you are using the unstable
#10 1.236 distribution that some required packages have not yet been created
#10 1.236 or been moved out of Incoming.
#10 1.236 The following information may help to resolve the situation:
#10 1.236 
#10 1.236 The following packages have unmet dependencies:
#10 1.305  solc : Depends: libc6 (>= 2.29) but 2.24-11+deb9u4 is to be installed
#10 1.305         Depends: libcvc4-5 but it is not installable
#10 1.305         Depends: libgcc-s1 (>= 3.0) but it is not installable
#10 1.305         Depends: libstdc++6 (>= 9) but 6.3.0-18+deb9u1 is to be installed
#10 1.319 E: Unable to correct problems, you have held broken packages.
```