### PR TITLE
Slack notification for hub release from circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,7 +382,7 @@ jobs:
           failure_message: ':red_circle: Failed to release simple-hub at $CIRCLE_SHA1!'
           success_message: ':tada: Released simple-hub at $CIRCLE_SHA1 '
 
-  deploy-persistent-seeder:
+  release-persistent-seeder:
     working_directory: /home/circleci/project
     resource_class: large
     docker:
@@ -472,7 +472,7 @@ workflows:
             branches:
               only: deploy
 
-      - deploy-persistent-seeder:
+      - release-persistent-seeder:
           filters:
             branches:
               only: deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,6 +376,11 @@ jobs:
           dockerfile_path: packages/simple-hub/docker/simple-hub.dockerfile
           pipeline: simple-hub
           app: simple-hub-production
+      - slack/status:
+          # notify-deployments
+          channel: 0125NB072B
+          failure_message: ':red_circle: Failed to release simple-hub at $CIRCLE_SHA1!'
+          success_message: ':tada: Released simple-hub at $CIRCLE_SHA1 '
 
   deploy-persistent-seeder:
     working_directory: /home/circleci/project
@@ -459,7 +464,8 @@ workflows:
             - prepare
           filters:
             branches:
-              only: deploy
+              # todo: change back before creating a PR
+              only: release-hub-slack #deploy
 
       - release-hub-production:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -464,13 +464,13 @@ workflows:
             - prepare
           filters:
             branches:
-              # todo: change back before creating a PR
-              only: release-hub-slack #deploy
+              only: deploy
 
       - release-hub-production:
           filters:
             branches:
-              only: deploy
+              # todo: change back before creating a PR
+              only: release-hub-slack #deploy
 
       - release-persistent-seeder:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,8 +469,7 @@ workflows:
       - release-hub-production:
           filters:
             branches:
-              # todo: change back before creating a PR
-              only: release-hub-slack #deploy
+              only: deploy
 
       - release-persistent-seeder:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ jobs:
           app: simple-hub-production
       - slack/status:
           # notify-deployments
-          channel: 0125NB072B
+          channel: C0125NB072B
           failure_message: ':red_circle: Failed to release simple-hub at $CIRCLE_SHA1!'
           success_message: ':tada: Released simple-hub at $CIRCLE_SHA1 '
 


### PR DESCRIPTION
Unfortunately, I am not sure there is a way to create a notification whenever a new container is released to heroku. If a developer deploys the hub from their local machine, no notification will be sent out.

Fixes https://github.com/statechannels/monorepo/issues/1627.