### PR TITLE
[web3t] Run e2e test against deployed apps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,7 +417,8 @@ workflows:
 
       - e2e-test-w3t-production:
           # for testing only
-          # requires:
+          requires:
+            - prepare
           #   - release-hub-production
           #   - release-netlify-production
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,6 +342,25 @@ jobs:
           tag: latest
       - run: heroku container:release -a simple-hub-staging simple-hub
 
+  e2e-test-w3t-production:
+    resource_class: large
+    working_directory: /home/circleci/project
+    docker:
+      - image: circleci/node:10.16.3-browsers
+    environment:
+      SC_ENV: production-ropsten
+    steps:
+      - install_xvfb
+      - run_xvfb
+      - checkout
+      - log_stats:
+          file: e2e-test-w3t-production-stats
+      - attach_workspace:
+          at: /home/circleci/project
+      - run: (cd packages/e2e-tests && yarn jest web3torrent)
+      - upload_logs:
+          file: e2e-test-w3t-production-stats
+
   push-master-to-deploy:
     working_directory: /home/circleci/project
     resource_class: small
@@ -392,6 +411,14 @@ workflows:
               only: deploy
 
       - release-hub-production:
+          filters:
+            branches:
+              only: deploy
+
+      - e2e-test-w3t-production:
+          requires:
+            - release-hub-production
+            - release-netlify-production
           filters:
             branches:
               only: deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,12 +416,15 @@ workflows:
               only: deploy
 
       - e2e-test-w3t-production:
-          requires:
-            - release-hub-production
-            - release-netlify-production
+          # for testing only
+          # requires:
+          #   - release-hub-production
+          #   - release-netlify-production
           filters:
             branches:
-              only: deploy
+              # for testing
+              # only: deploy
+              only: george/deploy-test-circle
 
   scheduled-release:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,16 +416,13 @@ workflows:
               only: deploy
 
       - e2e-test-w3t-production:
-          # for testing only
           requires:
             - prepare
-          #   - release-hub-production
-          #   - release-netlify-production
+            - release-hub-production
+            - release-netlify-production
           filters:
             branches:
-              # for testing
-              # only: deploy
-              only: george/deploy-test-circle
+              only: deploy
 
   scheduled-release:
     triggers:

--- a/.env.circle-integration-w3t
+++ b/.env.circle-integration-w3t
@@ -13,6 +13,7 @@ BROWSER_LOG_DESTINATION = 'browser.log'
 HEADLESS = 'false'
 USE_DAPPETEER = 'true'
 TARGET_NETWORK = 'localhost'
+WEB3TORRENT_URL = 'http://localhost:3000'
 
 ## xstate-wallet
 XSTATE_WALLET_DEPLOYER_ACCOUNT_INDEX = '3'

--- a/.env.circle-integration-w3t-with-hub
+++ b/.env.circle-integration-w3t-with-hub
@@ -13,6 +13,8 @@ BROWSER_LOG_DESTINATION = 'browser.log'
 HEADLESS = 'false'
 USE_DAPPETEER = 'true'
 TARGET_NETWORK = 'localhost'
+WEB3TORRENT_URL = 'http://localhost:3000'
+
 ## simple-hub
 SIMPLE_HUB_DEPLOYER_ACCOUNT_INDEX = '1'
 FIREBASE_PREFIX = 'simple-hub'

--- a/.env.local-ropsten
+++ b/.env.local-ropsten
@@ -1,6 +1,10 @@
 ## all
 NODE_ENV = 'production'
 
+
+# e2e-tests
+WEB3TORRENT_URL = 'https://localhost:3000'
+
 ## web3torrent, xstate-wallet, rps, simple-hub
 CHAIN_NETWORK_ID = '3'
 

--- a/.env.persistent-seeder
+++ b/.env.persistent-seeder
@@ -6,6 +6,7 @@ CHAIN_NETWORK_ID = '3'
 
 ## rps, xstate-wallet, e2e-tests
 TARGET_NETWORK = 'ropsten'
+WEB3TORRENT_URL = 'https://web3torrent.statechannels.org'
 
 ## e2e-tests
 HEADLESS=false

--- a/.env.production-ropsten
+++ b/.env.production-ropsten
@@ -4,7 +4,6 @@ NODE_ENV = 'production'
 # e2e-tests
 HEADLESS = 'false'
 USE_DAPPETEER = 'true'
-WEB3TORRENT_URL = 'http://localhost:3000'
 WEB3TORRENT_URL = 'https://web3torrent.statechannels.org'
 
 ## web3torrent, xstate-wallet, rps, simple-hub

--- a/.env.production-ropsten
+++ b/.env.production-ropsten
@@ -2,6 +2,9 @@
 NODE_ENV = 'production'
 
 # e2e-tests
+HEADLESS = 'false'
+USE_DAPPETEER = 'true'
+WEB3TORRENT_URL = 'http://localhost:3000'
 WEB3TORRENT_URL = 'https://web3torrent.statechannels.org'
 
 ## web3torrent, xstate-wallet, rps, simple-hub

--- a/.env.production-ropsten
+++ b/.env.production-ropsten
@@ -1,6 +1,9 @@
 ## all
 NODE_ENV = 'production'
 
