### PR TITLE
Enable source maps in prod

### DIFF
--- a/packages/xstate-wallet/webpack-build.config.js
+++ b/packages/xstate-wallet/webpack-build.config.js
@@ -2,6 +2,5 @@ const merge = require('webpack-merge');
 const common = require('./webpack.config.js');
 
 module.exports = merge(common, {
-  mode: 'production',
-  devtool: ''
+  mode: 'production'
 });


### PR DESCRIPTION
Enable sourcemaps in production for xstate wallet.

It looks like web3torrent already includes sourcemaps.