### PR TITLE
[simple-hub] add dotenv dependencies

### DIFF
--- a/packages/simple-hub/docker/simple-hub.dockerfile
+++ b/packages/simple-hub/docker/simple-hub.dockerfile
@@ -23,10 +23,6 @@ RUN sed -ie "/@statechannels\/jest-gas-reporter/d" **/*/package.json
 # Install production dependencies for simple-hub
 COPY ./yarn.lock /statechannels/monorepo/
 RUN yarn --production --prefer-offline
-WORKDIR /statechannels/monorepo/packages/simple-hub
-# Run added dependencies because of configureEnvVariables
-RUN yarn add --ignore-scripts --ignore-optional dotenv dotenv-expand
-
 
 # COPY SOURCE
 WORKDIR /statechannels/monorepo

--- a/packages/simple-hub/package.json
+++ b/packages/simple-hub/package.json
@@ -10,6 +10,8 @@
     "@statechannels/nitro-protocol": "0.0.1",
     "@statechannels/wire-format": "0.0.1",
     "async-lock": "1.2.2",
+    "dotenv": "8.2.0",
+    "dotenv-expand": "5.1.0",
     "ethers": "4.0.45",
     "firebase": "7.11.0",
     "fp-ts": "2.5.3",


### PR DESCRIPTION
The forcing function for this work is that running `yarn add` in the docker container results in all `yarn.lock` dependencies installed (which includes all monorepo production and dev dependencies).