### PR TITLE
[e2e] Add a persistent-seeder script

### DIFF
--- a/.env.circle-integration-rps
+++ b/.env.circle-integration-rps
@@ -1,19 +1,19 @@
 # For multiple
-NODE_ENV=test
+NODE_ENV = 'test'
 
 # For shared-ganache
-CHAIN_NETWORK_ID=9001
-GANACHE_CACHE_FOLDER=../../.ganache-deployments
-GANACHE_HOST=0.0.0.0
-GANACHE_PORT=8545
+CHAIN_NETWORK_ID = '9001'
+GANACHE_CACHE_FOLDER = '../../.ganache-deployments'
+GANACHE_HOST = '0.0.0.0'
+GANACHE_PORT = '8545'
 USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 
 # For e2e-test
 BROWSER_LOG_DESTINATION = 'browser.log'
 HEADLESS = 'true'
-USE_DAPPETEER=false
+USE_DAPPETEER = 'false'
 TARGET_NETWORK = 'localhost'
-DAPPETEER_PK='0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8'
+DAPPETEER_PK = '0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8'
 # ( etherlime account 0 )
 
 ## xstate-wallet
@@ -23,8 +23,8 @@ LOG_DESTINATION = 'pino.log'
 
 ## rps
 USE_VIRTUAL_FUNDING = 'FALSE'
-RPS_DEPLOYER_ACCOUNT_INDEX = 2
-FIREBASE_PROJECT='rock-paper-scissors-dev-4ff8d'
-FIREBASE_API_KEY='AIzaSyAOvhDzJir_El3O6SJ2xQlrpOisnObq6zw'
-WALLET_URL='http://127.0.0.1:3055'
+RPS_DEPLOYER_ACCOUNT_INDEX = '2'
+FIREBASE_PROJECT = 'rock-paper-scissors-dev-4ff8d'
+FIREBASE_API_KEY = 'AIzaSyAOvhDzJir_El3O6SJ2xQlrpOisnObq6zw'
+WALLET_URL = 'http://127.0.0.1:3055'
 

--- a/.env.circle-integration-rps
+++ b/.env.circle-integration-rps
@@ -12,6 +12,9 @@ USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 BROWSER_LOG_DESTINATION = 'browser.log'
 HEADLESS = 'true'
 USE_DAPPETEER=false
+TARGET_NETWORK = 'localhost'
+DAPPETEER_PK='0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8'
+# ( etherlime account 0 )
 
 ## xstate-wallet
 XSTATE_WALLET_DEPLOYER_ACCOUNT_INDEX = '3'

--- a/.env.circle-integration-w3t
+++ b/.env.circle-integration-w3t
@@ -1,19 +1,19 @@
 # For multiple
-NODE_ENV=test
+NODE_ENV = 'test'
 
 # For shared-ganache
-CHAIN_NETWORK_ID=9001
-GANACHE_CACHE_FOLDER=../../.ganache-deployments
-GANACHE_HOST=0.0.0.0
-GANACHE_PORT=8545
+CHAIN_NETWORK_ID = '9001'
+GANACHE_CACHE_FOLDER = '../../.ganache-deployments'
+GANACHE_HOST = '0.0.0.0'
+GANACHE_PORT = '8545'
 USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 
 # e2e-tests
 BROWSER_LOG_DESTINATION = 'browser.log'
-HEADLESS='true'
-USE_DAPPETEER='false'
+HEADLESS = 'true'
+USE_DAPPETEER = 'false'
 TARGET_NETWORK = 'localhost'
-DAPPETEER_PK='0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8'
+DAPPETEER_PK = '0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8'
 # ( etherlime account 0 )
 
 ## xstate-wallet

--- a/.env.circle-integration-w3t
+++ b/.env.circle-integration-w3t
@@ -8,10 +8,13 @@ GANACHE_HOST=0.0.0.0
 GANACHE_PORT=8545
 USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 
