### PR TITLE
Add validation on deployerAccountIndex

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,8 +206,6 @@ jobs:
     working_directory: /home/circleci/project
     docker:
       - image: circleci/node:10.16.3-browsers
-    environment:
-      SC_ENV: circle-integration-rps
     steps:
       - checkout
       - puppeteer/install
@@ -215,7 +213,7 @@ jobs:
           file: integration-test-stats
       - attach_workspace:
           at: /home/circleci/project
-      - run: (cd packages/e2e-tests && sh ./run-e2e.sh rps)
+      - run: (cd packages/e2e-tests && yarn test:e2e:rps)
       - upload_logs:
           file: integration-test-stats
       - upload_e2e_screenshots:
@@ -226,8 +224,6 @@ jobs:
     working_directory: /home/circleci/project
     docker:
       - image: circleci/node:10.16.3-browsers
-    environment:
-      SC_ENV: circle-integration-w3t
     steps:
       - checkout
       - puppeteer/install
@@ -235,7 +231,7 @@ jobs:
           file: integration-test-web3torrent-stats
       - attach_workspace:
           at: /home/circleci/project
-      - run: (cd packages/e2e-tests && sh ./run-e2e.sh web3torrent)
+      - run: (cd packages/e2e-tests && yarn test:e2e:wrt)
       - store_artifacts:
           path: /tmp/ganache.log
       - store_artifacts:
@@ -258,8 +254,6 @@ jobs:
     working_directory: /home/circleci/project
     docker:
       - image: circleci/node:10.16.3-browsers
-    environment:
-      SC_ENV: circle-integration-w3t-with-hub
     steps:
       - checkout
       - puppeteer/install
@@ -267,7 +261,7 @@ jobs:
           file: integration-test-web3torrent-with-hub-stats
       - attach_workspace:
           at: /home/circleci/project
-      - run: (cd packages/e2e-tests && sh ./run-e2e.sh web3torrent)
+      - run: (cd packages/e2e-tests && yarn test:e2e:w3t-with-hub)
       - store_artifacts:
           path: /tmp/ganache.log
       - store_artifacts:

--- a/packages/devtools/src/ganache/index.ts
+++ b/packages/devtools/src/ganache/index.ts
@@ -116,9 +116,7 @@ export const setupGanache = async (
       deployerAccountIndex >= ETHERLIME_ACCOUNTS.length
     ) {
       throw Error(
-        `Invalid deployer account index ${deployerAccountIndex} : ${JSON.stringify(
-          ETHERLIME_ACCOUNTS
-        )}`
+        `Invalid deployer account index ${deployerAccountIndex} : ${ETHERLIME_ACCOUNTS.length}`
       );
     }
 

--- a/packages/devtools/src/ganache/index.ts
+++ b/packages/devtools/src/ganache/index.ts
@@ -110,6 +110,18 @@ export const setupGanache = async (
     }
     say(`Using the deployments cache at ${deploymentsFile}.`);
 
+    if (
+      !Number.isFinite(deployerAccountIndex) ||
+      deployerAccountIndex < 0 ||
+      deployerAccountIndex >= ETHERLIME_ACCOUNTS.length
+    ) {
+      throw Error(
+        `Invalid deployer account index ${deployerAccountIndex} : ${JSON.stringify(
+          ETHERLIME_ACCOUNTS
+        )}`
+      );
+    }
+
     const deployerAccountKey = ETHERLIME_ACCOUNTS[deployerAccountIndex].privateKey;
 
     type = 'shared';

--- a/packages/e2e-tests/run-e2e.sh
+++ b/packages/e2e-tests/run-e2e.sh
@@ -27,7 +27,7 @@ yarn hub:watch | tee $E2E_ROOT/hub.log &
 hub=$!
 
 cd ../e2e-tests
-yarn run wait-on -d 5000 -t 60000 http://localhost:3000 http://localhost:3055
+yarn run wait-on -d 5000 http://localhost:3000 http://localhost:3055
 yarn test $APP
 code=$?
 

--- a/packages/e2e-tests/run-e2e.sh
+++ b/packages/e2e-tests/run-e2e.sh
@@ -2,25 +2,30 @@
 set -e
 set -u
 
-cd ../devtools
-yarn start:shared-ganache & 
+APP=$1
+E2E_ROOT=$(pwd)
+PACKAGES=$E2E_ROOT/..
+
+
+cd $PACKAGES/devtools
+yarn start:shared-ganache | tee $E2E_ROOT/shared-ganache.log & 
 ganache=$!
 
-cd ../$1 && yarn run wait-on ../../.ganache-deployments/ganache-deployments-8545.json
-yarn start &
+cd $PACKAGES/$APP && yarn run wait-on ../../.ganache-deployments/ganache-deployments-8545.json
+yarn start | tee $E2E_ROOT/app.log &
 app=$!
 
 cd ../xstate-wallet
-yarn start &
+yarn start | tee $E2E_ROOT/xstate-wallet.log &
 wallet=$!
 
 cd ../simple-hub
-yarn hub:watch &
+yarn hub:watch | tee $E2E_ROOT/hub.log &
 hub=$!
 
 cd ../e2e-tests
 yarn run wait-on -d 5000 http://localhost:3000 http://localhost:3055
-yarn test $1
+yarn test $APP
 code=$?
 
 kill $ganache

--- a/packages/e2e-tests/run-e2e.sh
+++ b/packages/e2e-tests/run-e2e.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+set -u
 
 cd ../devtools
 yarn start:shared-ganache & 

