### PR TITLE
[simple-hub] Fix tsc

### DIFF
--- a/packages/devtools/src/config/env.ts
+++ b/packages/devtools/src/config/env.ts
@@ -27,8 +27,9 @@ export function configureEnvVariables(monorepo = true): void {
   const SC_ENV = process.env.SC_ENV;
   if (SC_ENV) {
     const scEnvFile = path.join('../..', '.env.' + SC_ENV);
-    if (!fs.existsSync(scEnvFile)) {
-      throw new Error(`.env.${SC_ENV} must exist in the monorepo root`);
+    const scEnvFileFullPath = path.join(process.cwd(), scEnvFile);
+    if (!fs.existsSync(scEnvFileFullPath)) {
+      throw new Error(`${scEnvFileFullPath} must exist in the monorepo root`);
     }
 
     /* eslint-disable @typescript-eslint/no-var-requires */

--- a/packages/devtools/src/config/env.ts
+++ b/packages/devtools/src/config/env.ts
@@ -49,6 +49,7 @@ export function configureEnvVariables(monorepo = true): void {
   }
 
   // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
+  // NOTE: dotenv joins paths with cwd https://www.npmjs.com/package/dotenv#path
   let dotenvFiles = [
     `.env.${NODE_ENV}.local`,
     // Don't include `.env.local` for `test` environment

--- a/packages/simple-hub/docker/simple-hub.dockerfile
+++ b/packages/simple-hub/docker/simple-hub.dockerfile
@@ -44,4 +44,4 @@ WORKDIR /statechannels/monorepo/packages/simple-hub
 # To interactively debug the container:
 # docker run -it registry.heroku.com/simple-hub-staging/simple-hub:latest bash
 ENTRYPOINT ["docker/docker-entrypoint.sh"]
-CMD ["node", "./lib/server.js"]
+CMD ["node", "./lib/src/server.js"]

--- a/packages/simple-hub/env.ts
+++ b/packages/simple-hub/env.ts
@@ -14,11 +14,13 @@ function configureEnvVariables(monorepo = true) {
   const SC_ENV = process.env.SC_ENV;
   if (SC_ENV) {
     const scEnvFile = path.join('../..', '.env.' + SC_ENV);
-    if (!fs.existsSync(scEnvFile)) {
-      throw new Error(`.env.${SC_ENV} must exist in the monorepo root`);
+    const scEnvFileFullPath = path.join(process.cwd(), scEnvFile);
+    if (!fs.existsSync(scEnvFileFullPath)) {
+      throw new Error(`${scEnvFileFullPath} must exist in the monorepo root`);
     }
 
     /* eslint-disable @typescript-eslint/no-var-requires */
+    // NOTE: dotenv joins paths with cwd https://www.npmjs.com/package/dotenv#path
     require('dotenv-expand')(
       require('dotenv').config({
         path: scEnvFile

--- a/packages/simple-hub/env.ts
+++ b/packages/simple-hub/env.ts
@@ -1,14 +1,12 @@
-'use strict';
-
 // FIXME: To remove @statechannels/hub's dependency on @statechannels/devtools,
 // this file is a carbon copy of the file that exports configureEnvVariables in devtools.
 
 // const {configureEnvVariables} = require('@statechannels/devtools');
 
-const fs = require('fs');
-const path = require('path');
+import * as fs from 'fs';
+import * as path from 'path';
 
-function configureEnvVariables(monorepo = true) {
+function configureEnvVariables(monorepo = true): void {
   // State Channel Environment
   // Intended usage is a single file in monorepo root defining configuration for multiple packages
   const SC_ENV = process.env.SC_ENV;
@@ -45,11 +43,11 @@ function configureEnvVariables(monorepo = true) {
     NODE_ENV !== 'test' && `.env.local`,
     `.env.${NODE_ENV}`,
     '.env'
-  ].filter(x => !!x);
+  ].filter((x): x is string => !!x);
 
   if (monorepo) {
     const monorepoDotenvFiles = dotenvFiles.slice(0);
-    dotenvFiles.forEach(dotenvFile => {
+    dotenvFiles.forEach((dotenvFile: string) => {
       monorepoDotenvFiles.push(path.join('../..', dotenvFile));
     });
     dotenvFiles = monorepoDotenvFiles;
@@ -60,7 +58,7 @@ function configureEnvVariables(monorepo = true) {
   // that have already been set.  Variable expansion is supported in .env files.
   // https://github.com/motdotla/dotenv
   // https://github.com/motdotla/dotenv-expand
-  dotenvFiles.forEach(dotenvFile => {
+  dotenvFiles.forEach((dotenvFile: string) => {
     if (fs.existsSync(dotenvFile)) {
       // Need to refactor away from this
       /* eslint-disable @typescript-eslint/no-var-requires */

--- a/packages/simple-hub/jest/jest.config.js
+++ b/packages/simple-hub/jest/jest.config.js
@@ -4,7 +4,7 @@ const root = resolve(__dirname, '../');
 module.exports = {
   rootDir: root,
   collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
-  setupFiles: ['./env.js'],
+  setupFiles: ['./env.ts'],
   testMatch: ['<rootDir>/**/__test__/**/?(*.)(spec|test).ts'],
   testEnvironment: 'node',
   testURL: 'http://localhost',

--- a/packages/simple-hub/src/server.ts
+++ b/packages/simple-hub/src/server.ts
@@ -19,6 +19,7 @@ import {map as fpMap, fold} from 'fp-ts/lib/Either';
 import {cHubParticipantId, cFirebasePrefix} from './constants';
 
 export async function startServer() {
+  console.log(process.cwd());
   fbObservable()
     .pipe(
       map(({snapshotKey, message}) => ({

--- a/packages/simple-hub/src/server.ts
+++ b/packages/simple-hub/src/server.ts
@@ -19,7 +19,6 @@ import {map as fpMap, fold} from 'fp-ts/lib/Either';
 import {cHubParticipantId, cFirebasePrefix} from './constants';
 
 export async function startServer() {
-  console.log(process.cwd());
   fbObservable()
     .pipe(
       map(({snapshotKey, message}) => ({

--- a/packages/simple-hub/tsconfig.json
+++ b/packages/simple-hub/tsconfig.json
@@ -5,7 +5,6 @@
     "module": "commonjs",
     "target": "es2017",
     "noImplicitAny": false,
-    "rootDir": "src",
     "outDir": "lib",
     "esModuleInterop": true,
     "resolveJsonModule": true,
@@ -22,6 +21,6 @@
       "path": "../wire-format"
     }
   ],
-  "include": ["./src"],
+  "include": ["src/**/*", "env.ts"],
   "exclude": ["**/*test_data.ts", "**/__mocks__/*"]
 }


### PR DESCRIPTION
For some reason, `tsc` compilation no longer works for the `simple-hub` package. As in, `tsc` compilation  produces no output. This PR fixes `tsc` configuration and migrates `env.js` to typescript to match devtools.