### PR TITLE
[w3t, e2e] Wait for input button to not be disabled

### DIFF
--- a/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
+++ b/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
@@ -32,15 +32,9 @@ export async function uploadFile(
   filePath?: string
 ): Promise<string> {
   // https://pub.dev/documentation/puppeteer/latest/puppeteer/FileChooser-class.html
-  // Not clear why puppeteer FileChooser won't work out of box. We are doing it manually for now.
-  const inputUploadHandle = await page.waitForSelector('input[type=file]');
-  if (inputUploadHandle.getProperty('disabled')) {
-    console.warn('Input button is disabled!!');
-    await page.waitFor(4000);
-    if (inputUploadHandle.getProperty('disabled')) {
-      process.exit();
-    }
-  }
+  // Not clear why puppeteer FileChooser won't work out of box. We are doing it manually for now.')
+  const inputUploadHandle = await page.waitForSelector('input:not([disabled])[type=file]');
+
   // By default, generate a /tmp stub file with deterministic data for upload testing
   !filePath && (filePath = '/tmp/web3torrent-tests-stub') && prepareStubUploadFile(filePath);
 

--- a/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
+++ b/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
@@ -31,14 +31,19 @@ export async function uploadFile(
   metamask: Dappeteer,
   filePath?: string
 ): Promise<string> {
-  await page.waitForSelector('input[type=file]');
-
+  // https://pub.dev/documentation/puppeteer/latest/puppeteer/FileChooser-class.html
+  // Not clear why puppeteer FileChooser won't work out of box. We are doing it manually for now.
+  const inputUploadHandle = await page.waitForSelector('input[type=file]');
+  if (inputUploadHandle.getProperty('disabled')) {
+    console.warn('Input button is disabled!!');
+    await page.waitFor(4000);
+    if (inputUploadHandle.getProperty('disabled')) {
+      process.exit();
+    }
+  }
   // By default, generate a /tmp stub file with deterministic data for upload testing
   !filePath && (filePath = '/tmp/web3torrent-tests-stub') && prepareStubUploadFile(filePath);
 
-  // https://pub.dev/documentation/puppeteer/latest/puppeteer/FileChooser-class.html
-  // Not clear why puppeteer FileChooser won't work out of box. We are doing it manually for now.
-  const inputUploadHandle = await page.$('input[type=file]');
   await inputUploadHandle!.uploadFile(filePath);
   await inputUploadHandle!.evaluate(upload => {
     // eslint-disable-next-line no-undef

--- a/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
+++ b/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
@@ -44,8 +44,8 @@ export async function uploadFile(
   // By default, generate a /tmp stub file with deterministic data for upload testing
   !filePath && (filePath = '/tmp/web3torrent-tests-stub') && prepareStubUploadFile(filePath);
 
-  await inputUploadHandle!.uploadFile(filePath);
-  await inputUploadHandle!.evaluate(upload => {
+  await inputUploadHandle.uploadFile(filePath);
+  await inputUploadHandle.evaluate(upload => {
     // eslint-disable-next-line no-undef
     upload.dispatchEvent(new Event('change', {bubbles: true}));
   });


### PR DESCRIPTION
I am seeing this issue on production right now. I want to add some message to disambiguate this problem from other "we are stuck waiting on something" puppeteer error messages. 

