### PR TITLE
[nitro-protocol] Change solc version to 0.6.1

### DIFF
--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -42,7 +42,7 @@
     "prettier": "1.19.1",
     "prettier-plugin-solidity": "1.0.0-alpha.34",
     "server-destroy": "1.0.1",
-    "solc": "0.6.0",
+    "solc": "0.6.1",
     "solidoc": "https://github.com/statechannels/solidoc.git",
     "ts-jest": "25.0.0",
     "ts-node": "8.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -30532,6 +30532,20 @@ solc@0.6.0:
     semver "^5.5.0"
     tmp "0.0.33"
 
+solc@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/solc/-/solc-0.6.1.tgz#9a5080dd4106e37a87f84e6b355d4478e1ea5832"
+  integrity sha512-iKqNYps2p++x8L9sBg7JeAJb7EmW8VJ/2asAzwlLYcUhj86AzuWLe94UTSQHv1SSCCj/x6lya8twvXkZtlTbIQ==
+  dependencies:
+    command-exists "^1.2.8"
+    commander "3.0.2"
+    fs-extra "^0.30.0"
+    js-sha3 "0.8.0"
+    memorystream "^0.3.1"
+    require-from-string "^2.0.0"
+    semver "^5.5.0"
+    tmp "0.0.33"
+
 solc@^0.5.5:
   version "0.5.16"
   resolved "https://registry.npmjs.org/solc/-/solc-0.5.16.tgz#6c8d710a3792ccc79db924606b558a1149b1c603"


### PR DESCRIPTION
For now `solidoc` errors out if the contracts are compiled with `solc =/= 0.6.1`. On circle, we use a native `solc` pinned to `0.6.1` (which matches our contracts' pragmas); but for local development we may fallback on `solcjs`, which is currently pegged to `0.6.0`.

Note that the contract compilation does not error out if the mismatched compiler is used, but the resulting artifacts cause an error in `solidoc`. 

Longer term fix might be to fix `solidoc` (which is forked by us anyway). 