### PR TITLE
[e2e] Introduce TX_WAIT_TIMEOUT constant

### DIFF
--- a/packages/e2e-tests/puppeteer/constants.ts
+++ b/packages/e2e-tests/puppeteer/constants.ts
@@ -8,3 +8,4 @@ export const TARGET_NETWORK = process.env.TARGET_NETWORK ? process.env.TARGET_NE
 export const WEB3TORRENT_URL = process.env.WEB3TORRENT_URL
   ? process.env.WEB3TORRENT_URL
   : 'http://localhost:3000';
+export const TX_WAIT_TIMEOUT = process.env.TARGET_NETWORK === 'ropsten' ? 90000 : 30000;

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -3,7 +3,7 @@ import * as dappeteer from 'dappeteer';
 
 import * as fs from 'fs';
 import * as path from 'path';
-import {USE_DAPPETEER, TARGET_NETWORK} from './constants';
+import {USE_DAPPETEER, TARGET_NETWORK, TX_WAIT_TIMEOUT} from './constants';
 import {ETHERLIME_ACCOUNTS} from '@statechannels/devtools';
 
 const logDistinguisherCache: Record<string, true | undefined> = {};
@@ -216,7 +216,9 @@ export async function waitForBudgetEntry(page: Page): Promise<void> {
 
 export async function waitForEmptyBudget(page: Page): Promise<void> {
   // eslint-disable-next-line no-undef
-  await page.waitForFunction(() => !document.querySelector('.site-budget-table'));
+  await page.waitForFunction(() => !document.querySelector('.site-budget-table'), {
+    timeout: TX_WAIT_TIMEOUT
+  }); // wait for my tx, which could be slow if on a real blockchain);
 }
 
 export async function waitAndApproveBudget(page: Page): Promise<void> {
@@ -247,7 +249,7 @@ export async function waitAndApproveDepositWithHub(
 ): Promise<void> {
   console.log('Making deposit with hub');
   const walletIFrame = page.frames()[1];
-  await walletIFrame.waitForSelector('#please-approve-transaction', {timeout: 60000}); // longer timeout here because blockchain is slow
+  await walletIFrame.waitForSelector('#please-approve-transaction', {timeout: TX_WAIT_TIMEOUT}); // longer timeout here because blockchain is slow
   await metamask.confirmTransaction({gas: 20, gasLimit: 50000});
   await page.bringToFront();
 }


### PR DESCRIPTION
...and use it wherever we are waiting for a blockchain tx.

We have two e2e tests for web3torrent. Currently `withdraw.test.ts` fails when we target production https://app.circleci.com/pipelines/github/statechannels/monorepo/5927/workflows/72f3061a-0f91-47ae-8e3f-fa3739542874/jobs/23677/steps . However, this seems to be (only) because we time out waiting for ropsten. 

This PR is a hotfix for that which should get the test passing. 

`seed-download.test.ts` will still fail, this PR does nothing to help with that. 

We should probably introduce a more elegant and robust long term fix for this: currently it is difficult to tell when we are waiting for a blockchain transaction. One idea would be to wrap dappeteer's `metamask.confirmTransaction()` method with something like `metamask.confirmTransactionAndWait(numBlocks: number)`. 

