### PR TITLE
Dump store on error

### DIFF
--- a/packages/xstate-wallet/src/store/channel-store-entry.ts
+++ b/packages/xstate-wallet/src/store/channel-store-entry.ts
@@ -197,7 +197,7 @@ export class ChannelStoreEntry {
 
   signAndAdd(stateVars: StateVariables, privateKey: string): SignedState {
     if (this.isSupportedByMe && this.latestSignedByMe.turnNum.gte(stateVars.turnNum)) {
-      logger.error({entry: this.data(), stateVars});
+      logger.error({entry: this.data(), stateVars}, Errors.staleState);
       throw Error(Errors.staleState);
     }
 


### PR DESCRIPTION
This makes it easier to debug https://github.com/statechannels/monorepo/issues/1693 on circle, and is progress towards https://github.com/statechannels/monorepo/issues/1711.

```
[1588789200271] ERROR (xstate-wallet/19245 on MacBook-Pro-10.local): Transaction error
    error: "Transaction committed too early. See http://bit.ly/2kdckMn"
    store: {
      "budgets": [],
      "channels": [],
      "ledgers": [],
      "nonces": [],
      "objectives": [],
      "privateKeys": [
        {
          "key": "0x11115FAf6f1BF263e81956F0Cc68aEc8426607cf",
          "value": "0x95942b296854c97024ca3145abef8930bf329501b718c0f66d57dba596ff1318"
        }
      ]
    }
```