### PR TITLE
simple-hub: pino pretty from devDependency to dependency

### DIFF
--- a/packages/simple-hub/package.json
+++ b/packages/simple-hub/package.json
@@ -16,6 +16,7 @@
     "firebase": "7.11.0",
     "fp-ts": "2.5.3",
     "pino": "6.2.0",
+    "pino-pretty": "4.0.0",
     "rxfire": "3.11.2",
     "rxjs": "6.5.4"
   },
@@ -41,7 +42,6 @@
     "lint-staged": "10.0.4",
     "nodemon": "1.19.4",
     "npm-run-all": "4.1.5",
-    "pino-pretty": "4.0.0",
     "prettier": "1.19.1",
     "ts-jest": "25.0.0",
     "ts-node": "8.6.2",


### PR DESCRIPTION
Seeing the following error in production:
```
2020-05-02T00:57:59.861150+00:00 app[simple-hub.1]: Error: Missing `pino-pretty` module: `pino-pretty` must be installed separately
2020-05-02T00:57:59.861171+00:00 app[simple-hub.1]: at getPrettyStream (/statechannels/monorepo/node_modules/pino/lib/tools.js:187:11)
2020-05-02T00:57:59.861171+00:00 app[simple-hub.1]: at normalizeArgs (/statechannels/monorepo/node_modules/pino/lib/tools.js:347:16)
2020-05-02T00:57:59.861172+00:00 app[simple-hub.1]: at Object.pino [as default] (/statechannels/monorepo/node_modules/pino/pino.js:78:28)
2020-05-02T00:57:59.861172+00:00 app[simple-hub.1]: at Object.<anonymous> (/statechannels/monorepo/packages/simple-hub/lib/src/logger.js:14:79)
2020-05-02T00:57:59.861173+00:00 app[simple-hub.1]: at Module._compile (internal/modules/cjs/loader.js:778:30)
2020-05-02T00:57:59.861174+00:00 app[simple-hub.1]: at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
2020-05-02T00:57:59.861174+00:00 app[simple-hub.1]: at Module.load (internal/modules/cjs/loader.js:653:32)
2020-05-02T00:57:59.861174+00:00 app[simple-hub.1]: at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
2020-05-02T00:57:59.861175+00:00 app[simple-hub.1]: at Function.Module._load (internal/modules/cjs/loader.js:585:3)
2020-05-02T00:57:59.861175+00:00 app[simple-hub.1]: at Module.require (internal/modules/cjs/loader.js:692:17)
```