### PR TITLE
[web3torrent] Expose downloadable pino logs

### DIFF
--- a/packages/web3torrent/src/logger.ts
+++ b/packages/web3torrent/src/logger.ts
@@ -1,5 +1,6 @@
 import pino from 'pino';
-import {LOG_DESTINATION, ADD_LOGS, LOG_LEVEL} from './constants';
+import {LOG_DESTINATION, ADD_LOGS, LOG_LEVEL, VERSION} from './constants';
+import _ from 'lodash';
 
 // TODO: Is there a better way to determine if we're in a browser context?
 const IS_BROWSER_CONTEXT = process.env.NODE_ENV !== 'test';
@@ -28,11 +29,48 @@ const getCircularReplacer = () => {
     return value;
   };
 };
+class LogBlob {
+  private parts = [];
+  private _blob?: Blob;
 
-const browser =
-  LOG_TO_FILE && IS_BROWSER_CONTEXT
-    ? {write: o => console.log(JSON.stringify({...o, name}, getCircularReplacer()))}
-    : undefined;
+  append(part) {
+    this.parts.push(part);
+    this._blob = undefined;
+  }
+
+  get blob() {
+    if (!this._blob) this._blob = new Blob(this.parts, {type: 'text/plain'});
+
+    return this._blob;
+  }
+}
+
+const logBlob = new LogBlob();
+
+const serializeLogEvent = o => JSON.stringify({...o, name}, getCircularReplacer());
+
+let browser: any = IS_BROWSER_CONTEXT
+  ? {
+      transmit: {
+        send: (_logEvent, logEvent) =>
+          logBlob.append(
+            serializeLogEvent({
+              // For some reason, the shape of logEvent and the shape that pino normally prints are different:
+              // - there is a `ts` property instead of a `timestamp` property
+              // - The `level` property is of shape {label: string, value: number}
+              ..._.omit(logEvent, 'ts'),
+              level: logEvent.level.value,
+              time: logEvent.ts
+            }) + '\n'
+          )
+      }
+    }
+  : undefined;
+
+if (browser && LOG_TO_FILE) {
+  // TODO: Use the logBlob instead of writing to the browser logs
+  browser = {...browser, write: o => console.log(serializeLogEvent(o))};
+}
 
 const prettyPrint = LOG_TO_CONSOLE ? {translateTime: true} : false;
 
@@ -40,3 +78,21 @@ const level = LOG_LEVEL;
 const opts = {name, prettyPrint, browser, level};
 
 export const logger = destination ? pino(opts, destination) : pino(opts);
+
+if (IS_BROWSER_CONTEXT) {
+  (window as any).saveWeb3torrentLogs = function saveLogs() {
+    // Ref: https://stackoverflow.com/a/33542499
+    const filename = `web3torrent.${new Date(Date.now()).toUTCString()}.${VERSION}.pino.log`;
+    const {blob} = logBlob;
+    if (window.navigator.msSaveOrOpenBlob) {
+      window.navigator.msSaveBlob(blob, filename);
+    } else {
+      const elem = window.document.createElement('a');
+      elem.href = window.URL.createObjectURL(blob);
+      elem.download = filename;
+      document.body.appendChild(elem);
+      elem.click();
+      document.body.removeChild(elem);
+    }
+  };
+}

--- a/packages/web3torrent/src/logger.ts
+++ b/packages/web3torrent/src/logger.ts
@@ -82,7 +82,9 @@ export const logger = destination ? pino(opts, destination) : pino(opts);
 if (IS_BROWSER_CONTEXT) {
   (window as any).saveWeb3torrentLogs = function saveLogs() {
     // Ref: https://stackoverflow.com/a/33542499
-    const filename = `web3torrent.${new Date(Date.now()).toUTCString()}.${VERSION}.pino.log`;
+    const filename = `web3torrent.${new Date(Date.now()).toUTCString()}.${VERSION}.${
+      window.channelProvider.signingAddress
+    }.pino.log`;
     const {blob} = logBlob;
     if (window.navigator.msSaveOrOpenBlob) {
       window.navigator.msSaveBlob(blob, filename);


### PR DESCRIPTION
If I call `window.saveWeb3torrentLogs()`, my browser downloads a file like this:
[web3torrent.Wed, 13 May 2020 18_52_55 GMT.f4cb9bbd3.pino.log](https://github.com/statechannels/monorepo/files/4624057/web3torrent.Wed.13.May.2020.18_52_55.GMT.f4cb9bbd3.pino.log)

## Future improvements:
- [ ] Extract this pattern to a devtools utility
- [ ] Use this pattern in channel-provider and xstate-wallet
- [ ] Use this utility to download artifacts in integration tests