### PR TITLE
[xstate-wallet] Set mySelectedAddress to ethereum.selectedAddress on initialization

### DIFF
--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -235,7 +235,7 @@ const chainLogger = logger.child({module: 'chain'});
 export class ChainWatcher implements Chain {
   private _adjudicator?: Contract;
   private _assetHolders: Contract[];
-  private mySelectedAddress: string | null;
+  private mySelectedAddress: string | null = (window.ethereum || {}).selectedAddress;
   private provider: ReturnType<typeof getProvider>;
   private get signer() {
     if (!this.ethereumIsEnabled) throw new Error('Ethereum not enabled');

--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -235,7 +235,7 @@ const chainLogger = logger.child({module: 'chain'});
 export class ChainWatcher implements Chain {
   private _adjudicator?: Contract;
   private _assetHolders: Contract[];
-  private mySelectedAddress: string | null = (window.ethereum || {}).selectedAddress;
+  private mySelectedAddress: string | null = window.ethereum?.selectedAddress ?? null;
   private provider: ReturnType<typeof getProvider>;
   private get signer() {
     if (!this.ethereumIsEnabled) throw new Error('Ethereum not enabled');


### PR DESCRIPTION
After #1739 the wallet now asks the user to "Connect to MetaMask" every time even if they're already connected. This fixes that.