### PR TITLE
[xstate-wallet] fix release:netlify:production

### DIFF
--- a/packages/xstate-wallet/package.json
+++ b/packages/xstate-wallet/package.json
@@ -79,7 +79,7 @@
     "generateConfigs": "yarn run ts-node bin/generateConfigs.ts",
     "lint:check": "eslint . --ext .ts --cache",
     "lint:write": "eslint . --ext .ts --fix",
-    "release:netlify:production": "netlify deploy --site $WALLET_NETLIFY_ID --dir=build",
+    "release:netlify:production": "netlify deploy --site $XSTATE_WALLET_NETLIFY_ID --dir=build",
     "start": "node scripts/start.js",
     "start:shared-ganache": "NODE_ENV=development npx start-shared-ganache",
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
⚠️ Without this PR, `xstate-wallet` release pipeline is broken. ⚠️ 