### PR TITLE
[simple-hub] remove RUNTIME_ENV

### DIFF
--- a/.env.production-ropsten
+++ b/.env.production-ropsten
@@ -33,7 +33,6 @@ HUB_CHAIN_PK = '<override this on private heroku dashboard>'
 HUB_PARTICIPANT_ID = 'firebase:simple-hub'
 INFURA_API_KEY = '11f02c6889494cb8b8f1919a5c536098'
 RPC_ENDPOINT = https://ropsten.infura.io/v3/${INFURA_API_KEY}
-RUNTIME_ENV = 'staging'
 
 ## xstate-wallet
 # hub address is from Heroku which specifies a funded account on Ropsten (kept secret here)

--- a/packages/simple-hub/src/server.ts
+++ b/packages/simple-hub/src/server.ts
@@ -1,11 +1,12 @@
 import '../env'; // Note: importing this module has the side effect of modifying env vars
+import _ from 'lodash';
 
 import * as Sentry from '@sentry/node';
 
-if (process.env.RUNTIME_ENV) {
+if (process.env.HEROKU_APP_NAME) {
   Sentry.init({
     dsn: 'https://18f53d1daf144411b98547e2ac93a914@sentry.io/4410960',
-    environment: process.env.RUNTIME_ENV
+    environment: _.replace(process.env.HEROKU_APP_NAME, 'simple-hub-', '')
   });
 }
 import {fbObservable, deleteIncomingMessage, sendReplies} from './message/firebase-relay';


### PR DESCRIPTION
Running the hub locally with `SV_ENV=production-ropsten` sends alerts to Sentry for the production environment. With this PR, Sentry is configured using the [dyno metadata](https://devcenter.heroku.com/articles/dyno-metadata).