### PR TITLE
Add GetChannels call to wallet

### DIFF
--- a/packages/channel-client/src/channel-client.ts
+++ b/packages/channel-client/src/channel-client.ts
@@ -71,6 +71,10 @@ export class ChannelClient implements ChannelClientInterface {
       this.provider.off('BudgetUpdated', callback);
     };
   }
+  async getChannels(includeClosed: boolean): Promise<ChannelResult[]> {
+    return this.provider.send({method: 'GetChannels', params: {includeClosed}});
+  }
+
   async createChannel(
     participants: Participant[],
     allocations: TokenAllocations,

--- a/packages/channel-client/src/types.ts
+++ b/packages/channel-client/src/types.ts
@@ -58,6 +58,7 @@ export interface ChannelClientInterface {
   ): Promise<SiteBudget>;
   getBudget(hubAddress: string): Promise<SiteBudget>;
   closeAndWithdraw(hubAddress: string, hubDestination: string): Promise<SiteBudget>;
+  getChannels(includeClosed: boolean): Promise<ChannelResult[]>;
 }
 export interface EventsWithArgs {
   MessageQueued: [Message];

--- a/packages/channel-provider/src/types.ts
+++ b/packages/channel-provider/src/types.ts
@@ -23,7 +23,9 @@ import {
   GetBudgetRequest,
   ApproveBudgetAndFundResponse,
   ApproveBudgetAndFundRequest,
-  NotificationType
+  NotificationType,
+  GetChannelsRequest,
+  GetChannelsResponse
 } from '@statechannels/client-api-schema';
 
 export interface JsonRpcRequest<MethodName = string, RequestParams = any> {
@@ -85,6 +87,7 @@ export type MethodResponseType = {
   ApproveBudgetAndFund: ApproveBudgetAndFundResponse['result'];
   GetBudget: GetBudgetResponse['result'];
   CloseAndWithdraw: any; // TODO: Add types
+  GetChannels: GetChannelsResponse['result'];
 };
 
 type Method =
@@ -99,7 +102,8 @@ type Method =
   | 'ChallengeChannel'
   | 'ApproveBudgetAndFund'
   | 'GetBudget'
-  | 'CloseAndWithdraw';
+  | 'CloseAndWithdraw'
+  | 'GetChannels';
 
 type Request = {params: RequestParams['params']}; // Replace with union type
 type Call<K extends Method, T extends Request> = {
@@ -119,7 +123,8 @@ export type MethodRequestType =
   | Call<'ChallengeChannel', ChallengeChannelRequest>
   | Call<'ApproveBudgetAndFund', ApproveBudgetAndFundRequest>
   | Call<'GetBudget', GetBudgetRequest>
-  | Call<'CloseAndWithdraw', any>;
+  | Call<'CloseAndWithdraw', any>
+  | Call<'GetChannels', GetChannelsRequest>;
 
 export interface EventType extends NotificationType {
   [id: string]: [unknown]; // guid

--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -826,32 +826,6 @@
       ],
       "type": "object"
     },
-    "GetChannelResponse": {
-      "additionalProperties": false,
-      "properties": {
-        "id": {
-          "type": "number"
-        },
-        "jsonrpc": {
-          "enum": [
-            "2.0"
-          ],
-          "type": "string"
-        },
-        "result": {
-          "items": {
-            "$ref": "#/definitions/ChannelResult"
-          },
-          "type": "array"
-        }
-      },
-      "required": [
-        "id",
-        "jsonrpc",
-        "result"
-      ],
-      "type": "object"
-    },
     "GetChannelsRequest": {
       "additionalProperties": false,
       "properties": {
@@ -877,9 +851,6 @@
               "type": "boolean"
             }
           },
-          "required": [
-            "includeClosed"
-          ],
           "type": "object"
         }
       },
@@ -888,6 +859,32 @@
         "jsonrpc",
         "method",
         "params"
