### PR TITLE
Create a dockerignore that works with persistent seeder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,23 @@
-packages/simple-hub/docker/simple-hub.dockerfile.dockerignore
+# A .dockerignore symlink to this file exists in the monorepo root
+# circleci uses a docker version that does not support buildkit.
+# .dockerignore must be located at the root of the context and have a generic name.
+# https://github.com/statechannels/monorepo/issues/1615 tracks the buildkit issue.
+
+# Note: context for building the docker container is the root of the monorepo
+
+# Ignore all first.
+*
+# Then add back directories that are needed.
+!./*.json
+!.env.*
+!yarn.lock
+!./package.json
+!./packages/devtools
+!./packages/e2e-tests
+!./packages/channel-provider
+!./packages/client-api-schema
+!./packages/nitro-protocol
+!./packages/simple-hub/
+!./packages/wire-format
+# Then ignore node_modules
+**/node_modules

--- a/packages/e2e-tests/persistent-seeder-deployment/build-push-release.sh
+++ b/packages/e2e-tests/persistent-seeder-deployment/build-push-release.sh
@@ -2,29 +2,8 @@
 
 set -euf -o pipefail
 BASEDIR=$(dirname "$0")
-BACKUP_DOCKERIGNORE="$BASEDIR"/../../../bk.dockerignore
-GLOBAL_DOCKERIGNORE="$BASEDIR"/../../../.dockerignore
-
-switchDockerIgnore () {
-  # necessary for as long as circleci wont support docker 19.03, which adds multiple .dockerignore files support
-  # https://ideas.circleci.com/ideas/CCI-I-1265
-  # https://stackoverflow.com/a/57774684/6569950
-  echo "Switching dockerignore"
-  cp "$BASEDIR"/../../../.dockerignore "$BACKUP_DOCKERIGNORE"
-  cp persistent-seeder.dockerfile.dockerignore "$GLOBAL_DOCKERIGNORE"
-}
-
-restoreDockerIgnore() { #resets, if necessary, the .dockerignore file to it's original state
-  if test -f "$BACKUP_DOCKERIGNORE"; then
-    echo "Restoring dockerignore backup"
-    mv "$BACKUP_DOCKERIGNORE" "$GLOBAL_DOCKERIGNORE"
-  fi
-}
-
 
 # MAIN SCRIPT
-switchDockerIgnore
 docker build -t registry.heroku.com/persistent-seeder-staging/persistent-seeder -f persistent-seeder.dockerfile "$BASEDIR"/../../.. || restoreDockerIgnore
-restoreDockerIgnore
 docker push registry.heroku.com/persistent-seeder-staging/persistent-seeder
 heroku container:release -a persistent-seeder-staging persistent-seeder

--- a/packages/e2e-tests/persistent-seeder-deployment/persistent-seeder.dockerfile.dockerignore
+++ b/packages/e2e-tests/persistent-seeder-deployment/persistent-seeder.dockerfile.dockerignore
@@ -1,18 +1,1 @@
-# A .dockerignore symlink to this file exists in the monorepo root
-# circleci uses a docker version that does not support buildkit.
-# .dockerignore must be located at the root of the context and have a generic name.
-# https://github.com/statechannels/monorepo/issues/1615 tracks the buildkit issue.
-
-# Note: context for building the docker container is the root of the monorepo
-# Ignore all first, then add back directories that are needed.
-*
-
-!.env.*
-!./yarn.lock
-!./*.json
-!./packages/devtools
-!./packages/e2e-tests
-!./packages/channel-provider
-!./packages/client-api-schema
-
-**/node_modules
+../../../.dockerignore

--- a/packages/simple-hub/docker/simple-hub.dockerfile.dockerignore
+++ b/packages/simple-hub/docker/simple-hub.dockerfile.dockerignore
@@ -1,17 +1,1 @@
-# A .dockerignore symlink to this file exists in the monorepo root
-# circleci uses a docker version that does not support buildkit.
-# .dockerignore must be located at the root of the context and have a generic name.
-# https://github.com/statechannels/monorepo/issues/1615 tracks the buildkit issue.
-
-# Note: context for building the docker container is the root of the monorepo
-# Ignore all first, then add back directories that are needed.
-*
-
-!.env.*
-!yarn.lock
-!./package.json
-!./packages/nitro-protocol
-!./packages/simple-hub/
-!./packages/wire-format
-
-**/node_modules
+../../../.dockerignore


### PR DESCRIPTION
This PR symlinks package specific dockerignores (for `simple-hub` and `e2e-tests`) to the monorepo general `.dockerignore`. Before this PR, monorepo `.dockerignore` was a symlink to the `simple-hub `.dockerignore`, and `e2e-test` `.dockerignore` was a lone ranger 🤠  that will not work with CircleCI deployments.