### PR TITLE
Revert "W3T Restart Fixing"

### DIFF
--- a/packages/web3torrent/src/clients/web3torrent-client.ts
+++ b/packages/web3torrent/src/clients/web3torrent-client.ts
@@ -51,14 +51,13 @@ export const upload: (input: WebTorrentSeedInput) => Promise<ExtendedTorrent> = 
   );
 };
 
-export const cancel = (torrentId: string = '') => {
+export const cancel = (id: string = '') => {
   return new Promise((resolve, reject) =>
-    web3torrent.cancel(torrentId, err => {
+    web3torrent.cancel(id, err => {
       if (err) {
         reject(err);
       } else {
-        // TODO: clean up channel info
-        resolve(torrentId);
+        resolve(id);
       }
     })
   );

--- a/packages/web3torrent/src/library/paid-streaming-extension.ts
+++ b/packages/web3torrent/src/library/paid-streaming-extension.ts
@@ -133,7 +133,7 @@ export abstract class PaidStreamingExtension implements Extension {
       const jsonData = bencode.decode(buffer, undefined, undefined, 'utf8');
       this.messageHandler(jsonData);
     } catch (err) {
-      log.error(err, 'onMessage decoding or handling');
+      log.error({err}, 'onMessage decoding');
       return;
     }
   }

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -86,7 +86,6 @@ export type PaidStreamingExtensionNotice = {
 export type Wireish = Wire & PaidStreamingWire;
 export type PaidStreamingTorrent = ExtendedTorrent & {
   usingPaidStreaming: boolean;
-  destroyed?: boolean;
   on(event: TorrentEvents.WIRE, callback: (wire: PaidStreamingWire) => void): void;
   on(
     event: TorrentEvents.NOTICE,

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -111,7 +111,7 @@ const File: React.FC<Props> = props => {
           withdraw={closeBudget}
         />
       )}
-      {(torrent.status === Status.Idle || torrent.status === Status.Paused) && (
+      {torrent.status === Status.Idle && (
         <>
           <FormButton
             name="download"


### PR DESCRIPTION
Reverts statechannels/monorepo#1533

After #1533, wires were _destroyed_ when the leecher hit 'Cancel'. This has the consequence of severing communication between the two wallets, meaning the channels cannot close.