### PR TITLE
Add provider and (proper) signer to chain

### DIFF
--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -68,7 +68,6 @@ export class FakeChain implements Chain {
   private blockNumber: BigNumber = One;
   private channelStatus: Record<string, ChannelChainInfo> = {};
   private eventEmitter: EventEmitter<{
-    // TODO: Remove?
     updated: [Updated];
     // TODO: Add AssetHolder events
     challengeRegistered: [ChallengeRegistered];

--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -381,7 +381,7 @@ export class ChainWatcher implements Chain {
   }
 
   public chainUpdatedFeed(channelId: string): Observable<ChannelChainInfo> {
-    if (!this._assetHolders[0] && !this._adjudicator) {
+    if (!this._assetHolders || !this._assetHolders[0] || !this._adjudicator) {
       throw new Error('Not connected to contracts');
     }
 

--- a/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
+++ b/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
@@ -64,8 +64,8 @@ const mockMachine = Machine({
 });
 
 beforeAll(async () => {
-  (window as any).ethereum = {selectedAddress: '0xfec44e15328B7d1d8885a8226b0858964358F1D6'};
-  (chain as any).configureContracts();
+  (window as any).ethereum = {enable: () => ['0xfec44e15328B7d1d8885a8226b0858964358F1D6']};
+  chain.ethereumEnable();
 
   const signer = await provider.getSigner('0x28bF45680cA598708E5cDACc1414FCAc04a3F1ed');
   ETHAssetHolder = new Contract(

--- a/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
+++ b/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
@@ -63,8 +63,11 @@ const mockMachine = Machine({
   }
 });
 
-beforeEach(async () => {
-  const signer = await provider.getSigner();
+beforeAll(async () => {
+  (window as any).ethereum = {selectedAddress: '0xfec44e15328B7d1d8885a8226b0858964358F1D6'};
+  (chain as any).configureContracts();
+
+  const signer = await provider.getSigner('0x28bF45680cA598708E5cDACc1414FCAc04a3F1ed');
   ETHAssetHolder = new Contract(
     ETH_ASSET_HOLDER_ADDRESS,
     ContractArtifacts.EthAssetHolderArtifact.abi,


### PR DESCRIPTION
- The provider can be fetched on initialization
- The signer should only be available after ethereum is enabled.
  Before then, we don't know what signing address we should use.
- The signer uses the selected address

Resolves https://github.com/statechannels/monorepo/issues/1732