### PR TITLE
[web3torrent] ChannelsList component shows peerAccount

### DIFF
--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -47,7 +47,7 @@ function channelIdToTableRow(
   }
 
   let dataTransferred: string;
-  const peerAccount = channel[participantType];
+
   if (wire) {
     dataTransferred = isBeneficiary ? prettier(wire.uploaded) : prettier(wire.downloaded);
   } else {
@@ -61,7 +61,7 @@ function channelIdToTableRow(
     <tr className="peerInfo" key={channelId}>
       <td className="channel">{channelButton}</td>
       <td className="channel-id">{channelId}</td>
-      <td className="peer-id">{peerAccount}</td>
+      <td className="peer-id">{wire.paidStreamingExtension.peerAccount}</td>
       <td className="transferred">
         {dataTransferred}
         <i className={isBeneficiary ? 'up' : 'down'}></i>

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -47,7 +47,7 @@ function channelIdToTableRow(
   }
 
   let dataTransferred: string;
-
+  const peerAccount = isBeneficiary ? channel['payer'] : channel['beneficiary']; // If I am the payer, my peer is the beneficiary and vice versa
   if (wire) {
     dataTransferred = isBeneficiary ? prettier(wire.uploaded) : prettier(wire.downloaded);
   } else {
@@ -61,7 +61,7 @@ function channelIdToTableRow(
     <tr className="peerInfo" key={channelId}>
       <td className="channel">{channelButton}</td>
       <td className="channel-id">{channelId}</td>
-      <td className="peer-id">{wire.paidStreamingExtension.peerAccount}</td>
+      <td className="peer-id">{peerAccount}</td>
       <td className="transferred">
         {dataTransferred}
         <i className={isBeneficiary ? 'up' : 'down'}></i>


### PR DESCRIPTION
Pull property directly off the wire.

Should fix the issue where currently what is shown as a 'peer' in the UI, is actually me...
![Screenshot 2020-05-07 at 18 22 24](https://user-images.githubusercontent.com/1833419/81325037-b7682400-908f-11ea-90a5-ce47158a7a3f.png)

An extension to this PR would be to replace the trimmed peer addresses with blockies
