### PR TITLE
Sp/clean some env vars

### DIFF
--- a/packages/e2e-tests/Dockerfile
+++ b/packages/e2e-tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:10.16.3
 
-ARG BRANCH=sp/headful
+ARG BRANCH=master
 # this allows us to make an image with whatever branch we want
 # using --build-arg BRANCH=name_of_the_branch
 # e.g. docker build -t dapp --build-arg BRANCH=master .

--- a/packages/e2e-tests/Dockerfile
+++ b/packages/e2e-tests/Dockerfile
@@ -2,11 +2,9 @@ FROM node:10.16.3
 
 ARG BRANCH=master
 # this allows us to make an image with whatever branch we want
-# using --build-arg BRANCH=name_of_the_branch
 # e.g. docker build -t dapp --build-arg BRANCH=master .
 
 RUN  apt-get update \
-     # See https://crbug.com/795759
      && apt-get install -yq libgconf-2-4 \
      && apt-get install -y wget xvfb --no-install-recommends \
      && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
@@ -20,7 +18,8 @@ WORKDIR /monorepo
 ADD https://api.github.com/repos/statechannels/monorepo/git/refs/heads/$BRANCH version.json
 RUN  git pull 
 RUN  yarn
-# the following lines copy stuff into the image manually, so that we can try things without commiting and pushing
+
+# the following lines can be used to copy local files into the image, without commiting and pushing into github
 # COPY .env.circle-integration-w3t /home/appuser/monorepo/.env.circle-integration-w3t
 # COPY ./puppeteer/helpers.ts /home/appuser/monorepo/packages/e2e-tests/puppeteer/helpers.ts
 

--- a/packages/e2e-tests/Dockerfile
+++ b/packages/e2e-tests/Dockerfile
@@ -8,8 +8,6 @@ ARG BRANCH=sp/headful
 RUN  apt-get update \
      # See https://crbug.com/795759
      && apt-get install -yq libgconf-2-4 \
-     # Install latest chrome dev package, which installs the necessary libs to
-     # make the bundled version of Chromium that Puppeteer installs work.
      && apt-get install -y wget xvfb --no-install-recommends \
      && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
      && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
@@ -26,9 +24,7 @@ RUN  yarn
 # COPY .env.circle-integration-w3t /home/appuser/monorepo/.env.circle-integration-w3t
 # COPY ./puppeteer/helpers.ts /home/appuser/monorepo/packages/e2e-tests/puppeteer/helpers.ts
 
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 ENV DISPLAY :99.0
-ENV PUPPETEER_EXEC_PATH google-chrome-stable
 
 WORKDIR /monorepo/packages/e2e-tests
 

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -164,7 +164,6 @@ export async function setUpBrowser(
       'USE_DAPPETEER was set to TRUE, so ignoring HEADLESS variable and running in headFUL mode'
     );
     browser = await dappeteer.launch(puppeteer, {
-      executablePath: process.env.PUPPETEER_EXEC_PATH, // https://github.com/marketplace/actions/puppeteer-headful
       headless: false,
       slowMo,
       //, Needed to allow both windows to execute JS at the same time


### PR DESCRIPTION
Removes some unnecessary variables from the dockerfile for the e2e test suite.

Based upon @geoknee's work in https://github.com/statechannels/monorepo/commit/d430a69ab317b5b5871875a52e6cb58c81aa4dcb

Tested with the following commands:
 - `yarn test:e2e:w3t`
- `ỳarn persistent-seeder`