-# For e2e-test
+# e2e-tests
 BROWSER_LOG_DESTINATION = 'browser.log'
 HEADLESS = false
 USE_DAPPETEER='true'
+TARGET_NETWORK = 'localhost'
+80faa6ee8'
+# ( etherlime account 0 )
 
 ## xstate-wallet
 XSTATE_WALLET_DEPLOYER_ACCOUNT_INDEX = '3'
@@ -28,4 +31,3 @@ REACT_APP_LOG_DESTINATION = 'pino.log'
 REACT_APP_TRACKER_URL = 'localhost:8000'
 REACT_APP_TRACKER_URL_HTTP_PROTOCOL = 'http'
 REACT_APP_WALLET_URL = 'http://localhost:3055'
-

--- a/.env.circle-integration-w3t
+++ b/.env.circle-integration-w3t
@@ -10,8 +10,8 @@ USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 
 # e2e-tests
 BROWSER_LOG_DESTINATION = 'browser.log'
-HEADLESS = false
-USE_DAPPETEER='true'
+HEADLESS='true'
+USE_DAPPETEER='false'
 TARGET_NETWORK = 'localhost'
 80faa6ee8'
 # ( etherlime account 0 )

--- a/.env.circle-integration-w3t
+++ b/.env.circle-integration-w3t
@@ -10,8 +10,8 @@ USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 
 # For e2e-test
 BROWSER_LOG_DESTINATION = 'browser.log'
-HEADLESS = 'true'
-USE_DAPPETEER=false
+HEADLESS = false
+USE_DAPPETEER='true'
 
 ## xstate-wallet
 XSTATE_WALLET_DEPLOYER_ACCOUNT_INDEX = '3'

--- a/.env.circle-integration-w3t
+++ b/.env.circle-integration-w3t
@@ -13,7 +13,7 @@ BROWSER_LOG_DESTINATION = 'browser.log'
 HEADLESS='true'
 USE_DAPPETEER='false'
 TARGET_NETWORK = 'localhost'
-80faa6ee8'
+DAPPETEER_PK='0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8'
 # ( etherlime account 0 )
 
 ## xstate-wallet

--- a/.env.circle-integration-w3t-with-hub
+++ b/.env.circle-integration-w3t-with-hub
@@ -13,7 +13,7 @@ BROWSER_LOG_DESTINATION = 'browser.log'
 HEADLESS='true'
 USE_DAPPETEER='false'
 TARGET_NETWORK = 'localhost'
-DAPPETEER_PK='0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8'
+DAPPETEER_PK = '0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8'
 # ( etherlime account 0 )
 
 ## simple-hub

--- a/.env.circle-integration-w3t-with-hub
+++ b/.env.circle-integration-w3t-with-hub
@@ -10,8 +10,8 @@ USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 
 # For e2e-test
 BROWSER_LOG_DESTINATION = 'browser.log'
-HEADLESS = 'true'
-USE_DAPPETEER=false
+HEADLESS='true'
+USE_DAPPETEER='false'
 TARGET_NETWORK = 'localhost'
 80faa6ee8'
 # ( etherlime account 0 )

--- a/.env.circle-integration-w3t-with-hub
+++ b/.env.circle-integration-w3t-with-hub
@@ -13,7 +13,7 @@ BROWSER_LOG_DESTINATION = 'browser.log'
 HEADLESS='true'
 USE_DAPPETEER='false'
 TARGET_NETWORK = 'localhost'
-80faa6ee8'
+DAPPETEER_PK='0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8'
 # ( etherlime account 0 )
 
 ## simple-hub

--- a/.env.circle-integration-w3t-with-hub
+++ b/.env.circle-integration-w3t-with-hub
@@ -12,6 +12,9 @@ USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 BROWSER_LOG_DESTINATION = 'browser.log'
 HEADLESS = 'true'
 USE_DAPPETEER=false
