### PR TITLE
Run production tests in band

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,7 +404,7 @@ jobs:
           file: e2e-test-w3t-production-stats
       - attach_workspace:
           at: /home/circleci/project
-      - run: (cd packages/e2e-tests && yarn jest web3torrent --runInBand)
+      - run: (cd packages/e2e-tests && yarn jest web3torrent --runInBand --bail)
       - upload_logs:
           file: e2e-test-w3t-production-stats
       - notify_slack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,7 +404,7 @@ jobs:
           file: e2e-test-w3t-production-stats
       - attach_workspace:
           at: /home/circleci/project
-      - run: (cd packages/e2e-tests && yarn jest web3torrent)
+      - run: (cd packages/e2e-tests && yarn jest web3torrent --runInBand)
       - upload_logs:
           file: e2e-test-w3t-production-stats
       - notify_slack


### PR DESCRIPTION
We do this on `master`, and it should improve the reliability of the test.