### PR TITLE
[e2e] Wait-on reads from env vars

### DIFF
--- a/packages/e2e-tests/jest.setup.ts
+++ b/packages/e2e-tests/jest.setup.ts
@@ -1,7 +1,8 @@
 import waitOn from 'wait-on';
+import {APP_URL, WALLET_URL} from './puppeteer/constants';
 
 export default async (): Promise<void> => {
-  const resources = ['http://localhost:3000', 'http://localhost:3055'];
+  const resources = [APP_URL, WALLET_URL];
   const opts = {resources, delay: 5000, interval: 2000, timeout: 120000};
   try {
     console.log('Waiting for servers');

--- a/packages/e2e-tests/puppeteer/__tests__/web3torrent/seed-download.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/web3torrent/seed-download.test.ts
@@ -9,7 +9,7 @@ import {
   HEADLESS,
   USES_VIRTUAL_FUNDING,
   USE_DAPPETEER,
-  WEB3TORRENT_URL
+  APP_URL as WEB3TORRENT_URL
 } from '../../constants';
 
 import {

--- a/packages/e2e-tests/puppeteer/__tests__/web3torrent/withdraw.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/web3torrent/withdraw.test.ts
@@ -14,7 +14,7 @@ import {
   USES_VIRTUAL_FUNDING,
   HEADLESS,
   USE_DAPPETEER,
-  WEB3TORRENT_URL
+  APP_URL as WEB3TORRENT_URL
 } from '../../constants';
 import {Browser, Page} from 'puppeteer';
 import {uploadFile} from '../../scripts/web3torrent';

--- a/packages/e2e-tests/puppeteer/constants.ts
+++ b/packages/e2e-tests/puppeteer/constants.ts
@@ -5,7 +5,10 @@ export const USE_DAPPETEER = getEnvBool('USE_DAPPETEER');
 export const USES_VIRTUAL_FUNDING = process.env.REACT_APP_FUNDING_STRATEGY === 'Virtual';
 export const JEST_TIMEOUT = HEADLESS ? 200_000 : 1_000_000;
 export const TARGET_NETWORK = process.env.TARGET_NETWORK ? process.env.TARGET_NETWORK : 'localhost';
-export const WEB3TORRENT_URL = process.env.WEB3TORRENT_URL
+export const APP_URL = process.env.WEB3TORRENT_URL
   ? process.env.WEB3TORRENT_URL
   : 'http://localhost:3000';
+export const WALLET_URL = process.env.REACT_APP_WALLET_URL
+  ? process.env.REACT_APP_WALLET_URL
+  : 'http://localhost:3055';
 export const TX_WAIT_TIMEOUT = process.env.TARGET_NETWORK === 'ropsten' ? 90000 : 30000;

--- a/packages/e2e-tests/puppeteer/scripts/persistent-seeder.ts
+++ b/packages/e2e-tests/puppeteer/scripts/persistent-seeder.ts
@@ -1,6 +1,6 @@
 import {setUpBrowser, setupLogging} from '../helpers';
 import {uploadFile} from './web3torrent';
-import {WEB3TORRENT_URL} from '../constants';
+import {APP_URL as WEB3TORRENT_URL} from '../constants';
 
 export async function persistentSeeder(): Promise<void> {
   console.log('Opening browser');


### PR DESCRIPTION
- defaults to previous localhost 3000 and 3055

Currently there is an unnecessary wait-until-timeout situation when running e2e tests against non localhost servers.

https://app.circleci.com/pipelines/github/statechannels/monorepo/6004/workflows/d3324ad3-f0ef-4c50-ac8a-c9837e3fb706/jobs/24213/steps

