### PR TITLE
Add timeouts to integration tests

### DIFF
--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -287,12 +287,6 @@ export async function withdrawAndWait(page: Page, metamask: dappeteer.Dappeteer)
   await waitAndApproveWithdraw(page, metamask);
 }
 
-interface Window {
-  channelProvider: import('@statechannels/channel-provider').ChannelProviderInterface;
-  done(): void;
-}
-declare let window: Window;
-
 let doneFuncCounter = 0;
 const doneWhen = (page: Page, done: string): Promise<void> => {
   const doneFunc = `done${doneFuncCounter++}`;

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -292,10 +292,12 @@ const doneWhen = (page: Page, done: string): Promise<void> => {
   const doneFunc = `done${doneFuncCounter++}`;
   const cb = `cb${doneFuncCounter}`;
 
-  return new Promise(resolve =>
-    page.exposeFunction(doneFunc, resolve).then(() => {
-      page.evaluate(
-        `
+  return new Promise(
+    (resolve, reject) =>
+      setTimeout(() => reject(`Timed out waiting for ${done}`), 30_000) &&
+      page.exposeFunction(doneFunc, resolve).then(() => {
+        page.evaluate(
+          `
           ${cb} = channelStatus => {
             if (${done}) {
               window.${doneFunc}('Done');
@@ -304,8 +306,8 @@ const doneWhen = (page: Page, done: string): Promise<void> => {
           }
           window.channelProvider.on('ChannelUpdated', ${cb});
           `
-      );
-    })
+        );
+      })
   );
 };
 export const waitAndOpenChannel = (usingVirtualFunding: boolean) => async (

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -15,7 +15,7 @@ export const waitForWalletToBeDisplayed = async (page: Page): Promise<void> => {
 
 export const waitForWalletToBeHidden = async (page: Page): Promise<void> => {
   const walletIframe = page.frames()[1];
-  await walletIframe.waitForSelector(':root', {hidden: true});
+  await walletIframe.waitForSelector(':root', {hidden: true, timeout: 30_000});
 };
 
 export async function setupLogging(


### PR DESCRIPTION
Returns useful error messages in circle:
```
  console.log puppeteer/__tests__/web3torrent/seed-download.test.ts:99
    B cancels download
 
 FAIL  puppeteer/__tests__/web3torrent/seed-download.test.ts (65.291s)
  Web3-Torrent Integration Tests
    ✕ allows peers to start torrenting (62732ms)
 
  ● Web3-Torrent Integration Tests › allows peers to start torrenting
    Failed: "Timed out waiting for channelStatus.status === 'closed'"
```