### PR TITLE
Add conclude-channel idempotency tests for direct and virtual funding

### DIFF
--- a/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
@@ -76,7 +76,7 @@ const context: Init = {channelId: targetChannelId, funding: 'Direct'};
 let aStore: TestStore;
 let bStore: TestStore;
 
-const allSignState = (state: State) => ({
+const allSignedState = (state: State) => ({
   ...state,
   signatures: [wallet1, wallet2].map(({privateKey}) => createSignatureEntry(state, privateKey))
 });
@@ -194,12 +194,12 @@ beforeEach(async () => {
   const hubStore = new SimpleHub(wallet3.privateKey);
 
   [aStore, bStore].forEach(async (store: TestStore) => {
-    await store.createEntry(allSignState(firstState(allocation, targetChannel)), {
+    await store.createEntry(allSignedState(firstState(allocation, targetChannel)), {
       applicationSite: TEST_SITE
     });
 
     const ledgerEntry = await store.createEntry(
-      allSignState(firstState(allocation, ledgerChannel))
+      allSignedState(firstState(allocation, ledgerChannel))
     );
     await store.setLedgerByEntry(ledgerEntry);
   });

--- a/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
@@ -1,7 +1,8 @@
 import {interpret} from 'xstate';
 import waitForExpect from 'wait-for-expect';
 
-import {Init, machine as createMachine} from '../create-and-fund';
+import {Init, machine as createChannel} from '../create-and-fund';
+import {machine as concludeChannel} from '../conclude-channel';
 
 import {Store} from '../../store';
 import {bigNumberify} from 'ethers/utils';
@@ -9,7 +10,6 @@ import {bigNumberify} from 'ethers/utils';
 import {firstState, calculateChannelId, createSignatureEntry} from '../../store/state-utils';
 import {ChannelConstants, Outcome, State} from '../../store/types';
 import {AddressZero} from 'ethers/constants';
-import {machine as concludeMachine} from '../conclude-channel';
 
 import {wallet1, wallet2, participants, wallet3, TEST_SITE} from './data';
 import {subscribeToMessages} from './message-service';
@@ -94,15 +94,15 @@ beforeEach(async () => {
 
 it('reaches the same amount when running conclude twice', async () => {
   // Let A and B create and fund channel
-  await runUntilSuccess(createMachine);
+  await runUntilSuccess(createChannel);
 
   // Both conclude the channel
-  await runUntilSuccess(concludeMachine);
+  await runUntilSuccess(concludeChannel);
   const amountA1 = (await aStore.chain.getChainInfo(targetChannelId)).amount;
   const amountB1 = (await bStore.chain.getChainInfo(targetChannelId)).amount;
 
   // Run conclude again
-  await runUntilSuccess(concludeMachine);
+  await runUntilSuccess(concludeChannel);
   const amountA2 = (await aStore.chain.getChainInfo(targetChannelId)).amount;
   const amountB2 = (await bStore.chain.getChainInfo(targetChannelId)).amount;
 

--- a/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
@@ -37,17 +37,8 @@ const targetChannel: ChannelConstants = {
 };
 const targetChannelId = calculateChannelId(targetChannel);
 
-const ledgerChannel: ChannelConstants = {
-  channelNonce: bigNumberify(1),
-  chainId,
-  challengeDuration,
-  participants,
-  appDefinition
-};
-
 const destinations = participants.map(p => p.destination);
 const amounts = [bigNumberify(7), bigNumberify(5)];
-const totalAmount = amounts.reduce((a, b) => a.add(b));
 
 const allocation: Outcome = {
   type: 'SimpleAllocation',
@@ -57,9 +48,6 @@ const allocation: Outcome = {
     amount: amounts[i]
   }))
 };
-
-const ledgerAmounts = amounts.map(a => a.add(2));
-const depositAmount = ledgerAmounts.reduce(add).toHexString();
 
 const context: Init = {channelId: targetChannelId, funding: 'Direct'};
 
@@ -85,10 +73,6 @@ beforeEach(async () => {
     await store.createEntry(allSignState(firstState(allocation, targetChannel)), {
       applicationSite: TEST_SITE
     });
-    const ledgerEntry = await store.createEntry(
-      allSignState(firstState(allocation, ledgerChannel))
-    );
-    await store.setLedgerByEntry(ledgerEntry);
   });
 
   subscribeToMessages({

--- a/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
@@ -86,16 +86,16 @@ const allSignState = (state: State) => ({
 
 let chain: FakeChain;
 
-const runUntilSuccess = async (machine, fundingType: 'direct' | 'virtual' = 'direct') => {
+const runUntilSuccess = async (machine, fundingType: 'Direct' | 'Virtual' = 'Direct') => {
   const runMachine = (store: Store) => interpret(machine(store).withContext(context)).start();
   const services = [aStore, bStore].map(runMachine);
-  const targetState = fundingType == 'direct' ? 'success' : {virtualDefunding: 'asLeaf'};
+  const targetState = fundingType == 'Direct' ? 'success' : {virtualDefunding: 'asLeaf'};
 
   await Promise.all(
     services.map(
       service =>
         new Promise(resolve =>
-          service.onTransition(state => state.matches(targetState) && resolve())
+          service.onTransition(state => state.matches(targetState) && service.stop() && resolve())
         )
     )
   );
@@ -217,7 +217,7 @@ it('reaches the same state when running conclude twice for virtual funding', asy
   await createLedgerChannels();
 
   // Both conclude the channel
-  await runUntilSuccess(concludeChannel, 'virtual');
+  await runUntilSuccess(concludeChannel, 'Virtual');
   const amountA1 = (await aStore.chain.getChainInfo(targetChannelId)).amount;
   const amountB1 = (await bStore.chain.getChainInfo(targetChannelId)).amount;
 
@@ -228,7 +228,7 @@ it('reaches the same state when running conclude twice for virtual funding', asy
   expect(entryB1.isFinalized).toBe(true);
 
   // Conclude again
-  await runUntilSuccess(concludeChannel, 'virtual');
+  await runUntilSuccess(concludeChannel, 'Virtual');
   const amountA2 = (await aStore.chain.getChainInfo(targetChannelId)).amount;
   const amountB2 = (await bStore.chain.getChainInfo(targetChannelId)).amount;
 

--- a/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
@@ -1,0 +1,88 @@
+import {AddressZero} from 'ethers/constants';
+import {interpret} from 'xstate';
+import {bigNumberify, hexZeroPad} from 'ethers/utils';
+import waitForExpect from 'wait-for-expect';
+
+import {CHALLENGE_DURATION, CHAIN_NETWORK_ID} from '../../config';
+import {FakeChain} from '../../chain';
+import {machine as concludeChannelMachine} from '../conclude-channel';
+import {Player} from '../../integration-tests/helpers';
+import {signState} from '../../store/state-utils';
+import {simpleEthAllocation} from '../../utils/outcome';
+import {State} from '../../store/types';
+
+import {TestStore} from './store';
+
+jest.setTimeout(50000);
+
+// Test suite variables
+let fakeChain: FakeChain;
+let store: TestStore;
+let playerA: Player;
+let playerB: Player;
+let state: State;
+let channelId: string;
+
+beforeEach(async () => {
+  fakeChain = new FakeChain();
+  store = new TestStore(fakeChain);
+
+  playerA = await Player.createPlayer(
+    '0x275a2e2cd9314f53b42246694034a80119963097e3adf495fbf6d821dc8b6c8e',
+    'PlayerA',
+    fakeChain
+  );
+
+  playerB = await Player.createPlayer(
+    '0x3341c348ea8ade1ba7c3b6f071bfe9635c544b7fb5501797eaa2f673169a7d0d',
+    'PlayerB',
+    fakeChain
+  );
+
+  await store.setPrivateKey('0x275a2e2cd9314f53b42246694034a80119963097e3adf495fbf6d821dc8b6c8e');
+
+  state = {
+    outcome: simpleEthAllocation([
+      {
+        destination: playerA.destination,
+        amount: bigNumberify(hexZeroPad('0x06f05b59d3b20000', 32))
+      },
+      {
+        destination: playerA.destination,
+        amount: bigNumberify(hexZeroPad('0x06f05b59d3b20000', 32))
+      }
+    ]),
+    turnNum: bigNumberify(5),
+    appData: '0x0',
+    isFinal: false,
+    challengeDuration: CHALLENGE_DURATION,
+    chainId: CHAIN_NETWORK_ID,
+    channelNonce: bigNumberify(0),
+    appDefinition: AddressZero,
+    participants: [playerA.participant, playerB.participant]
+  };
+
+  const allSignState = {
+    ...state,
+    signatures: [playerA, playerB].map(({privateKey, signingAddress}) => ({
+      signature: signState(state, privateKey),
+      signer: signingAddress
+    }))
+  };
+
+  channelId = (await store.createEntry(allSignState)).channelId;
+});
+
+it('is idempoent when concluding twice', async () => {
+  interpret(concludeChannelMachine(store)).start();
+  const service = interpret(concludeChannelMachine(store)).start();
+
+  await waitForExpect(async () => {
+    expect(service.state.value).toEqual('waitForResponseOrTimeout');
+    const {
+      channelStorage: {finalizesAt, turnNumRecord}
+    } = await fakeChain.getChainInfo(channelId);
+    expect(finalizesAt).toStrictEqual(state.challengeDuration.add(1));
+    expect(turnNumRecord).toStrictEqual(state.turnNum);
+  }, 10000);
+});

--- a/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
@@ -7,12 +7,7 @@ import {machine as concludeChannel} from '../conclude-channel';
 import {Store} from '../../store';
 import {bigNumberify} from 'ethers/utils';
 
-import {
-  firstState,
-  calculateChannelId,
-  createSignatureEntry,
-  outcomesEqual
-} from '../../store/state-utils';
+import {firstState, calculateChannelId, createSignatureEntry} from '../../store/state-utils';
 import {ChannelConstants, Outcome, State} from '../../store/types';
 import {AddressZero} from 'ethers/constants';
 
@@ -243,6 +238,6 @@ it('reaches the same state when running conclude twice for virtual funding', asy
   expect(amountA2).toMatchObject(amountA1);
   expect(amountB2).toMatchObject(amountB1);
 
-  expect(outcomesEqual(entryA1.latestState.outcome, entryA2.latestState.outcome)).toBe(true);
-  expect(outcomesEqual(entryB1.latestState.outcome, entryB2.latestState.outcome)).toBe(true);
+  expect(entryA1).toMatchObject(entryA2);
+  expect(entryB1).toMatchObject(entryB2);
 });

--- a/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
@@ -92,7 +92,7 @@ beforeEach(async () => {
   });
 });
 
-it('reaches the same amount when running conclude twice', async () => {
+it('reaches the state when running conclude twice', async () => {
   // Let A and B create and fund channel
   await runUntilSuccess(createChannel);
 
@@ -101,11 +101,24 @@ it('reaches the same amount when running conclude twice', async () => {
   const amountA1 = (await aStore.chain.getChainInfo(targetChannelId)).amount;
   const amountB1 = (await bStore.chain.getChainInfo(targetChannelId)).amount;
 
-  // Run conclude again
+  // store entries should have been udpated to finalized state
+  const aEntry1 = await aStore.getEntry(targetChannelId);
+  const bEntry1 = await bStore.getEntry(targetChannelId);
+  expect(aEntry1.isFinalized).toBe(true);
+  expect(bEntry1.isFinalized).toBe(true);
+
+  // Conclude again
   await runUntilSuccess(concludeChannel);
   const amountA2 = (await aStore.chain.getChainInfo(targetChannelId)).amount;
   const amountB2 = (await bStore.chain.getChainInfo(targetChannelId)).amount;
 
+  const aEntry2 = await aStore.getEntry(targetChannelId);
+  const bEntry2 = await bStore.getEntry(targetChannelId);
+
   expect(amountA2).toMatchObject(amountA1);
   expect(amountB2).toMatchObject(amountB1);
+
+  // No change to the store entires, meaning that turnNum, etc. remain the same
+  expect(aEntry1).toMatchObject(aEntry2);
+  expect(bEntry1).toMatchObject(bEntry2);
 });

--- a/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
@@ -93,8 +93,8 @@ it('is idempoent when concluding twice', async () => {
 
   // Inject service.stop() when A concludes and  A restarts concluding
 
-  interpret(concludeChannelMachine(aStore)).start();
-  interpret(concludeChannelMachine(bStore)).start();
+  interpret(concludeChannelMachine(aStore).withContext(context)).start();
+  interpret(concludeChannelMachine(bStore).withContext(context)).start();
 
   // Assert expected states
 });

--- a/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
@@ -92,7 +92,7 @@ beforeEach(async () => {
   });
 });
 
-it('reaches the state when running conclude twice', async () => {
+it('reaches the same state when running conclude twice', async () => {
   // Let A and B create and fund channel
   await runUntilSuccess(createChannel);
 

--- a/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
@@ -1,7 +1,7 @@
 import {interpret} from 'xstate';
 import waitForExpect from 'wait-for-expect';
 
-import {Init, machine} from '../create-and-fund';
+import {Init, machine as createMachine} from '../create-and-fund';
 
 import {Store} from '../../store';
 import {bigNumberify} from 'ethers/utils';
@@ -9,7 +9,7 @@ import {bigNumberify} from 'ethers/utils';
 import {firstState, calculateChannelId, createSignatureEntry} from '../../store/state-utils';
 import {ChannelConstants, Outcome, State} from '../../store/types';
 import {AddressZero} from 'ethers/constants';
-import {machine as concludeChannelMachine} from '../conclude-channel';
+import {machine as concludeMachine} from '../conclude-channel';
 
 import {wallet1, wallet2, participants, wallet3, TEST_SITE} from './data';
 import {subscribeToMessages} from './message-service';
@@ -83,7 +83,8 @@ beforeEach(async () => {
 });
 
 it('is idempoent when concluding twice', async () => {
-  const connectToStore = (store: Store) => interpret(machine(store).withContext(context)).start();
+  // Let A and B create and fund channel
+  const connectToStore = (store: Store) => interpret(createMachine(store).withContext(context)).start();
   const [aService, bService] = [aStore, bStore].map(connectToStore);
 
   await waitForExpect(async () => {
@@ -91,10 +92,17 @@ it('is idempoent when concluding twice', async () => {
     expect(aService.state.value).toEqual('success');
   }, EXPECT_TIMEOUT);
 
+  // Both conclude the channel
+  const connectToStore2 = (store: Store) => interpret(concludeMachine(store).withContext(context)).start();
+  const [aService2, bService2] = [aStore, bStore].map(connectToStore2);
+
+  await waitForExpect(async () => {
+    expect(bService2.state.value).toEqual('success');
+    expect(aService2.state.value).toEqual('success');
+  }, EXPECT_TIMEOUT);
+
   // Inject service.stop() when A concludes and  A restarts concluding
 
-  interpret(concludeChannelMachine(aStore).withContext(context)).start();
-  interpret(concludeChannelMachine(bStore).withContext(context)).start();
-
   // Assert expected states
+  expect((await aStore.chain.getChainInfo(targetChannelId)).amount).toMatchObject(bigNumberify(0));
 });

--- a/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
@@ -102,23 +102,23 @@ it('reaches the same state when running conclude twice', async () => {
   const amountB1 = (await bStore.chain.getChainInfo(targetChannelId)).amount;
 
   // store entries should have been udpated to finalized state
-  const aEntry1 = await aStore.getEntry(targetChannelId);
-  const bEntry1 = await bStore.getEntry(targetChannelId);
-  expect(aEntry1.isFinalized).toBe(true);
-  expect(bEntry1.isFinalized).toBe(true);
+  const entryA1 = await aStore.getEntry(targetChannelId);
+  const entryB1 = await bStore.getEntry(targetChannelId);
+  expect(entryA1.isFinalized).toBe(true);
+  expect(entryB1.isFinalized).toBe(true);
 
   // Conclude again
   await runUntilSuccess(concludeChannel);
   const amountA2 = (await aStore.chain.getChainInfo(targetChannelId)).amount;
   const amountB2 = (await bStore.chain.getChainInfo(targetChannelId)).amount;
 
-  const aEntry2 = await aStore.getEntry(targetChannelId);
-  const bEntry2 = await bStore.getEntry(targetChannelId);
+  const entryA2 = await aStore.getEntry(targetChannelId);
+  const entryB2 = await bStore.getEntry(targetChannelId);
 
   expect(amountA2).toMatchObject(amountA1);
   expect(amountB2).toMatchObject(amountB1);
 
   // No change to the store entires, meaning that turnNum, etc. remain the same
-  expect(aEntry1).toMatchObject(aEntry2);
-  expect(bEntry1).toMatchObject(bEntry2);
+  expect(entryA1).toMatchObject(entryA2);
+  expect(entryB1).toMatchObject(entryB2);
 });

--- a/packages/xstate-wallet/src/workflows/tests/support-state.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/support-state.test.ts
@@ -1,0 +1,159 @@
+import {interpret} from 'xstate';
+
+import {Init, machine as createChannel} from '../create-and-fund';
+import {machine as concludeChannel} from '../conclude-channel';
+
+import {Store, SignedState} from '../../store';
+import {bigNumberify} from 'ethers/utils';
+
+import {firstState, calculateChannelId, createSignatureEntry} from '../../store/state-utils';
+import {ChannelConstants, Outcome, State} from '../../store/types';
+import {AddressZero} from 'ethers/constants';
+
+import {wallet1, wallet2, participants, TEST_SITE} from './data';
+
+import {subscribeToMessages} from './message-service';
+
+import {FakeChain} from '../../chain';
+import {ETH_ASSET_HOLDER_ADDRESS} from '../../config';
+
+import {TestStore} from './store';
+
+jest.setTimeout(5000);
+
+const chainId = '0x01';
+const challengeDuration = bigNumberify(10);
+const appDefinition = AddressZero;
+
+const targetChannel: ChannelConstants = {
+  channelNonce: bigNumberify(0),
+  chainId,
+  challengeDuration,
+  participants,
+  appDefinition
+};
+const targetChannelId = calculateChannelId(targetChannel);
+
+const destinations = participants.map(p => p.destination);
+
+const amounts = [bigNumberify(7), bigNumberify(5)];
+
+const allocation: Outcome = {
+  type: 'SimpleAllocation',
+  assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS,
+  allocationItems: [0, 1].map(i => ({
+    destination: destinations[i],
+    amount: amounts[i]
+  }))
+};
+
+const context: Init = {channelId: targetChannelId, funding: 'Direct'};
+
+const allSignedState = (state: State) => ({
+  ...state,
+  signatures: [wallet1, wallet2].map(({privateKey}) => createSignatureEntry(state, privateKey))
+});
+
+const ASignedStateOnly = (state: State) => ({
+  ...state,
+  signatures: [createSignatureEntry(state, wallet1.privateKey)]
+});
+
+const BSignedStateOnly = (state: State) => ({
+  ...state,
+  signatures: [createSignatureEntry(state, wallet2.privateKey)]
+});
+
+const noSignedState = (state: State) => ({
+  ...state,
+  signatures: []
+});
+
+const runUntilSuccess = async (machine, stores: Array<TestStore>) => {
+  const runMachine = (store: Store) => interpret(machine(store).withContext(context)).start();
+  const services = stores.map(runMachine);
+
+  await Promise.all(
+    services.map(
+      service =>
+        new Promise(resolve =>
+          service.onTransition(state => state.matches('success') && service.stop() && resolve())
+        )
+    )
+  );
+};
+
+const concludeAndAssert = async (stores: Array<TestStore>) => {
+  const [aStore, bStore] = stores;
+  // Both conclude the channel
+  await runUntilSuccess(concludeChannel, stores);
+
+  // store entries should have been udpated to finalized state
+  const entryA1 = await aStore.getEntry(targetChannelId);
+  const entryB1 = await bStore.getEntry(targetChannelId);
+  expect(entryA1.isFinalized).toBe(true);
+  expect(entryB1.isFinalized).toBe(true);
+};
+
+const setupStores = async (entryState: SignedState) => {
+  const chain = new FakeChain();
+  const aStore = new TestStore(chain);
+  await aStore.initialize([wallet1.privateKey]);
+  const bStore = new TestStore(chain);
+  await bStore.initialize([wallet2.privateKey]);
+  await aStore.createEntry(entryState, {
+    applicationSite: TEST_SITE
+  });
+  await bStore.createEntry(entryState, {
+    applicationSite: TEST_SITE
+  });
+
+  subscribeToMessages({
+    [participants[0].participantId]: aStore,
+    [participants[1].participantId]: bStore
+  });
+
+  return [aStore, bStore];
+};
+
+describe('supportState machine is idempotent', () => {
+  // eslint-disable-next-line jest/expect-expect
+  it('concludes correctly when starting with all signed states', async () => {
+    const entryState = allSignedState(firstState(allocation, targetChannel));
+
+    const stores = await setupStores(entryState);
+
+    await runUntilSuccess(createChannel, stores);
+    await concludeAndAssert(stores);
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  it('concludes correctly when starting with A signed state only', async () => {
+    const entryState = ASignedStateOnly(firstState(allocation, targetChannel));
+
+    const stores = await setupStores(entryState);
+
+    await runUntilSuccess(createChannel, stores);
+    await concludeAndAssert(stores);
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  it('concludes correctly when starting with B signed state only', async () => {
+    const entryState = BSignedStateOnly(firstState(allocation, targetChannel));
+
+    const stores = await setupStores(entryState);
+
+    await runUntilSuccess(createChannel, stores);
+    await concludeAndAssert(stores);
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  it('concludes correctly when starting with no signed state', async () => {
+    const entryState = noSignedState(firstState(allocation, targetChannel));
+
+    const stores = await setupStores(entryState);
+
+    await runUntilSuccess(createChannel, stores);
+    await concludeAndAssert(stores);
+  });
+});


### PR DESCRIPTION
Addresses: https://github.com/statechannels/monorepo/issues/1602

TODO
- [x] Fix the setup to simulate a directly funded channel between PlayerA and PlayerB
- [x] Fix the failing test
- ~~[ ] Refactor the test setup code (currently it is copied from `challenge.test.ts`)~~

Update: Latest commit also adds a test for the virtual funding case, which addresses: https://github.com/statechannels/monorepo/issues/1603