+# e2e-tests
+WEB3TORRENT_URL = 'https://web3torrent.statechannels.org'
+
 ## web3torrent, xstate-wallet, rps, simple-hub
 CHAIN_NETWORK_ID = '3'
 

--- a/packages/e2e-tests/puppeteer/__tests__/web3torrent/seed-download.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/web3torrent/seed-download.test.ts
@@ -2,7 +2,15 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable jest/expect-expect */
 import {Page, Browser} from 'puppeteer';
-import {JEST_TIMEOUT, HEADLESS, USES_VIRTUAL_FUNDING, USE_DAPPETEER} from '../../constants';
+
+// importing from '../../constants' will also run devtools configureEnvVariables
+import {
+  JEST_TIMEOUT,
+  HEADLESS,
+  USES_VIRTUAL_FUNDING,
+  USE_DAPPETEER,
+  WEB3TORRENT_URL
+} from '../../constants';
 
 import {
   setUpBrowser,
@@ -31,7 +39,6 @@ let tabs: [Page, Page];
 
 describe('Web3-Torrent Integration Tests', () => {
   beforeAll(async () => {
-    // 100ms sloMo avoids some undiagnosed race conditions
     console.log('Opening browsers');
 
     const setupAPromise = setUpBrowser(HEADLESS, 4, 0);
@@ -51,7 +58,7 @@ describe('Web3-Torrent Integration Tests', () => {
     if (!USE_DAPPETEER) await setupFakeWeb3(web3tTabA, 0);
     if (!USE_DAPPETEER) await setupFakeWeb3(web3tTabB, 0);
 
-    await web3tTabA.goto('http://localhost:3000/upload', {waitUntil: 'load'});
+    await web3tTabA.goto(WEB3TORRENT_URL + '/upload', {waitUntil: 'load'});
 
     await web3tTabA.bringToFront();
   });

--- a/packages/e2e-tests/puppeteer/__tests__/web3torrent/withdraw.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/web3torrent/withdraw.test.ts
@@ -9,7 +9,13 @@ import {
   setupLogging,
   setupFakeWeb3
 } from '../../helpers';
-import {JEST_TIMEOUT, USES_VIRTUAL_FUNDING, HEADLESS, USE_DAPPETEER} from '../../constants';
+import {
+  JEST_TIMEOUT,
+  USES_VIRTUAL_FUNDING,
+  HEADLESS,
+  USE_DAPPETEER,
+  WEB3TORRENT_URL
+} from '../../constants';
 import {Browser, Page} from 'puppeteer';
 import {uploadFile} from '../../scripts/web3torrent';
 import {Dappeteer} from 'dappeteer';
@@ -33,7 +39,7 @@ describe('withdrawal from a ledger channel', () => {
     console.log('Loading dapps');
     await setupLogging(web3tTabA, 0, 'withdraw', true);
     if (!USE_DAPPETEER) await setupFakeWeb3(web3tTabA, 0);
-    await web3tTabA.goto('http://localhost:3000/upload', {waitUntil: 'load'});
+    await web3tTabA.goto(WEB3TORRENT_URL + '/upload', {waitUntil: 'load'});
     await web3tTabA.bringToFront();
   });
 

--- a/packages/e2e-tests/puppeteer/constants.ts
+++ b/packages/e2e-tests/puppeteer/constants.ts
@@ -5,3 +5,6 @@ export const USE_DAPPETEER = getEnvBool('USE_DAPPETEER');
 export const USES_VIRTUAL_FUNDING = process.env.REACT_APP_FUNDING_STRATEGY === 'Virtual';
 export const JEST_TIMEOUT = HEADLESS ? 200_000 : 1_000_000;
 export const TARGET_NETWORK = process.env.TARGET_NETWORK ? process.env.TARGET_NETWORK : 'localhost';
+export const WEB3TORRENT_URL = process.env.WEB3TORRENT_URL
+  ? process.env.WEB3TORRENT_URL
+  : 'http://localhost:3000';

--- a/packages/e2e-tests/puppeteer/scripts/persistent-seeder.ts
+++ b/packages/e2e-tests/puppeteer/scripts/persistent-seeder.ts
@@ -1,5 +1,6 @@
 import {setUpBrowser, setupLogging} from '../helpers';
 import {uploadFile} from './web3torrent';
+import {WEB3TORRENT_URL} from '../constants';
 
 export async function persistentSeeder(): Promise<void> {
   console.log('Opening browser');
@@ -11,7 +12,7 @@ export async function persistentSeeder(): Promise<void> {
   console.log('Setting up logging...');
   await setupLogging(web3tTabA, 0, 'minimal-dapp', true);
 
-  await web3tTabA.goto('https://web3torrent.statechannels.org/upload', {waitUntil: 'load'});
+  await web3tTabA.goto(WEB3TORRENT_URL + '/upload', {waitUntil: 'load'});
   await web3tTabA.bringToFront();
 
   const url = await uploadFile(web3tTabA, true, metamask, './nitro-protocol.pdf');


### PR DESCRIPTION
- converts e2e tests for w3t to read in target app url via new env var 
- new circle job `e2e-test-w3t-production`
  - only runs on deploy branch, and *after* apps have been redeployed
  - does not start any servers of its own
  - runs e2e tests (headful, dappeteer enabled) against specified environment (assumes servers are running)

Closes #1620 .

Tested against *this* branch (temporarily). Test runs and fails due to known issues. 