+      ],
+      "type": "object"
+    },
+    "GetChannelsResponse": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "number"
+        },
+        "jsonrpc": {
+          "enum": [
+            "2.0"
+          ],
+          "type": "string"
+        },
+        "result": {
+          "items": {
+            "$ref": "#/definitions/ChannelResult"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
       ],
       "type": "object"
     },
@@ -1326,6 +1323,9 @@
         },
         {
           "$ref": "#/definitions/CloseAndWithdrawRequest"
+        },
+        {
+          "$ref": "#/definitions/GetChannelsRequest"
         }
       ]
     },
@@ -1366,6 +1366,9 @@
         },
         {
           "$ref": "#/definitions/CloseAndWithdrawResponse"
+        },
+        {
+          "$ref": "#/definitions/GetChannelsResponse"
         }
       ]
     },

--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -826,6 +826,71 @@
       ],
       "type": "object"
     },
+    "GetChannelResponse": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "number"
+        },
+        "jsonrpc": {
+          "enum": [
+            "2.0"
+          ],
+          "type": "string"
+        },
+        "result": {
+          "items": {
+            "$ref": "#/definitions/ChannelResult"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "GetChannelsRequest": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "number"
+        },
+        "jsonrpc": {
+          "enum": [
+            "2.0"
+          ],
+          "type": "string"
+        },
+        "method": {
+          "enum": [
+            "GetChannels"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": false,
+          "properties": {
+            "includeClosed": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "includeClosed"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
     "GetStateParams": {
       "additionalProperties": false,
       "properties": {

--- a/packages/client-api-schema/src/types.ts
+++ b/packages/client-api-schema/src/types.ts
@@ -208,6 +208,9 @@ export interface TokenBudgetRequest {
   requestedSendCapacity: Uint256;
   requestedReceiveCapacity: Uint256;
 }
+
+export type GetChannelsRequest = JsonRpcRequest<'GetChannels', {includeClosed?: boolean}>;
+export type GetChannelsResponse = JsonRpcResponse<Array<ChannelResult>>;
 export type GetBudgetRequest = JsonRpcRequest<'GetBudget', {hubAddress: Address}>;
 export type GetBudgetResponse = JsonRpcResponse<SiteBudget | {}>;
 
@@ -258,7 +261,8 @@ export type Request =
   | GetBudgetRequest
   | ApproveBudgetAndFundRequest
   | CloseChannelRequest
-  | CloseAndWithdrawRequest;
+  | CloseAndWithdrawRequest
+  | GetChannelsRequest;
 
 export type Response =
   | CreateChannelResponse
@@ -272,7 +276,8 @@ export type Response =
   | GetBudgetResponse
   | CloseChannelResponse
   | ApproveBudgetAndFundResponse
-  | CloseAndWithdrawResponse;
+  | CloseAndWithdrawResponse
+  | GetChannelsResponse;
 
 export type UserDeclinedErrorResponse = JsonRpcError<typeof UserDeclinedErrorCode, 'User declined'>;
 

--- a/packages/client-api-schema/src/types.ts
+++ b/packages/client-api-schema/src/types.ts
@@ -210,7 +210,7 @@ export interface TokenBudgetRequest {
 }
 
 export type GetChannelsRequest = JsonRpcRequest<'GetChannels', {includeClosed?: boolean}>;
-export type GetChannelsResponse = JsonRpcResponse<Array<ChannelResult>>;
+export type GetChannelsResponse = JsonRpcResponse<ChannelResult[]>;
 export type GetBudgetRequest = JsonRpcRequest<'GetBudget', {hubAddress: Address}>;
 export type GetBudgetResponse = JsonRpcResponse<SiteBudget | {}>;
 

--- a/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
+++ b/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
@@ -94,6 +94,7 @@ class MockChannelClient implements ChannelClientInterface {
   challengeChannel = jest.fn(async function(channelId: string) {
     return await mockChannelResult;
   });
+  getChannels = jest.fn();
   pushMessage(message) {
     return new Promise<any>(() => {
       /* */

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -342,8 +342,8 @@ export class PaymentChannelClient {
   }
 
   async getChannels(): Promise<Record<string, ChannelState | undefined>> {
-    const channelResults = await this.channelClient.getChannels(false);
-    channelResults.map(convertToChannelState).forEach(cr => this.updateChannelCache(cr));
+    const channelResults = await this.channelClient.getChannels(true);
+    channelResults.map(convertToChannelState).forEach(cr => (this.channelCache[cr.channelId] = cr));
     return this.channelCache;
   }
 

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -280,7 +280,7 @@ export class PaymentChannelClient {
       channelState.beneficiary,
       channelState.payer,
       add(channelState.beneficiaryBalance, amount),
-      subract(payerBalance, amount),
+      subtract(payerBalance, amount),
       channelState.beneficiaryOutcomeAddress,
       channelState.payerOutcomeAddress
     );
@@ -339,6 +339,12 @@ export class PaymentChannelClient {
       HUB.signingAddress,
       HUB.outcomeAddress
     );
+  }
+
+  async getChannels(): Promise<Record<string, ChannelState | undefined>> {
+    const channelResults = await this.channelClient.getChannels(false);
+    channelResults.map(convertToChannelState).forEach(cr => this.updateChannelCache(cr));
+    return this.channelCache;
   }
 
   async getBudget(): Promise<SiteBudget> {
@@ -410,7 +416,7 @@ const formatAllocations = (aAddress: string, bAddress: string, aBal: string, bBa
   ];
 };
 
-const subract = (a: string, b: string) =>
+const subtract = (a: string, b: string) =>
   hexZeroPad(
     bigNumberify(a)
       .sub(bigNumberify(b))

--- a/packages/web3torrent/src/pages/file/File.test.tsx
+++ b/packages/web3torrent/src/pages/file/File.test.tsx
@@ -8,6 +8,7 @@ import {TorrentStaticData} from '../../types';
 import {testSelector, createMockExtendedTorrent, createMockTorrentUI} from '../../utils/test-utils';
 import * as TorrentStatus from '../../utils/torrent-status-checker';
 import * as Web3TorrentClient from './../../clients/web3torrent-client';
+import {paymentChannelClient} from '../../clients/payment-channel-client';
 import File from './File';
 import WebTorrentPaidStreamingClient from '../../library/web3torrent-lib';
 
@@ -21,6 +22,8 @@ describe('<File />', () => {
     torrentFile = jest
       .spyOn(Web3TorrentClient, 'download')
       .mockImplementation(_pD => Promise.resolve(createMockExtendedTorrent()));
+
+    jest.spyOn(paymentChannelClient, 'getChannels').mockImplementation(() => Promise.resolve({}));
 
     component = mount(
       <Router>

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -42,6 +42,7 @@ const File: React.FC<Props> = props => {
   const [loading, setLoading] = useState(false);
   const [errorLabel, setErrorLabel] = useState('');
   const [warning, setWarning] = useState('');
+  const [channels, setChannels] = useState(undefined);
   const torrentName = queryParams.get('name');
   const torrentLength = Number(queryParams.get('length'));
 
@@ -81,9 +82,12 @@ const File: React.FC<Props> = props => {
     }
     return undefined;
   }, [torrent, infoHash, torrentName, torrentLength, web3Torrent]);
-
-  const {channelCache, mySigningAddress: me} = web3Torrent.paymentChannelClient;
-
+  useEffect(() => {
+    if (props.ready) {
+      web3Torrent.paymentChannelClient.getChannels().then(channels => setChannels(channels));
+    }
+  }, [props.ready, web3Torrent.paymentChannelClient]);
+  const {mySigningAddress: me} = web3Torrent.paymentChannelClient;
   const {budget, closeBudget} = useBudget(props);
   // TODO: We shouldn't have to check all these different conditions
   const showBudget =
@@ -94,7 +98,7 @@ const File: React.FC<Props> = props => {
       <div className="jumbotron-upload">
         <h1>{torrent.originalSeed ? 'Upload a File' : 'Download a File'}</h1>
       </div>
-      <TorrentInfo torrent={torrent} channelCache={channelCache} mySigningAddress={me} />
+      <TorrentInfo torrent={torrent} channelCache={channels} mySigningAddress={me} />
       {warning &&
         ((!torrent.uploaded && torrent.status === Status.Seeding) ||
           torrent.status === Status.Idle) && (
@@ -106,7 +110,7 @@ const File: React.FC<Props> = props => {
       {showBudget && (
         <SiteBudgetTable
           budgetCache={budget}
-          channelCache={channelCache}
+          channelCache={channels}
           mySigningAddress={me}
           withdraw={closeBudget}
         />

--- a/packages/xstate-wallet/src/messaging.ts
+++ b/packages/xstate-wallet/src/messaging.ts
@@ -24,7 +24,7 @@ import {fromEvent, Observable} from 'rxjs';
 import {validateMessage} from '@statechannels/wire-format';
 import {unreachable, isSimpleEthAllocation, makeDestination} from './utils';
 import {Message, SiteBudget, Participant} from './store/types';
-import {serializeSiteBudget} from './serde/app-messages/serialize';
+import {serializeSiteBudget, serializeChannelEntry} from './serde/app-messages/serialize';
 import {deserializeMessage} from './serde/wire-format/deserialize';
 import {serializeMessage} from './serde/wire-format/serialize';
 import {AppRequestEvent} from './event-types';
@@ -179,6 +179,14 @@ export class MessagingService implements MessagingServiceInterface {
         } else {
           this.eventEmitter.emit('AppRequest', {type: 'ENABLE_ETHEREUM', requestId});
         }
+        break;
+      case 'GetChannels':
+        const channelEntries = await this.store.getApplicationChannels(
+          fromDomain,
+          request.params.includeClosed
+        );
+        await this.sendResponse(requestId, channelEntries.map(serializeChannelEntry));
+
         break;
       case 'ChallengeChannel':
       case 'CreateChannel':

--- a/packages/xstate-wallet/src/messaging.ts
+++ b/packages/xstate-wallet/src/messaging.ts
@@ -185,7 +185,10 @@ export class MessagingService implements MessagingServiceInterface {
           fromDomain,
           request.params.includeClosed
         );
-        await this.sendResponse(requestId, channelEntries.map(serializeChannelEntry));
+        const serializedChannelEntries = await Promise.all(
+          channelEntries.map(serializeChannelEntry)
+        );
+        await this.sendResponse(requestId, serializedChannelEntries);
 
         break;
       case 'ChallengeChannel':

--- a/packages/xstate-wallet/src/store/dexie-backend.ts
+++ b/packages/xstate-wallet/src/store/dexie-backend.ts
@@ -13,7 +13,7 @@ import * as _ from 'lodash';
 
 import Dexie, {Transaction, TransactionMode} from 'dexie';
 
-import {unreachable, arrayToRecord} from '../utils';
+import {unreachable} from '../utils';
 import {logger} from '../logger';
 
 const STORES: ObjectStores[] = [
@@ -64,9 +64,15 @@ export class Backend implements DBBackend {
   // Generic Getters
 
   public async channels() {
-    const channelData = (await this.getAll(ObjectStores.channels, true)) as ChannelStoredData[];
-    const channelEntries = channelData.map(data => ChannelStoreEntry.fromJson(data));
-    return arrayToRecord(channelEntries, 'channelId');
+    const channelData = (await this.getAll(ObjectStores.channels, true)) as {
+      key: string;
+      value: ChannelStoredData;
+    }[];
+    const channels = {};
+    channelData.forEach(cd => {
+      channels[cd.key] = ChannelStoreEntry.fromJson(cd.value);
+    });
+    return channels;
   }
 
   public async objectives() {

--- a/packages/xstate-wallet/src/store/memory-backend.ts
+++ b/packages/xstate-wallet/src/store/memory-backend.ts
@@ -34,9 +34,13 @@ export class MemoryBackend implements DBBackend {
     return _.cloneDeep(this._objectives);
   }
   public async channels() {
-    const channels: Record<string, ChannelStoredData | undefined> = _.cloneDeep(this._channels);
+    const channelsData: Record<string, ChannelStoredData | undefined> = _.cloneDeep(this._channels);
+    const channels = {};
+    for (const channelId of Object.keys(channelsData)) {
+      channels[channelId] = new ChannelStoreEntry(channelsData[channelId] as ChannelStoredData);
+    }
 
-    return channels as Record<string, ChannelStoredData | undefined>;
+    return channels as Record<string, ChannelStoreEntry | undefined>;
   }
   public async nonces() {
     const nonces: Record<string, BigNumber | string | undefined> = this._nonces;

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -265,8 +265,8 @@ export class Store {
       }
     );
 
-  public getApplicationChannels = (applicationSite: string, includeClosed = false) => {
-    return this.backend.transaction('readonly', [ObjectStores.channels], async () =>
+  public getApplicationChannels = (applicationSite: string, includeClosed = false) =>
+    this.backend.transaction('readonly', [ObjectStores.channels], async () =>
       recordToArray(await this.backend.channels()).filter(
         channel =>
           !!channel &&
@@ -275,7 +275,6 @@ export class Store {
           channel.channelConstants.appDefinition !== '0x0'
       )
     );
-  };
 
   public createChannel = (
     participants: Participant[],

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -9,7 +9,7 @@ import * as _ from 'lodash';
 
 import {Chain, FakeChain} from '../chain';
 import {CHAIN_NETWORK_ID, HUB} from '../config';
-import {checkThat, isSimpleEthAllocation} from '../utils';
+import {checkThat, isSimpleEthAllocation, recordToArray} from '../utils';
 
 import {calculateChannelId, hashState} from './state-utils';
 import {ChannelStoreEntry} from './channel-store-entry';
@@ -263,6 +263,16 @@ export class Store {
         if (peerId) await this.backend.setLedger(peerId.participantId, entry.channelId);
         else throw 'No peer';
       }
+    );
+
+  public getApplicationChannels = (applicationSite: string, includeClosed = false) =>
+    this.backend.transaction('readonly', [ObjectStores.channels], async () =>
+      recordToArray(await this.backend.channels()).filter(
+        channel =>
+          channel.applicationSite === applicationSite &&
+          (!channel.isFinalized || includeClosed) &&
+          channel.channelConstants.appDefinition !== '0x0'
+      )
     );
 
   public createChannel = (

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -272,7 +272,7 @@ export class Store {
           !!channel &&
           channel.applicationSite === applicationSite &&
           (!channel.isFinalized || includeClosed) &&
-          channel.channelConstants.appDefinition !== '0x0'
+          !bigNumberify(channel.channelConstants.appDefinition).isZero()
       )
     );
 

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -265,15 +265,17 @@ export class Store {
       }
     );
 
-  public getApplicationChannels = (applicationSite: string, includeClosed = false) =>
-    this.backend.transaction('readonly', [ObjectStores.channels], async () =>
+  public getApplicationChannels = (applicationSite: string, includeClosed = false) => {
+    return this.backend.transaction('readonly', [ObjectStores.channels], async () =>
       recordToArray(await this.backend.channels()).filter(
         channel =>
+          !!channel &&
           channel.applicationSite === applicationSite &&
           (!channel.isFinalized || includeClosed) &&
           channel.channelConstants.appDefinition !== '0x0'
       )
     );
+  };
 
   public createChannel = (
     participants: Participant[],

--- a/packages/xstate-wallet/src/store/tests/dexie-store.test.ts
+++ b/packages/xstate-wallet/src/store/tests/dexie-store.test.ts
@@ -238,7 +238,6 @@ describe('setLedger', () => {
   });
 });
 
-
 const getBackend = (store: Store) => (store as any).backend as Backend;
 
 describe('transactions', () => {

--- a/packages/xstate-wallet/src/store/tests/dexie-store.test.ts
+++ b/packages/xstate-wallet/src/store/tests/dexie-store.test.ts
@@ -238,11 +238,6 @@ describe('setLedger', () => {
   });
 });
 
-describe('getApplicationChannels', () => {
-  it('works', async () => {
-    
-  });
-});
 
 const getBackend = (store: Store) => (store as any).backend as Backend;
 

--- a/packages/xstate-wallet/src/store/tests/dexie-store.test.ts
+++ b/packages/xstate-wallet/src/store/tests/dexie-store.test.ts
@@ -238,6 +238,12 @@ describe('setLedger', () => {
   });
 });
 
+describe('getApplicationChannels', () => {
+  it('works', async () => {
+    
+  });
+});
+
 const getBackend = (store: Store) => (store as any).backend as Backend;
 
 describe('transactions', () => {

--- a/packages/xstate-wallet/src/store/types.ts
+++ b/packages/xstate-wallet/src/store/types.ts
@@ -156,7 +156,7 @@ export interface DBBackend {
   ledgers(): Promise<Record<string, string | undefined>>;
   nonces(): Promise<Record<string, BigNumber | undefined>>;
   objectives(): Promise<Objective[]>;
-  channels(): Promise<Record<string, ChannelStoredData | undefined>>;
+  channels(): Promise<Record<string, ChannelStoreEntry | undefined>>;
 
   setPrivateKey(key: string, value: string): Promise<string>;
   getPrivateKey(key: string): Promise<string | undefined>;

--- a/packages/xstate-wallet/src/utils/helpers.ts
+++ b/packages/xstate-wallet/src/utils/helpers.ts
@@ -74,16 +74,3 @@ export function recordToArray<T>(record: Record<string | number, T | undefined>)
     .map(k => record[k])
     .filter(e => e !== undefined) as Array<T>;
 }
-
-export function filterRecords<T>(
-  record: Record<string | number, T | undefined>,
-  condition: (entry: T | undefined) => boolean
-): Record<string | number, T> {
-  const filteredRecords = {};
-  Object.keys(record).forEach(k => {
-    if (condition(record[k])) {
-      filteredRecords[k] = record;
-    }
-  });
-  return filteredRecords;
-}

--- a/packages/xstate-wallet/src/utils/helpers.ts
+++ b/packages/xstate-wallet/src/utils/helpers.ts
@@ -58,3 +58,32 @@ export function createDestination(address: string): string {
 export function formatAmount(amount: BigNumber): string {
   return hexZeroPad(hexlify(amount), 32);
 }
+
+export function arrayToRecord<T, K extends keyof T>(
+  array: Array<T>,
+  idProperty: K
+): Record<string | number, T> {
+  return array.reduce((obj, item) => {
+    obj[item[idProperty]] = item;
+    return obj;
+  }, {} as any);
+}
+
+export function recordToArray<T>(record: Record<string | number, T | undefined>): Array<T> {
+  return Object.keys(record)
+    .map(k => record[k])
+    .filter(e => e !== undefined) as Array<T>;
+}
+
+export function filterRecords<T>(
+  record: Record<string | number, T | undefined>,
+  condition: (entry: T | undefined) => boolean
+): Record<string | number, T> {
+  const filteredRecords = {};
+  Object.keys(record).forEach(k => {
+    if (condition(record[k])) {
+      filteredRecords[k] = record;
+    }
+  });
+  return filteredRecords;
+}


### PR DESCRIPTION
Fixes #1736.

Adds a `GetChannels` all to the wallet API and modifies web3torrent to call this when loading the `File` component. This allows the user to see the previous channels / balances they have already set up.