### PR TITLE
Remove superfluous call to EnableEthereum breaking CI

### DIFF
--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -325,7 +325,6 @@ export class PaymentChannelClient {
   }
 
   async createBudget(amount: string) {
-    await this.enable();
     const playerDestinationAddress = this.channelClient.selectedAddress;
     this.budgetCache = await this.channelClient.approveBudgetAndFund(
       amount,


### PR DESCRIPTION
Commit 312859a6094863e3e7fec92811ef2a4a299e8164 added an extra call to `EnableEthereum` on the wallet. It should have been harmless, since the wallet does a check to see if it has already been enabled (see below), but due to some kind of timing issue with how quickly MetaMask is able to provide `window.ethereum.selectedAddress`, even after a successful connection, the workflow started twice showing the UI twice, breaking our puppeteer testing scripts.

https://github.com/statechannels/monorepo/blob/d370d4efb131001bc87557a4363fced0c04994ad/packages/xstate-wallet/src/messaging.ts#L173-L181

Action item for future:
- Update the wallet to store whether or not it thinks it got a successful enable from MetaMask