### PR TITLE
Bump up release-netlify-production resource_class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,6 +298,7 @@ jobs:
 
   release-netlify-production:
     <<: *defaults
+    resource_class: large
     steps:
       - checkout
       - log_stats:


### PR DESCRIPTION
The job is [running out of memory](https://circle-production-customer-artifacts.s3.amazonaws.com/picard/5d85227bbc97ad5ba7cf4fb2/5eac40a9ffae755ecb225523-0-build/artifacts/netlify-stats?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20200501T153939Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Credential=AKIAJR3Q6CR467H7Z55A%2F20200501%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=939483a173df678f8fbefe8cb07c857e363cafd5260728d88935de58112b0329) when building `xtate-wallet` and `web3torrent` simultaneously: 