+TARGET_NETWORK = 'localhost'
+80faa6ee8'
+# ( etherlime account 0 )
 
 ## simple-hub
 SIMPLE_HUB_DEPLOYER_ACCOUNT_INDEX = '1'

--- a/.env.persistent-seeder
+++ b/.env.persistent-seeder
@@ -1,0 +1,39 @@
+## all
+NODE_ENV = 'production'
+
+## web3torrent, xstate-wallet, rps, simple-hub
+CHAIN_NETWORK_ID = '3'
+
+## rps, xstate-wallet, e2e-tests
+TARGET_NETWORK = 'ropsten'
+
+## e2e-tests
+HEADLESS=false
+USE_DAPPETEER=true
+DAPPETEER_PK=
+# unsetting causes dappeteer default, has 0.7927 ropsten ETH at the time of writing
+
+## web3torrent, rps
+WALLET_URL = 'https://xstate-wallet.statechannels.org'
+
+## web3torrent
+FIREBASE_API_KEY = 'AIzaSyAOvhDzJir_El3O6SJ2xQlrpOisnObq6zw'
+FIREBASE_PREFIX = 'netlify-ropsten'
+FIREBASE_PROJECT = 'rock-paper-scissors-production'
+
+REACT_APP_CHAIN_NETWORK_ID = $CHAIN_NETWORK_ID
+REACT_APP_FIREBASE_API_KEY = $FIREBASE_API_KEY
+REACT_APP_FIREBASE_PREFIX = $FIREBASE_PREFIX
+REACT_APP_FIREBASE_URL = $FIREBASE_URL
+REACT_APP_FUNDING_STRATEGY = 'Virtual'
+REACT_APP_LOG_DESTINATION = $LOG_DESTINATION
+REACT_APP_SINGLE_ASSET_PAYMENT_CONTRACT_ADDRESS = '0xde8585b18e89ad34521f87f236dd745b1c4af99b'
+REACT_APP_TARGET_NETWORK = $TARGET_NETWORK
+REACT_APP_TRACKER_URL = 'web3torrent-tracker-staging.herokuapp.com/'
+REACT_APP_TRACKER_URL_HTTP_PROTOCOL = 'https'
+REACT_APP_WALLET_URL = $WALLET_URL
+SKIP_PREFLIGHT_CHECK = 'true'
+
+## rps
+RPS_CONTRACT_ADDRESS = '0x6CF0c4Ab3F1e66913c0983DC0bb1202d958ABb8f'
+

--- a/packages/e2e-tests/Dockerfile
+++ b/packages/e2e-tests/Dockerfile
@@ -4,12 +4,6 @@ ARG BRANCH=sp/headfull-docker-george
 # this allows us to make an image with whatever branch we want
 # using --build-arg BRANCH=name_of_the_branch
 # e.g. docker build -t dapp --build-arg BRANCH=master .
-LABEL "com.github.actions.name"="Puppeteer Headful"
-LABEL "com.github.actions.description"="A GitHub Action / Docker image for Puppeteer, the Headful Chrome Node API"
-LABEL "com.github.actions.icon"="layout"
-LABEL "com.github.actions.color"="blue"
-
-LABEL "maintainer"="State Channels"
 
 RUN  apt-get update \
      # See https://crbug.com/795759
@@ -28,7 +22,6 @@ WORKDIR /monorepo
 ADD https://api.github.com/repos/statechannels/monorepo/git/refs/heads/$BRANCH version.json
 RUN  git pull 
 RUN  yarn
-
 
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 

--- a/packages/e2e-tests/Dockerfile
+++ b/packages/e2e-tests/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:10.16.3
 
+ARG BRANCH=sp/headfull-docker
+# this allows us to make an image with whatever branch we want
+# using --build-arg BRANCH=name_of_the_branch
+# e.g. docker build -t dapp --build-arg BRANCH=master .
 LABEL "com.github.actions.name"="Puppeteer Headful"
 LABEL "com.github.actions.description"="A GitHub Action / Docker image for Puppeteer, the Headful Chrome Node API"
 LABEL "com.github.actions.icon"="layout"
