### PR TITLE
[xstate-wallet] :pig: Add gap when creating final state

### DIFF
--- a/packages/xstate-wallet/src/workflows/conclude-channel.ts
+++ b/packages/xstate-wallet/src/workflows/conclude-channel.ts
@@ -28,7 +28,7 @@ const finalState = (store: Store) => async (context: Init): Promise<SupportState
   }
 
   // Otherwise create a new final state
-  return {state: {...latestSignedByMe, turnNum: latest.turnNum.add(1), isFinal: true}};
+  return {state: {...latestSignedByMe, turnNum: latest.turnNum.add(10), isFinal: true}};
 };
 
 const supportState = (store: Store) => SupportState.machine(store);

--- a/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/conclude-channel.test.ts
@@ -162,6 +162,8 @@ const concludeAfterCrashAndAssert = async (fundingType: 'Direct' | 'Virtual') =>
   const crashState = fundingType == 'Direct' ? 'withdrawing' : {virtualDefunding: 'gettingRole'};
   const successState = fundingType == 'Direct' ? 'success' : {virtualDefunding: 'asLeaf'};
 
+  interpret(concludeChannel(bStore).withContext(context)).start();
+
   // Simulate A crashes before withdrawing
   const aMachine = interpret(concludeChannel(aStore).withContext(context))
     .onTransition(state => {


### PR DESCRIPTION
This is a quick fix to get the wallet to wait until there's a conclusion
proof.