### PR TITLE
Show transaction id after submission

### DIFF
--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -301,9 +301,9 @@ export class ChainWatcher implements Chain {
       ),
       to: NITRO_ADJUDICATOR_ADDRESS
     };
+
     const response = await signer.sendTransaction(transactionRequest);
-    const transaction = await response.wait();
-    return transaction.transactionHash;
+    return response.hash;
   }
 
   public async challenge(support: SignedState[], privateKey: string): Promise<string | undefined> {
@@ -335,8 +335,7 @@ export class ChainWatcher implements Chain {
       value: amount
     };
     const response = await signer.sendTransaction(transactionRequest);
-    const transaction = await response.wait();
-    return transaction.transactionHash;
+    return response.hash;
   }
 
   public async getChainInfo(channelId: string): Promise<ChannelChainInfo> {

--- a/packages/xstate-wallet/src/ui/approve-budget-and-fund-workflow.tsx
+++ b/packages/xstate-wallet/src/ui/approve-budget-and-fund-workflow.tsx
@@ -91,8 +91,11 @@ export const ApproveBudgetAndFund = (props: Props) => {
       <Text pb={2}>Waiting for your transaction to be mined.</Text>
 
       <Text>
-        Click <Link href={`https://etherscan.io/tx/${transactionId}`}>here</Link> to follow the
-        progress on etherscan.
+        Click{' '}
+        <Link target="_blank" href={`https://ropsten.etherscan.io/tx/${transactionId}`}>
+          here
+        </Link>{' '}
+        to follow the progress on etherscan.
       </Text>
     </Flex>
   );

--- a/packages/xstate-wallet/src/ui/close-ledger-and-withdraw.tsx
+++ b/packages/xstate-wallet/src/ui/close-ledger-and-withdraw.tsx
@@ -76,8 +76,11 @@ export const CloseLedgerAndWithdraw = (props: Props) => {
       <Text pb={2}>Waiting for your transaction to be mined.</Text>
 
       <Text>
-        Click <Link href={`https://etherscan.io/tx/${transactionId}`}>here</Link> to follow the
-        progress on etherscan.
+        Click{' '}
+        <Link target="_blank" href={`https://ropsten.etherscan.io/tx/${transactionId}`}>
+          here
+        </Link>{' '}
+        to follow the progress on etherscan.
       </Text>
     </Flex>
   );

--- a/packages/xstate-wallet/src/workflows/close-ledger-and-withdraw.ts
+++ b/packages/xstate-wallet/src/workflows/close-ledger-and-withdraw.ts
@@ -194,7 +194,7 @@ const submitWithdrawTransaction = (store: Store) => async context => {
   if (!ledgerEntry.isFinalized) {
     throw new Error(`Channel ${ledgerEntry.channelId} is not finalized`);
   }
-  await store.chain.finalizeAndWithdraw(ledgerEntry.support);
+  return store.chain.finalizeAndWithdraw(ledgerEntry.support);
 };
 
 const createObjective = (store: Store) => async context => {


### PR DESCRIPTION
Fixes #1692 

Returns the transaction id immediately instead of waiting for it to be mined (by calling `wait()`)
