### PR TITLE
[xstate-wallet] Set production xstate-wallet webpack to development mode

### DIFF
--- a/packages/xstate-wallet/webpack-build.config.js
+++ b/packages/xstate-wallet/webpack-build.config.js
@@ -2,5 +2,5 @@ const merge = require('webpack-merge');
 const common = require('./webpack.config.js');
 
 module.exports = merge(common, {
-  mode: 'production'
+  mode: 'development'
 });


### PR DESCRIPTION
Based on https://github.com/statechannels/monorepo/pull/1696#issuecomment-624313116.

Turns off code minification which interferes with our usage of `Function.name`. [Here](https://github.com/babel/minify/issues/811) is a related issue from `babel` explaining the situation in general.

Example usage in `xstate-wallet`: https://github.com/statechannels/monorepo/blob/187dfc9dc685cccb504eb93c08e025df02e36b72/packages/xstate-wallet/src/workflows/create-and-fund.ts#L117-L121