### PR TITLE
Check for duplicate turn numbers in store invariant check

### DIFF
--- a/packages/xstate-wallet/src/store/channel-store-entry.ts
+++ b/packages/xstate-wallet/src/store/channel-store-entry.ts
@@ -259,7 +259,10 @@ export class ChannelStoreEntry {
 
     const duplicateTurnNums = turnNums.some((t, i) => turnNums.indexOf(t) != i);
     if (duplicateTurnNums) {
-      logger.error({signedStates: _.map(signedStates, s => s.turnNum.toHexString())});
+      logger.error(
+        {signedStates: _.map(signedStates, s => s.turnNum.toHexString())},
+        Errors.duplicateTurnNums
+      );
       throw Error(Errors.duplicateTurnNums);
     }
     if (!isReverseSorted(turnNums)) {

--- a/packages/xstate-wallet/src/store/channel-store-entry.ts
+++ b/packages/xstate-wallet/src/store/channel-store-entry.ts
@@ -257,6 +257,11 @@ export class ChannelStoreEntry {
     const {signedStates} = this;
     const turnNums = _.map(signedStates, s => parseInt(s.turnNum.toHexString(), 16));
 
+    const duplicateTurnNums = turnNums.some((t, i) => turnNums.indexOf(t) != i);
+    if (duplicateTurnNums) {
+      logger.error({signedStates: _.map(signedStates, s => s.turnNum.toHexString())});
+      throw Error(Errors.duplicateTurnNums);
+    }
     if (!isReverseSorted(turnNums)) {
       logger.error({signedStates: _.map(signedStates, s => s.turnNum.toHexString())});
       throw Error(Errors.notSorted);

--- a/packages/xstate-wallet/src/store/index.ts
+++ b/packages/xstate-wallet/src/store/index.ts
@@ -52,6 +52,7 @@ export function isGuarantees(funding): funding is Guarantees {
   return funding.type === 'Guarantees';
 }
 export enum Errors {
+  duplicateTurnNums = 'multiple states with same turn number',
   notSorted = 'states not sorted',
   multipleSignedStates = 'Store signed multiple states for a single turn',
   staleState = 'Attempting to sign a stale state',

--- a/packages/xstate-wallet/src/workflows/tests/data.ts
+++ b/packages/xstate-wallet/src/workflows/tests/data.ts
@@ -34,10 +34,10 @@ export const third: Participant = HUB;
 export const participants: [Participant, Participant] = [first, second];
 export const threeParticipants: [Participant, Participant, Participant] = [first, second, third];
 
-export const appState = (n: BigNumberish): State => ({
+export const appState = (n: BigNumberish, isFinal = false): State => ({
   appData: '0x0000000000000000000000000000000000000000000000000000000000000000',
   appDefinition: '0x0000000000000000000000000000000000000000',
-  isFinal: false,
+  isFinal,
   turnNum: bigNumberify(n),
   outcome: simpleEthAllocation([
     {destination: first.destination, amount: bigNumberify(1)},


### PR DESCRIPTION
Fixes #1554 by throwing an error when we have multiple states with the same turn number.

This would of caught #1729 