### PR TITLE
[w3t] Add GENERATE_SOURCEMAP to CircleCI build env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,6 +336,7 @@ jobs:
     <<: *defaults
     resource_class: large
     environment:
+      GENERATE_SOURCEMAP: true
       SC_ENV: production-ropsten
     steps:
       - checkout


### PR DESCRIPTION
Builds source maps for `web3torrent` https://github.com/statechannels/monorepo/blob/a92bb3908ec6fe79c4b47cca1c19eb7c2a59b7c4/packages/web3torrent/config/webpack.config.js#L36-L36