### PR TITLE
[simple-hub] change heroku application naming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,15 +332,15 @@ jobs:
       - run: curl https://cli-assets.heroku.com/install.sh | sh
       - run: heroku container:login
       - docker/build:
-          cache_from: registry.heroku.com/simple-hub-staging/simple-hub:latest
+          cache_from: registry.heroku.com/simple-hub-production/simple-hub:latest
           dockerfile: packages/simple-hub/docker/simple-hub.dockerfile
-          image: registry.heroku.com/simple-hub-staging/simple-hub
+          image: registry.heroku.com/simple-hub-production/simple-hub
           tag: latest
       - docker/push:
-          image: simple-hub-staging/simple-hub
+          image: simple-hub-production/simple-hub
           registry: registry.heroku.com
           tag: latest
-      - run: heroku container:release -a simple-hub-staging simple-hub
+      - run: heroku container:release -a simple-hub-production simple-hub
 
   e2e-test-w3t-production:
     resource_class: large

--- a/packages/simple-hub/docker/build-push-release.sh
+++ b/packages/simple-hub/docker/build-push-release.sh
@@ -2,6 +2,6 @@
 set -euf -o pipefail
 BASEDIR=$(dirname "$0")
 
-docker build -t registry.heroku.com/simple-hub-staging/simple-hub -f "$BASEDIR"/simple-hub.dockerfile "$BASEDIR"/../../..
-docker push registry.heroku.com/simple-hub-staging/simple-hub
-heroku container:release -a simple-hub-staging simple-hub
+docker build -t registry.heroku.com/simple-hub-production/simple-hub -f "$BASEDIR"/simple-hub.dockerfile "$BASEDIR"/../../..
+docker push registry.heroku.com/simple-hub-production/simple-hub
+heroku container:release -a simple-hub-production simple-hub

--- a/packages/simple-hub/docker/simple-hub.dockerfile
+++ b/packages/simple-hub/docker/simple-hub.dockerfile
@@ -38,6 +38,6 @@ WORKDIR /statechannels/monorepo/packages/simple-hub
 # https://devcenter.heroku.com/articles/container-registry-and-runtime#dockerfile-commands-and-runtime
 #   CMD will always be executed by a shell ... to execute single binaries or use images without a shell please use ENTRYPOINT
 # To interactively debug the container:
-# docker run -it registry.heroku.com/simple-hub-staging/simple-hub:latest bash
+# docker run -it registry.heroku.com/simple-hub-production/simple-hub:latest bash
 ENTRYPOINT ["docker/docker-entrypoint.sh"]
 CMD ["node", "./lib/src/server.js"]

--- a/packages/simple-hub/readme.md
+++ b/packages/simple-hub/readme.md
@@ -58,11 +58,11 @@ Heroku runs a production version of the build `docker/simple-hub.dockerfile`. To
 To start a hub in a docker container locally with development environment variables:
 
 ```
-docker run -it --env-file .env.development registry.heroku.com/simple-hub-staging/simple-hub:latest
+docker run -it --env-file .env.development registry.heroku.com/simple-hub-production/simple-hub:latest
 ```
 
 To start a docker container locally without starting the hub, append `bash` to the command above. This is handy when you would like to poke around the container or try running commands in the container:
 
 ```
-docker run -it --env-file .env.development registry.heroku.com/simple-hub-staging/simple-hub:latest bash
+docker run -it --env-file .env.development registry.heroku.com/simple-hub-production/simple-hub:latest bash
 ```


### PR DESCRIPTION
As soon as this PR is merged in, https://dashboard.heroku.com/apps/simple-hub-staging/settings should be ranamed from `simple-hub-staging` to `simple-hub-production`