### PR TITLE
Persistent Seeder Fix

### DIFF
--- a/packages/e2e-tests/persistent-seeder/persistent-seeder.dockerfile
+++ b/packages/e2e-tests/persistent-seeder/persistent-seeder.dockerfile
@@ -2,7 +2,7 @@ FROM circleci/node:10.16.3-browsers
 USER root
 ENV DISPLAY :99.0
 
-RUN  apt-get install -y xvfb
+RUN  apt-get install -y xvfb libudev-dev
 
 WORKDIR /statechannels/monorepo
 

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -250,7 +250,11 @@ export async function waitAndApproveDepositWithHub(
 ): Promise<void> {
   console.log('Making deposit with hub');
   const walletIFrame = page.frames()[1];
-  await walletIFrame.waitForSelector('#please-approve-transaction', {timeout: TX_WAIT_TIMEOUT}); // longer timeout here because blockchain is slow
+  console.log('Waiting for #please-approve-transaction');
+  console.time('#please-approve-transaction');
+  await walletIFrame.waitForSelector('#please-approve-transaction', {timeout: TX_WAIT_TIMEOUT * 3}); // longer timeout here because blockchain is slow
+  console.timeEnd('#please-approve-transaction');
+
   await metamask.confirmTransaction({gas: 20, gasLimit: 50000});
   await page.bringToFront();
 }

--- a/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
+++ b/packages/e2e-tests/puppeteer/scripts/web3torrent.ts
@@ -11,6 +11,7 @@ import {
   waitAndApproveDepositWithHub
 } from '../helpers';
 import {Dappeteer} from 'dappeteer';
+import {TX_WAIT_TIMEOUT} from '../constants';
 
 function prepareStubUploadFile(path: string): void {
   const content = 'web3torrent\n'.repeat(1000000);
@@ -33,9 +34,10 @@ export async function uploadFile(
   // Not clear why puppeteer FileChooser won't work out of box. We are doing it manually for now.')
   const inputUploadHandle = await page.waitForSelector('input:not([disabled])[type=file]');
 
-  // By default, generate a /tmp stub file with deterministic data for upload testing
-  prepareStubUploadFile(filePath);
-
+  if (filePath === '/tmp/web3torrent-tests-stub') {
+    // By default, generate a /tmp stub file with deterministic data for upload testing
+    prepareStubUploadFile(filePath);
+  }
   await inputUploadHandle.uploadFile(filePath);
   await inputUploadHandle.evaluate(upload => {
     // eslint-disable-next-line no-undef
@@ -50,7 +52,7 @@ export async function uploadFile(
   }
 
   const downloadLinkSelector = '#download-link';
-  await page.waitForSelector(downloadLinkSelector, {timeout: 60000}); // wait for my tx, which could be slow if on a real blockchain
+  await page.waitForSelector(downloadLinkSelector, {timeout: TX_WAIT_TIMEOUT}); // wait for my tx, which could be slow if on a real blockchain
   const downloadLink = await page.$eval(downloadLinkSelector, a => a.getAttribute('href'));
 
   return downloadLink ? downloadLink : '';

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -128,10 +128,10 @@ export const defaultTrackerOpts = {
 };
 
 export const testTorrent = {
-  name: 'Big Buck Bunny',
-  length: 276445467,
+  name: 'nitro-protocol.pdf',
+  length: 403507,
   magnetURI:
-    'magnet:?xt=urn:btih:dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&dn=Big+Buck+Bunny&xl=276445467'
+    'magnet:?xt=urn:btih:0ab7ca2523f6838a915f30d17ec1703b786c9e5d&dn=nitro-protocol.pdf&xl=403507'
 };
 
 export const mockCurrentUser = '0x8fd00f170fdf3772c5ebdcd90bf257316c69ba45';

--- a/packages/web3torrent/src/pages/welcome/Welcome.tsx
+++ b/packages/web3torrent/src/pages/welcome/Welcome.tsx
@@ -1,11 +1,10 @@
-import React, {useState, useEffect} from 'react';
+import React from 'react';
 import {useHistory} from 'react-router-dom';
 import {FormButton} from '../../components/form';
 import {ShareList} from '../../components/share-list/ShareList';
-import {preseededTorrentsUI, defaultTrackerOpts} from '../../constants';
+import {preseededTorrentsUI} from '../../constants';
 import {RoutePath} from '../../routes';
 import './Welcome.scss';
-import {Client} from 'bittorrent-tracker';
 import {logger} from '../../logger';
 
 const log = logger.child({module: 'welcome-page-tracker-client'});
@@ -16,30 +15,6 @@ interface Props {
 
 const Welcome: React.FC<Props> = props => {
   const history = useHistory();
-  const [trackerClient] = useState(new Client(defaultTrackerOpts));
-  const [torrents, setTorrents] = useState({
-    [preseededTorrentsUI[0].infoHash]: false
-  }); // do not display by default
-
-  useEffect(() => {
-    const updateIfSeederFound = data => {
-      log.info({data}, 'got an announce response from tracker: ');
-      if (data.complete > 0) {
-        // there are some seeders for this torrent
-        setTorrents({[preseededTorrentsUI[0].infoHash]: true});
-        // this torrent should be displayed
-        log.info(`Seeder found for ${preseededTorrentsUI[0].infoHash}`);
-      }
-      trackerClient.start();
-    };
-    trackerClient.on('update', updateIfSeederFound);
-
-    return () => {
-      trackerClient.off('update', updateIfSeederFound);
-      trackerClient.stop();
-      trackerClient.destroy();
-    };
-  }, [trackerClient]);
 
   return (
     <section className="section fill">
@@ -62,7 +37,7 @@ const Welcome: React.FC<Props> = props => {
         </p>
       </div>
       <h2>Download a sample file</h2>
-      <ShareList torrents={preseededTorrentsUI.filter(torrent => torrents[torrent.infoHash])} />
+      <ShareList torrents={preseededTorrentsUI} />
       <h2>Or share a file</h2>
       <FormButton
         name="upload"


### PR DESCRIPTION
**This PR:**
1. Sets the pre-defined torrent to show in the welcome screen to be the same that is shared by the persistent seeder.
2. It also fixes a regression that I found, where the file that was shared, wasn't the correct file (because it would be replaced by the stub file for the tests).
3. It gives more time for [some](https://github.com/statechannels/monorepo/compare/persistent-seeder-set?expand=1#diff-d745dc9ef530a2204bfa4ffd6363d00cR255) [parts](https://github.com/statechannels/monorepo/compare/persistent-seeder-set?expand=1#diff-9ed3cedce43d8747b5dc9942f0b66cedR55) of the seeding process that could take more time and fail.
3. I decided to remove the check in the welcome screen for the persistent seeder torrent because the result wasn't to be trusted. 
The check is done, then, in the **File** page, which simplifies/reduces the number of things the web3torrent does (I've seen some memory leaks in the welcome screen when the torrent is found in the welcome screen).

this PR includes @snario's fix #1741, and closes #1548 