--- a/packages/e2e-tests/run-e2e.sh
+++ b/packages/e2e-tests/run-e2e.sh
@@ -6,6 +6,9 @@ APP=$1
 E2E_ROOT=$(pwd)
 PACKAGES=$E2E_ROOT/..
 
+# Kill child processes if I receive SIGINT, SIGTERM or EXIT
+trap 'trap - SIGTERM && kill 0' SIGINT SIGTERM EXIT
+
 
 cd $PACKAGES/devtools
 yarn start:shared-ganache | tee $E2E_ROOT/shared-ganache.log & 
@@ -24,15 +27,10 @@ yarn hub:watch | tee $E2E_ROOT/hub.log &
 hub=$!
 
 cd ../e2e-tests
-yarn run wait-on -d 5000 http://localhost:3000 http://localhost:3055
+yarn run wait-on -d 5000 -t 60000 http://localhost:3000 http://localhost:3055
 yarn test $APP
 code=$?
 
-kill $ganache
-kill $wallet
-kill $app
-kill $hub
-killall node
 if test -f "../../.ganache-deployments/ganache-deployments-8545.json"; then
   rm ../../.ganache-deployments/ganache-deployments-8545.json
 fi

--- a/packages/e2e-tests/run-e2e.sh
+++ b/packages/e2e-tests/run-e2e.sh
@@ -7,6 +7,10 @@ E2E_ROOT=$(pwd)
 PACKAGES=$E2E_ROOT/..
 MONOREPO_ROOT=$E2E_ROOT/../..
 
+WAIT_ON_TIMEOUT=60000
+WAIT_ON_INTERVAL=5000
+WAIT_ON_DELAY=5000
+
 cleanup() {
   if test -f "$MONOREPO_ROOT/.ganache-deployments/ganache-deployments-8545.json"; then
     rm $MONOREPO_ROOT/.ganache-deployments/ganache-deployments-8545.json
@@ -21,17 +25,18 @@ trap 'trap - SIGTERM && cleanup' SIGINT SIGTERM EXIT
 cd $PACKAGES/devtools
 yarn start:shared-ganache | tee $E2E_ROOT/shared-ganache.log & 
 
-cd $PACKAGES/$APP && yarn run wait-on ../../.ganache-deployments/ganache-deployments-8545.json
+yarn run wait-on -t $WAIT_ON_TIMEOUT -i $WAIT_ON_INTERVAL $MONOREPO_ROOT/.ganache-deployments/ganache-deployments-8545.json
+cd $PACKAGES/$APP 
 yarn start | tee $E2E_ROOT/app.log &
 
-cd ../xstate-wallet
+cd $PACKAGES/xstate-wallet
 yarn start | tee $E2E_ROOT/xstate-wallet.log &
 
-cd ../simple-hub
+cd $PACKAGES/simple-hub
 yarn hub:watch | tee $E2E_ROOT/hub.log &
 
-cd ../e2e-tests
-yarn run wait-on -d 5000 http://localhost:3000 http://localhost:3055
+cd $PACKAGES/e2e-tests
+yarn run wait-on -d $WAIT_ON_DELAY -t $WAIT_ON_TIMEOUT -i $WAIT_ON_INTERVAL http://localhost:3000 http://localhost:3055
 yarn test $APP
 code=$?
 

--- a/packages/e2e-tests/run-e2e.sh
+++ b/packages/e2e-tests/run-e2e.sh
@@ -5,33 +5,34 @@ set -u
 APP=$1
 E2E_ROOT=$(pwd)
 PACKAGES=$E2E_ROOT/..
+MONOREPO_ROOT=$E2E_ROOT/../..
+
+cleanup() {
+  if test -f "$MONOREPO_ROOT/.ganache-deployments/ganache-deployments-8545.json"; then
+    rm $MONOREPO_ROOT/.ganache-deployments/ganache-deployments-8545.json
+  fi
+  kill 0
+}
 
 # Kill child processes if I receive SIGINT, SIGTERM or EXIT
-trap 'trap - SIGTERM && kill 0' SIGINT SIGTERM EXIT
+trap 'trap - SIGTERM && cleanup' SIGINT SIGTERM EXIT
 
 
 cd $PACKAGES/devtools
 yarn start:shared-ganache | tee $E2E_ROOT/shared-ganache.log & 
-ganache=$!
 
 cd $PACKAGES/$APP && yarn run wait-on ../../.ganache-deployments/ganache-deployments-8545.json
 yarn start | tee $E2E_ROOT/app.log &
-app=$!
 
 cd ../xstate-wallet
 yarn start | tee $E2E_ROOT/xstate-wallet.log &
-wallet=$!
 
 cd ../simple-hub
 yarn hub:watch | tee $E2E_ROOT/hub.log &
-hub=$!
 
 cd ../e2e-tests
 yarn run wait-on -d 5000 http://localhost:3000 http://localhost:3055
 yarn test $APP
 code=$?
 
-if test -f "../../.ganache-deployments/ganache-deployments-8545.json"; then
-  rm ../../.ganache-deployments/ganache-deployments-8545.json
-fi
 exit $code


### PR DESCRIPTION
See https://github.com/statechannels/monorepo/issues/1593#issuecomment-620954074

There isn't much to be done to resolve #1593 without knowing _why_ the wallet was `undefined` [here](https://github.com/statechannels/monorepo/blob/master/packages/devtools/src/ganache/index.ts#L113). It's either the case that
- `deployerAccountIndex` was out of range (perhaps `NaN`?)
- `ETHERLIME_ACCOUNTS` was modified by something (I can't see how this is possible.)

Aborting in this case, and logging the info, will help us resolve the issue in the future.