@@ -17,11 +21,12 @@ RUN  apt-get update \
      && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
      && apt-get update \
      && apt-get install -y google-chrome-stable --no-install-recommends \
-     && rm -rf /var/lib/apt/lists/* \
-     && git clone -b george/headful-puppeteer-ci --single-branch https://github.com/statechannels/monorepo.git monorepo \
-     && cd monorepo \
-     && git pull \
-     && yarn
+     && rm -rf /var/lib/apt/lists/*
+
+RUN  git clone -b $BRANCH --single-branch https://github.com/statechannels/monorepo.git monorepo
+WORKDIR /monorepo
+RUN  git pull 
+RUN  yarn
 
 
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true

--- a/packages/e2e-tests/Dockerfile
+++ b/packages/e2e-tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:10.16.3
 
-ARG BRANCH=sp/headfull-docker
+ARG BRANCH=sp/headfull-docker-george
 # this allows us to make an image with whatever branch we want
 # using --build-arg BRANCH=name_of_the_branch
 # e.g. docker build -t dapp --build-arg BRANCH=master .

--- a/packages/e2e-tests/Dockerfile
+++ b/packages/e2e-tests/Dockerfile
@@ -25,6 +25,7 @@ RUN  apt-get update \
 
 RUN  git clone -b $BRANCH --single-branch https://github.com/statechannels/monorepo.git monorepo
 WORKDIR /monorepo
+ADD https://api.github.com/repos/statechannels/monorepo/git/refs/heads/$BRANCH version.json
 RUN  git pull 
 RUN  yarn
 

--- a/packages/e2e-tests/Dockerfile
+++ b/packages/e2e-tests/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:10.16.3
+
+LABEL "com.github.actions.name"="Puppeteer Headful"
+LABEL "com.github.actions.description"="A GitHub Action / Docker image for Puppeteer, the Headful Chrome Node API"
+LABEL "com.github.actions.icon"="layout"
+LABEL "com.github.actions.color"="blue"
+
+LABEL "maintainer"="State Channels"
+
+RUN  apt-get update \
+     # See https://crbug.com/795759
+     && apt-get install -yq libgconf-2-4 \
+     # Install latest chrome dev package, which installs the necessary libs to
+     # make the bundled version of Chromium that Puppeteer installs work.
+     && apt-get install -y wget xvfb --no-install-recommends \
+     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+     && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+     && apt-get update \
+     && apt-get install -y google-chrome-stable --no-install-recommends \
+     && rm -rf /var/lib/apt/lists/* \
+     && git clone -b george/headful-puppeteer-ci --single-branch https://github.com/statechannels/monorepo.git monorepo \
+     && cd monorepo \
+     && git pull \
+     && yarn
+
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/packages/e2e-tests/entrypoint.sh
+++ b/packages/e2e-tests/entrypoint.sh
@@ -7,15 +7,8 @@ Xvfb -ac :99 -screen 0 1280x1024x16 > /dev/null 2>&1 &
 export DISPLAY=:99.0
 export PUPPETEER_EXEC_PATH="google-chrome-stable"
 
-# Run commands
-cmd=$@
-echo "Running '$cmd'!"
-if $cmd; then
-    # no op
-    echo "Successfully ran '$cmd'"
-else
-    exit_code=$?
-    echo "Failure running '$cmd', exited with $exit_code"
-    echo ''
-    exit $exit_code
-fi
+#!/bin/sh
+cd packages/e2e-tests
+
+set -e
+exec "$@"

--- a/packages/e2e-tests/entrypoint.sh
+++ b/packages/e2e-tests/entrypoint.sh
@@ -1,14 +1,13 @@
 #!/bin/sh
 
-# Startup Xvfb
-Xvfb -ac :99 -screen 0 1280x1024x16 > /dev/null 2>&1 &
-
 # Export some variables
 export DISPLAY=:99.0
 export PUPPETEER_EXEC_PATH="google-chrome-stable"
 
-#!/bin/sh
-cd packages/e2e-tests
+# Startup Xvfb
+Xvfb -ac :99 -screen 0 1280x800x24 -ac -nolisten tcp -dpi 96 +extension RANDR > /dev/null 2>&1 &
 
+cd packages/e2e-tests
+# LOG_DESTINATION='console' yarn test:e2e:w3t
 set -e
 exec "$@"

--- a/packages/e2e-tests/entrypoint.sh
+++ b/packages/e2e-tests/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Startup Xvfb
+Xvfb -ac :99 -screen 0 1280x1024x16 > /dev/null 2>&1 &
+
+# Export some variables
+export DISPLAY=:99.0
+export PUPPETEER_EXEC_PATH="google-chrome-stable"
+
+# Run commands
+cmd=$@
+echo "Running '$cmd'!"
+if $cmd; then
+    # no op
+    echo "Successfully ran '$cmd'"
+else
+    exit_code=$?
+    echo "Failure running '$cmd', exited with $exit_code"
+    echo ''
+    exit $exit_code
+fi

--- a/packages/e2e-tests/entrypoint.sh
+++ b/packages/e2e-tests/entrypoint.sh
@@ -8,6 +8,5 @@ export PUPPETEER_EXEC_PATH="google-chrome-stable"
 Xvfb -ac :99 -screen 0 1280x800x24 -ac -nolisten tcp -dpi 96 +extension RANDR > /dev/null 2>&1 &
 
 cd packages/e2e-tests
-# LOG_DESTINATION='console' yarn test:e2e:w3t
 set -e
 exec "$@"

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -41,6 +41,7 @@
     "precommit": "lint-staged --quiet",
     "puppeteer:dev:web3torrent": "ts-node -O '{\"module\":\"commonjs\",\"noUnusedLocals\":false}' ./puppeteer/scripts/web3torrent.ts",
     "puppeteer:dev:rps": "ts-node -O '{\"module\":\"commonjs\",\"noUnusedLocals\":false}' ./puppeteer/scripts/rps.ts",
+    "puppeteer:dev:minimal-dapp": "NODE_ENV=development HEADLESS=false USE_DAPPETEER=true ts-node -O '{\"module\":\"commonjs\",\"noUnusedLocals\":false}' ./puppeteer/scripts/minimal-dapp.ts",
     "test": "jest",
     "test:show": "HEADLESS=false yarn run test",
     "test:e2e:rps": "SC_ENV=circle-integration-rps sh ./run-e2e.sh rps",

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -25,7 +25,7 @@
     "prettier": "1.19.1",
     "puppeteer": "2.1.1",
     "ts-jest": "25.0.0",
-    "ts-node": "8.6.2",
+    "ts-node": "8.9.1",
     "typescript": "3.7.5",
     "wait-on": "4.0.0"
   },
@@ -41,7 +41,7 @@
     "precommit": "lint-staged --quiet",
     "puppeteer:dev:web3torrent": "ts-node -O '{\"module\":\"commonjs\",\"noUnusedLocals\":false}' ./puppeteer/scripts/web3torrent.ts",
     "puppeteer:dev:rps": "ts-node -O '{\"module\":\"commonjs\",\"noUnusedLocals\":false}' ./puppeteer/scripts/rps.ts",
-    "puppeteer:dev:minimal-dapp": "NODE_ENV=development HEADLESS=false USE_DAPPETEER=true ts-node -O '{\"module\":\"commonjs\",\"noUnusedLocals\":false}' ./puppeteer/scripts/minimal-dapp.ts",
+    "persistent-seeder": "SC_ENV=persistent-seeder ts-node -O '{\"module\":\"commonjs\",\"noUnusedLocals\":false}' ./puppeteer/scripts/persistent-seeder.ts",
     "test": "jest",
     "test:show": "HEADLESS=false yarn run test",
     "test:e2e:rps": "SC_ENV=circle-integration-rps sh ./run-e2e.sh rps",

--- a/packages/e2e-tests/puppeteer/constants.ts
+++ b/packages/e2e-tests/puppeteer/constants.ts
@@ -4,3 +4,5 @@ export const HEADLESS = getEnvBool('HEADLESS');
 export const USE_DAPPETEER = getEnvBool('USE_DAPPETEER');
 export const USES_VIRTUAL_FUNDING = process.env.REACT_APP_FUNDING_STRATEGY === 'Virtual';
 export const JEST_TIMEOUT = HEADLESS ? 200_000 : 1_000_000;
+export const DAPPETEER_PK = process.env.DAPPETEER_PK;
+export const TARGET_NETWORK = process.env.TARGET_NETWORK ? process.env.TARGET_NETWORK : 'localhost';

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -3,7 +3,7 @@ import * as dappeteer from 'dappeteer';
 
 import * as fs from 'fs';
 import * as path from 'path';
-import {USE_DAPPETEER} from './constants';
+import {USE_DAPPETEER, DAPPETEER_PK, TARGET_NETWORK} from './constants';
 
 const logDistinguisherCache: Record<string, true | undefined> = {};
 
@@ -177,12 +177,12 @@ export async function setUpBrowser(
       ]
     });
     metamask = await dappeteer.getMetamask(browser);
-    await metamask.importPK('0x7ab741b57e8d94dd7e1a29055646bafde7010f38a900f55bbd7647880faa6ee8'); // etherlime account 0
+    !!DAPPETEER_PK && (await metamask.importPK(DAPPETEER_PK));
 
     // Because of the implementation of switchNetwork not allowing for
     // custom host & ports (see https://github.com/decentraland/dappeteer/blob/7720a675d2d0c4fa10e93d33426b984cc391d4c3/src/index.ts#L149)
-    // our only option is "localhost", which defaults to 8545
-    await metamask.switchNetwork('localhost'); // In production, replace with 'ropsten'
+    // our only options are "localhost" (which defaults to 8545) or a public network such as 'ropsten'
+    await metamask.switchNetwork(TARGET_NETWORK);
   }
 
   return {browser, metamask};

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -226,7 +226,7 @@ export async function waitAndApproveDepositWithHub(
 ): Promise<void> {
   console.log('Making deposit with hub');
   const walletIFrame = page.frames()[1];
-  await walletIFrame.waitForSelector('#please-approve-transaction');
+  await walletIFrame.waitForSelector('#please-approve-transaction', {timeout: 60000}); // longer timeout here because blockchain is slow
   await metamask.confirmTransaction({gas: 20, gasLimit: 50000});
   await page.bringToFront();
 }

--- a/packages/e2e-tests/puppeteer/scripts/minimal-dapp.ts
+++ b/packages/e2e-tests/puppeteer/scripts/minimal-dapp.ts
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import {setUpBrowser, setupLogging} from '../helpers';
+
+(async (): Promise<void> => {
+  if (require.main === module) {
+    console.log('Opening browser');
+    const {browser} = await setUpBrowser(false, 0);
+
+    console.log('Waiting on pages');
+    const web3tTabA = (await browser.pages())[0];
+
+    console.log('Setting up logging...');
+    await setupLogging(web3tTabA, 0, 'minimal-dapp', true);
+
+    await web3tTabA.goto('http://bbc.com', {waitUntil: 'load'});
+    await web3tTabA.bringToFront();
+    console.log('completed!');
+  }
+})();

--- a/packages/e2e-tests/puppeteer/scripts/persistent-seeder.ts
+++ b/packages/e2e-tests/puppeteer/scripts/persistent-seeder.ts
@@ -1,10 +1,10 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {setUpBrowser, setupLogging} from '../helpers';
+import {uploadFile} from './web3torrent';
 
 (async (): Promise<void> => {
   if (require.main === module) {
     console.log('Opening browser');
-    const {browser} = await setUpBrowser(false, 0);
+    const {browser, metamask} = await setUpBrowser(false, 0);
 
     console.log('Waiting on pages');
     const web3tTabA = (await browser.pages())[0];
@@ -12,8 +12,10 @@ import {setUpBrowser, setupLogging} from '../helpers';
     console.log('Setting up logging...');
     await setupLogging(web3tTabA, 0, 'minimal-dapp', true);
 
-    await web3tTabA.goto('http://bbc.com', {waitUntil: 'load'});
+    await web3tTabA.goto('https://web3torrent.statechannels.org/upload', {waitUntil: 'load'});
     await web3tTabA.bringToFront();
-    console.log('completed!');
+
+    const url = await uploadFile(web3tTabA, true, metamask);
+    console.log(`seeding: go to ${url}`);
   }
 })();

--- a/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
+++ b/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
@@ -53,7 +53,7 @@ export async function uploadFile(
   }
 
   const downloadLinkSelector = '#download-link';
-  await page.waitForSelector(downloadLinkSelector);
+  await page.waitForSelector(downloadLinkSelector, {timeout: 60000}); // wait for my tx, which could be slow if on a real blockchain
   const downloadLink = await page.$eval(downloadLinkSelector, a => a.getAttribute('href'));
 
   return downloadLink ? downloadLink : '';

--- a/packages/e2e-tests/run-e2e.sh
+++ b/packages/e2e-tests/run-e2e.sh
@@ -26,4 +26,5 @@ kill $wallet
 kill $app
 kill $hub
 killall node
+rm -rf ../../.ganache-deployments
 exit $code

--- a/packages/e2e-tests/run-e2e.sh
+++ b/packages/e2e-tests/run-e2e.sh
@@ -26,5 +26,7 @@ kill $wallet
 kill $app
 kill $hub
 killall node
-rm -rf ../../.ganache-deployments
+if test -f "../../.ganache-deployments/ganache-deployments-8545.json"; then
+  rm ../../.ganache-deployments/ganache-deployments-8545.json
+fi
 exit $code

--- a/yarn.lock
+++ b/yarn.lock
@@ -30678,6 +30678,14 @@ source-map-support@^0.5.0, source-map-support@^0.5.3, source-map-support@^0.5.6,
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
+source-map-support@^0.5.17:
+  version "0.5.19"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-url@^0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz#7ecaf13b57bcd09da8a40c5d269db33799d4aaf9"
@@ -32548,6 +32556,17 @@ ts-node@8.6.2:
     diff "^4.0.1"
     make-error "^1.1.1"
     source-map-support "^0.5.6"
+    yn "3.1.1"
+
+ts-node@8.9.1:
+  version "8.9.1"
+  resolved "https://registry.npmjs.org/ts-node/-/ts-node-8.9.1.tgz#2f857f46c47e91dcd28a14e052482eb14cfd65a5"
+  integrity sha512-yrq6ODsxEFTLz0R3BX2myf0WBCSQh9A+py8PBo1dCzWIOcvisbyH6akNKqDHMgXePF2kir5mm5JXJTH3OUJYOQ==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
     yn "3.1.1"
 
 ts-pnp@1.1.4:


### PR DESCRIPTION
and associated SC_ENV, that successfully runs in a Docker container. 
<img width="920" alt="Screenshot 2020-04-28 at 16 33 57" src="https://user-images.githubusercontent.com/1833419/80507286-9bb59d00-896e-11ea-9ae6-386dbb521b81.png">

Progress toward #1548 .

Instuctions
---
- `cd packages/e2e-tests`
- `docker build -t dapp . `
- `docker run -it dapp /bin/bash` to get an interactive shell inside the Docker container
- `yarn persistent-seeder` to launch web3torrent & dappeteer , upload a file and make a deposit

TODO
--- 
- [x] cleanup
- [ ] deployment (separate PR)
- [ ] use this as launchpad for enabling dappeteer in CI (separate PR)
