### PR TITLE
Change virtual-funding ganache port to 8545

### DIFF
--- a/.env.virtual-funding
+++ b/.env.virtual-funding
@@ -3,7 +3,7 @@ NODE_ENV = 'development'
 CHAIN_NETWORK_ID = '9001'
 GANACHE_CACHE_FOLDER = '../../.ganache-deployments'
 GANACHE_HOST = '0.0.0.0'
-GANACHE_PORT = '8547'
+GANACHE_PORT = '8545'
 USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 
 

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -178,8 +178,11 @@ export async function setUpBrowser(
     });
     metamask = await dappeteer.getMetamask(browser);
     await metamask.importPK('0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8'); // etherlime account 0
-    // await metamask.addNetwork('http://localhost:8547'); // does not seem to work
-    await metamask.switchNetwork('localhost'); // defaults to 8545. In production, replace with 'ropsten'
+
+    // Because of the implementation of switchNetwork not allowing for
+    // custom host & ports (see https://github.com/decentraland/dappeteer/blob/7720a675d2d0c4fa10e93d33426b984cc391d4c3/src/index.ts#L149)
+    // our only option is "localhost", which defaults to 8545
+    await metamask.switchNetwork('localhost'); // In production, replace with 'ropsten'
   }
 
   return {browser, metamask};

--- a/packages/rps/README.md
+++ b/packages/rps/README.md
@@ -24,7 +24,7 @@ that you have already cloned the monorepo, and run `yarn install` from the root 
    AUTO_OPPONENT=B yarn start
    ```
 3. In your browser, you will need to set up your ethereum wallet to connect to the
-   ganache network that you started in step 1. The default for ganache is currently localhost:8547.
+   ganache network that you started in step 1. The default for ganache is currently localhost:8545.
 
 ### About the auto-player and auto-opponent
 

--- a/packages/tic-tac-toe/README.md
+++ b/packages/tic-tac-toe/README.md
@@ -28,7 +28,7 @@ that you have already cloned the monorepo, and run `yarn install` from the root 
    AUTO_OPPONENT=B yarn start
    ```
 3. In your browser, you will need to set up your ethereum wallet to connect to the
-   ganache network that you started in step 1. The default for ganache is currently localhost:8547.
+   ganache network that you started in step 1. The default for ganache is currently localhost:8545.
 
 ### About the auto-player and auto-opponent
 


### PR DESCRIPTION
When using `SC_ENV=virtual-funding` and trying to run `puppeteer:dev:web3torrent` in the `e2e-tests` package, I'm not able to use it adequately because `switchNetwork` on `dappeteer` only works with 8545.

I don't think there is any benefit in using 8547 over 8545, so I propose we just change the default.