### PR TITLE
[web3torrent] Do not rely on a timer for UI updates

### DIFF
--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -592,6 +592,29 @@
       ],
       "type": "object"
     },
+    "DomainBudget": {
+      "additionalProperties": false,
+      "properties": {
+        "budgets": {
+          "items": {
+            "$ref": "#/definitions/TokenBudget"
+          },
+          "type": "array"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "hubAddress": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "domain",
+        "hubAddress",
+        "budgets"
+      ],
+      "type": "object"
+    },
     "EnableEthereumError": {
       "additionalProperties": false,
       "properties": {
@@ -1371,29 +1394,6 @@
           "$ref": "#/definitions/GetChannelsResponse"
         }
       ]
-    },
-    "DomainBudget": {
-      "additionalProperties": false,
-      "properties": {
-        "budgets": {
-          "items": {
-            "$ref": "#/definitions/TokenBudget"
-          },
-          "type": "array"
-        },
-        "domain": {
-          "type": "string"
-        },
-        "hubAddress": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "domain",
-        "hubAddress",
-        "budgets"
-      ],
-      "type": "object"
     },
     "TokenBudget": {
       "additionalProperties": false,

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -12,11 +12,17 @@ export enum ClientEvents {
 }
 
 export enum TorrentEvents {
-  WIRE = 'wire',
-  NOTICE = 'notice',
-  STOP = 'stop',
   DONE = 'done',
-  ERROR = 'error'
+  DOWNLOAD = 'download',
+  ERROR = 'error',
+  INFOHASH = 'infoHash',
+  NOTICE = 'notice',
+  NOPEERS = 'noPeers',
+  METADATA = 'metadata',
+  READY = 'ready',
+  UPLOAD = 'upload',
+  WARNING = 'warning',
+  WIRE = 'wire'
 }
 
 export enum TorrentTestResult {

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -11,6 +11,7 @@ export enum ClientEvents {
   TORRENT_NOTICE = 'torrent_notice'
 }
 
+// The events are documented at https://webtorrent.io/docs
 export enum TorrentEvents {
   DONE = 'done',
   DOWNLOAD = 'download',

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -417,16 +417,13 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
 
       this.emit(ClientEvents.TORRENT_DONE, {torrent});
       await this.closeDownloadingChannels(torrent);
-<<<<<<< HEAD
       track('Torrent Finished Downloading', {
         infoHash: torrent.infoHash,
         magnetURI: torrent.magnetURI,
         filename: torrent.name,
         filesize: torrent.length
       });
-=======
       this.informListeners();
->>>>>>> web3torrent: remove the update timer
     });
 
     torrent.on(TorrentEvents.ERROR, err => {

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -68,10 +68,12 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
   }
 
   removeListenerForUpdates(key: string) {
-    this.listenersForUpdates = {
-      ...this.listenersForUpdates,
-      [key]: undefined
+    const listenersForUpdatesCopy = {
+      ...this.listenersForUpdates
     };
+
+    delete listenersForUpdatesCopy[key];
+    this.listenersForUpdates = listenersForUpdatesCopy;
   }
 
   async enable() {

--- a/packages/web3torrent/src/pages/file/File.test.tsx
+++ b/packages/web3torrent/src/pages/file/File.test.tsx
@@ -50,22 +50,4 @@ describe('<File />', () => {
   //   expect(ChannelClient.mock.instances[0].approveBudgetAndFund).toHaveBeenCalled();
   //   expect(torrentFile).toHaveBeenCalled();
   // });
-
-  it('should run checker function if the File Button is clicked', async () => {
-    const torrentStatusChecker = jest
-      .spyOn(TorrentStatus, 'getTorrentUI')
-      .mockImplementation((_w3t: WebTorrentPaidStreamingClient, _staticData: TorrentStaticData) =>
-        createMockTorrentUI()
-      );
-
-    await act(async () => {
-      await component.find(testSelector('download-button')).simulate('click');
-    });
-
-    act(() => {
-      jest.runOnlyPendingTimers();
-    });
-
-    expect(torrentStatusChecker).toHaveBeenCalled();
-  });
 });

--- a/packages/web3torrent/src/pages/file/File.test.tsx
+++ b/packages/web3torrent/src/pages/file/File.test.tsx
@@ -30,7 +30,6 @@ describe('<File />', () => {
         <File ready={true} />
       </Router>
     );
-    jest.useFakeTimers();
   });
 
   afterAll(() => {

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -65,8 +65,8 @@ const File: React.FC<Props> = props => {
           length: torrentLength
         })
       );
-    web3Torrent.addListenerForUpdates('file-component', onTorrentUpdate);
-    return () => web3Torrent.removeListenerForUpdates('file-component');
+    web3Torrent.addListener('stateUpdate' + infoHash, onTorrentUpdate);
+    return () => web3Torrent.removeListener('stateUpdate' + infoHash, onTorrentUpdate);
   }, [infoHash, torrentLength, torrentName, web3Torrent]);
 
   useEffect(() => {

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -74,8 +74,8 @@ const File: React.FC<Props> = props => {
           length: torrentLength
         })
       );
-    web3Torrent.addListenerForUpdates(infoHash, onTorrentUpdate);
-    return () => web3Torrent.removeListenerForUpdates(infoHash);
+    web3Torrent.addListenerForUpdates('file-component', onTorrentUpdate);
+    return () => web3Torrent.removeListenerForUpdates('file-component');
   }, [infoHash, torrentLength, torrentName, web3Torrent]);
 
   useEffect(() => {

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -57,15 +57,6 @@ const File: React.FC<Props> = props => {
   );
 
   useEffect(() => {
-    const testResult = async () => {
-      const torrentCheckResult = await checkTorrent(infoHash);
-      setWarning(torrentCheckResult);
-    };
-
-    if (infoHash) {
-      testResult();
-    }
-
     const onTorrentUpdate = () =>
       setTorrent(
         getTorrentUI(web3Torrent, {
@@ -77,6 +68,17 @@ const File: React.FC<Props> = props => {
     web3Torrent.addListenerForUpdates('file-component', onTorrentUpdate);
     return () => web3Torrent.removeListenerForUpdates('file-component');
   }, [infoHash, torrentLength, torrentName, web3Torrent]);
+
+  useEffect(() => {
+    const testResult = async () => {
+      const torrentCheckResult = await checkTorrent(infoHash);
+      setWarning(torrentCheckResult);
+    };
+
+    if (infoHash) {
+      testResult();
+    }
+  }, [infoHash]);
 
   useEffect(() => {
     if (props.ready) {

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -8,7 +8,7 @@ import {Status, TorrentUI} from '../../types';
 import {useQuery} from '../../utils/url';
 import {getTorrentUI} from '../../utils/torrent-status-checker';
 import './File.scss';
-import {TorrentTestResult} from '../../library/web3torrent-lib';
+import WebTorrentPaidStreamingClient, {TorrentTestResult} from '../../library/web3torrent-lib';
 import _ from 'lodash';
 import {Flash} from 'rimble-ui';
 import {checkTorrentInTracker} from '../../utils/check-torrent-in-tracker';
@@ -65,8 +65,15 @@ const File: React.FC<Props> = props => {
           length: torrentLength
         })
       );
-    web3Torrent.addListener('stateUpdate' + infoHash, onTorrentUpdate);
-    return () => web3Torrent.removeListener('stateUpdate' + infoHash, onTorrentUpdate);
+    web3Torrent.addListener(
+      WebTorrentPaidStreamingClient.torrentUpdatedEventName(infoHash),
+      onTorrentUpdate
+    );
+    return () =>
+      web3Torrent.removeListener(
+        WebTorrentPaidStreamingClient.torrentUpdatedEventName(infoHash),
+        onTorrentUpdate
+      );
   }, [infoHash, torrentLength, torrentName, web3Torrent]);
 
   useEffect(() => {


### PR DESCRIPTION
Fixes https://github.com/statechannels/monorepo/issues/1805.

The upsides are:
- More responsive UI instead. With a timer, the UI state lags by at most 1 seconds behind the data state.
- Finegrain control over what events trigger UI updates.