### PR TITLE
Fix channels not closing on torrent finish

### DIFF
--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -248,17 +248,19 @@ export class PaymentChannelClient {
     return convertToChannelState(channelResult);
   }
 
-  // payer may use this method to make payments (if they have sufficient funds)
-  async makePayment(channelId: string, amount: string) {
-    const readyToPay = (state: ChannelState | undefined) =>
-      state &&
+  getLatestPaymentReceipt() {
+    const readyToPay = (state: ChannelState) =>
       state.status === 'running' &&
       state.payer === this.mySigningAddress &&
       state.turnNum.mod(2).eq(Index.Payer);
 
-    const channelState: ChannelState = await this.channelClient.channelState
+    return this.channelClient.channelState
       .pipe(map(convertToChannelState), filter(readyToPay), first())
       .toPromise();
+  }
+  // payer may use this method to make payments (if they have sufficient funds)
+  async makePayment(channelId: string, amount: string) {
+    const channelState: ChannelState = await this.getLatestPaymentReceipt();
 
     const {payerBalance} = channelState;
     if (bigNumberify(payerBalance).lt(amount)) {

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -323,6 +323,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
       switch (command) {
         case PaidStreamingExtensionNotices.STOP: // synonymous with a prompt for a payment
           if (torrent.paused) {
+            await this.paymentChannelClient.getLatestPaymentReceipt();
             // We currently treat pausing torrent as canceling downloads
             await this.closeDownloadingChannels(torrent);
           } else if (!torrent.done) {
@@ -340,8 +341,10 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     });
 
     torrent.on(TorrentEvents.DONE, async () => {
+      await this.paymentChannelClient.getLatestPaymentReceipt();
       log.info('<< Torrent DONE!');
       log.trace({torrent, peers: this.peersList[torrent.infoHash]});
+
       this.emit(ClientEvents.TORRENT_DONE, {torrent});
       await this.closeDownloadingChannels(torrent);
     });


### PR DESCRIPTION
Fixes #1729.
Fixes #1738.

> The root cause of this is that the web3torrent seeder sends a final state update acknowledging the payment when it is complete. This arrives while the leacher has started calling closeChannel so the final payment is accepted into the store after finalState is called to create the final state.
> 
> I think there is two issues here:
> 
> #1554 I think the leacher store is accepting (or silently ignoring) the leacher's final payment update. We should probably throw an error in this case.
> The seeder's paymentChannelClient should wait to receive the final state before calling closeChannel

After some local testing I think this may be the cause of #1738 as well, since the `store` had two states with the same turnNum, causing the signature to be incorrect.

I've left properly detecting/handling a duplicate state in a message to #1554.
