### PR TITLE
[w3t] Log info about waiting for the wallet to wake up

### DIFF
--- a/packages/channel-provider/src/channel-provider.ts
+++ b/packages/channel-provider/src/channel-provider.ts
@@ -52,6 +52,7 @@ class ChannelProvider implements ChannelProviderInterface {
     this.messaging.setUrl(this.url);
     await this.ui.mount();
     console.info('Application successfully mounted Wallet iFrame inside DOM.');
+    console.info('Waiting for wallet ping...');
     await this.walletReady;
     console.info('Wallet ready to receive requests');
     const {signingAddress, selectedAddress, walletVersion} = await this.send({


### PR DESCRIPTION
Currently we only log info when the wallet successfully loads. At a minimum, we should hint that we are waiting for this. 

Currently if all you see  " 'Application successfully mounted Wallet iFrame inside DOM.'" (after several seconds), it is not obvious that all-is-not-well.

We might want to actually show the user some hint of the problem, too. Right now the upload button being disabled is the only hint (but this is also the hint for being on the wrong network, which doesn't have a separate hint #1641 ). 

Suggestions for a better message are welcome. 

