### PR TITLE
Don't use dappeteer in circle

### DIFF
--- a/.env.circle-integration-rps
+++ b/.env.circle-integration-rps
@@ -10,7 +10,7 @@ USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 
 # For e2e-test
 BROWSER_LOG_DESTINATION = 'browser.log'
-HEADLESS = 'false'
+HEADLESS = 'true'
 USE_DAPPETEER = 'false'
 TARGET_NETWORK = 'localhost'
 SCREENSHOT_DIR = 'screenshots'

--- a/.env.circle-integration-rps
+++ b/.env.circle-integration-rps
@@ -11,7 +11,7 @@ USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 # For e2e-test
 BROWSER_LOG_DESTINATION = 'browser.log'
 HEADLESS = 'false'
-USE_DAPPETEER = 'true'
+USE_DAPPETEER = 'false'
 TARGET_NETWORK = 'localhost'
 SCREENSHOT_DIR = 'screenshots'
 

--- a/.env.circle-integration-w3t
+++ b/.env.circle-integration-w3t
@@ -10,7 +10,7 @@ USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 
 # e2e-tests
 BROWSER_LOG_DESTINATION = 'browser.log'
-HEADLESS = 'false'
+HEADLESS = 'true'
 USE_DAPPETEER = 'false'
 TARGET_NETWORK = 'localhost'
 WEB3TORRENT_URL = 'http://localhost:3000'

--- a/.env.circle-integration-w3t
+++ b/.env.circle-integration-w3t
@@ -11,7 +11,7 @@ USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 # e2e-tests
 BROWSER_LOG_DESTINATION = 'browser.log'
 HEADLESS = 'false'
-USE_DAPPETEER = 'true'
+USE_DAPPETEER = 'false'
 TARGET_NETWORK = 'localhost'
 WEB3TORRENT_URL = 'http://localhost:3000'
 SCREENSHOT_DIR = 'screenshots'

--- a/.env.circle-integration-w3t-with-hub
+++ b/.env.circle-integration-w3t-with-hub
@@ -10,7 +10,7 @@ USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 
 # For e2e-test
 BROWSER_LOG_DESTINATION = 'browser.log'
-HEADLESS = 'false'
+HEADLESS = 'true'
 USE_DAPPETEER = 'false'
 TARGET_NETWORK = 'localhost'
 WEB3TORRENT_URL = 'http://localhost:3000'

--- a/.env.circle-integration-w3t-with-hub
+++ b/.env.circle-integration-w3t-with-hub
@@ -11,7 +11,7 @@ USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 # For e2e-test
 BROWSER_LOG_DESTINATION = 'browser.log'
 HEADLESS = 'false'
-USE_DAPPETEER = 'true'
+USE_DAPPETEER = 'false'
 TARGET_NETWORK = 'localhost'
 WEB3TORRENT_URL = 'http://localhost:3000'
 SCREENSHOT_DIR = 'screenshots'

--- a/packages/e2e-tests/puppeteer/__tests__/web3torrent/seed-download.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/web3torrent/seed-download.test.ts
@@ -63,7 +63,7 @@ describe('Web3-Torrent Integration Tests', () => {
     console.log('Loading dapps');
     await forEachTab(async (tab, idx) => {
       await setupLogging(tab, idx, 'seed-download', true);
-      if (!USE_DAPPETEER) await setupFakeWeb3(web3tTabB, idx);
+      if (!USE_DAPPETEER) await setupFakeWeb3(tab, idx);
     });
 
     browsers = [browserA, browserB];

--- a/packages/e2e-tests/puppeteer/constants.ts
+++ b/packages/e2e-tests/puppeteer/constants.ts
@@ -3,7 +3,7 @@ configureEnvVariables();
 export const HEADLESS = getEnvBool('HEADLESS');
 export const USE_DAPPETEER = getEnvBool('USE_DAPPETEER');
 export const USES_VIRTUAL_FUNDING = process.env.REACT_APP_FUNDING_STRATEGY === 'Virtual';
-export const JEST_TIMEOUT = HEADLESS ? 200_000 : 1_000_000;
+export const JEST_TIMEOUT = 200_000;
 export const TARGET_NETWORK = process.env.TARGET_NETWORK || 'localhost';
 export const APP_URL = process.env.WEB3TORRENT_URL
   ? process.env.WEB3TORRENT_URL


### PR DESCRIPTION
As per our discussion in standup, we should remove sources of failure until the circle integration tests pass reliably.