### PR TITLE
[debugging] Simulate a slow chain

### DIFF
--- a/packages/devtools/src/ganache/server.ts
+++ b/packages/devtools/src/ganache/server.ts
@@ -30,7 +30,10 @@ export class GanacheServer {
 
     const oneMillion = ethers.utils.parseEther('1000000');
 
+    const blockTime = 30; // simulate 15s blocktime of a real chain, plus a little extra to account for slower MM polling when not on localhost:8545
+
     const opts = [
+      [`--blockTime ${blockTime}`],
       [`--networkId ${this.chainId}`, `--port ${this.port}`],
       accounts.map(a => `--account ${a.privateKey},${a.amount || oneMillion}`),
       [`--gasLimit ${gasLimit}`, `--gasPrice ${gasPrice}`],


### PR DESCRIPTION
Unknown: why does torrenting not work in production?

Known: production uses ropsten, which is slower than ganache (by default)

Hypothesis: perhaps the long wait is to blame?

Ansatz: simulate the long wait.

Conclusion: Hypothesis rejected. 