### PR TITLE
Fix store dump

### DIFF
--- a/packages/xstate-wallet/src/store/dexie-backend.ts
+++ b/packages/xstate-wallet/src/store/dexie-backend.ts
@@ -238,7 +238,9 @@ export class Backend implements DBBackend {
   private async dump() {
     return this._db.transaction('r!', STORES, async () =>
       _.reduce(
-        await Promise.all(STORES.map(store => ({[store]: this._db.table(store).toArray()}))),
+        await Promise.all(
+          STORES.map(async store => ({[store]: await this._db.table(store).toArray()}))
+        ),
         _.merge
       )
     );

--- a/packages/xstate-wallet/src/store/dexie-backend.ts
+++ b/packages/xstate-wallet/src/store/dexie-backend.ts
@@ -163,7 +163,7 @@ export class Backend implements DBBackend {
   public async transaction<T, S extends ObjectStores>(
     mode: TXMode,
     stores: S[],
-    cb: (tx: Transaction) => Promise<T>
+    callback: (tx: Transaction) => Promise<T>
   ) {
     let dexieMode: TransactionMode;
     switch (mode) {
@@ -178,9 +178,16 @@ export class Backend implements DBBackend {
     }
 
     try {
-      return await this._db.transaction(dexieMode, stores, cb);
+      return await this._db.transaction(dexieMode, stores, callback);
     } catch (error) {
-      logger.error({error: error.message ?? error, store: await this.dump()}, 'Transaction error');
+      logger.error(
+        {
+          error: error.message ?? error,
+          store: await this.dump(),
+          callback: callback.toString().slice(0, 200) + '...}'
+        },
+        'Transaction error'
+      );
       throw error;
     }
   }


### PR DESCRIPTION
I checked in some bad code, so the example in https://github.com/statechannels/monorepo/pull/1710 was misleading.

This fixes that, and also logs a long enough slice of the callback implementation to identify which store method made the transaction.

```
[1588814673736] ERROR (xstate-wallet/4508 on MacBook-Pro-10.local): Transaction error
    error: "Couldn't find the signing key for any participant in wallet."
    store: {
      "budgets": [],
      "channels": [],
      "ledgers": [],
      "nonces": [],
      "objectives": [],
      "privateKeys": [
        {
          "key": "0x661b985FC2C3CC76c4DB53c8F110D084Bedf0b56",
          "value": "0xdd90c4aa5138901170ebac67ef70b35e157e4e23c6ad6af9c73620a28eb69fb7"
        }
      ]
    }
    callback: "() => __awaiter(this, void 0, void 0, function* () {\n            const addresses = participants.map(x => x.signingAddress);\n            const privateKeys = yield this.backend.privateKeys();\n          ...}"
```