### PR TITLE
[web3torrent] Differentiate between client and torrent

### DIFF
--- a/packages/web3torrent/src/App.test.tsx
+++ b/packages/web3torrent/src/App.test.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
-import {web3torrent, Web3TorrentContext} from './clients/web3torrent-client';
+import {web3TorrentClient, Web3TorrentClientContext} from './clients/web3torrent-client';
 afterAll(() => {
-  web3torrent.destroy();
+  web3TorrentClient.destroy();
 });
 
 it('renders app without crashing', () => {
   const div = document.createElement('div');
 
   ReactDOM.render(
-    <Web3TorrentContext.Provider value={web3torrent}>
+    <Web3TorrentClientContext.Provider value={web3TorrentClient}>
       <App />
-    </Web3TorrentContext.Provider>,
+    </Web3TorrentClientContext.Provider>,
     div
   );
 

--- a/packages/web3torrent/src/App.tsx
+++ b/packages/web3torrent/src/App.tsx
@@ -11,7 +11,7 @@ import Upload from './pages/upload/Upload';
 import {RoutePath} from './routes';
 import {requiredNetwork} from './constants';
 import {Budgets} from './pages/budgets/Budgets';
-import {web3torrent} from './clients/web3torrent-client';
+import {web3TorrentClient} from './clients/web3torrent-client';
 import {identify} from './analytics';
 
 const App: React.FC = () => {
@@ -21,14 +21,14 @@ const App: React.FC = () => {
 
   const [initialized, setInitialized] = useState(false);
   useEffect(() => {
-    web3torrent.paymentChannelClient.initialize().then(() => {
+    web3TorrentClient.paymentChannelClient.initialize().then(() => {
       setInitialized(true);
       if (process.env.NODE_ENV === 'production') {
         Sentry.configureScope(scope => {
-          scope.setUser({id: web3torrent.paymentChannelClient.mySigningAddress});
+          scope.setUser({id: web3TorrentClient.paymentChannelClient.mySigningAddress});
         });
-        identify(web3torrent.paymentChannelClient.mySigningAddress, {
-          outcomeAddress: web3torrent.paymentChannelClient.myEthereumSelectedAddress
+        identify(web3TorrentClient.paymentChannelClient.mySigningAddress, {
+          outcomeAddress: web3TorrentClient.paymentChannelClient.myEthereumSelectedAddress
         });
       }
     });

--- a/packages/web3torrent/src/clients/web3torrent-client.test.ts
+++ b/packages/web3torrent/src/clients/web3torrent-client.test.ts
@@ -3,7 +3,7 @@ import {PaidStreamingTorrent, WebTorrentAddInput, WebTorrentSeedInput} from '../
 import {TorrentCallback} from '../library/web3torrent-lib';
 import {Status} from '../types';
 import {createMockExtendedTorrent, createMockTorrentPeers, pseAccount} from '../utils/test-utils';
-import {download, getTorrentPeers, cancel, upload, web3torrent} from './web3torrent-client';
+import {download, getTorrentPeers, cancel, upload, web3TorrentClient} from './web3torrent-client';
 import {getStatus} from '../utils/torrent-status-checker';
 
 describe('Web3TorrentClient', () => {
@@ -21,7 +21,7 @@ describe('Web3TorrentClient', () => {
     beforeEach(() => {
       torrent = createMockExtendedTorrent();
       addSpy = jest
-        .spyOn(web3torrent, 'add')
+        .spyOn(web3TorrentClient, 'add')
         .mockImplementation(
           (_: WebTorrentAddInput, callback: TorrentOptions | TorrentCallback | undefined) => {
             return (callback as TorrentCallback)(torrent as PaidStreamingTorrent);
@@ -30,7 +30,7 @@ describe('Web3TorrentClient', () => {
     });
 
     afterAll(() => {
-      web3torrent.destroy();
+      web3TorrentClient.destroy();
     });
 
     it('should return a torrent with a status of Connecting', async () => {
@@ -63,7 +63,7 @@ describe('Web3TorrentClient', () => {
     beforeEach(() => {
       torrent = createMockExtendedTorrent();
       seedSpy = jest
-        .spyOn(web3torrent, 'seed')
+        .spyOn(web3TorrentClient, 'seed')
         .mockImplementation(
           (
             _: WebTorrentSeedInput,
@@ -99,7 +99,7 @@ describe('Web3TorrentClient', () => {
     >;
 
     beforeEach(() => {
-      removeSpy = jest.spyOn(web3torrent, 'cancel').mockImplementation(
+      removeSpy = jest.spyOn(web3TorrentClient, 'cancel').mockImplementation(
         (torrentInfoHash: string, callback?: (err: string | Error) => void): Promise<void> => {
           if (callback) {
             return new Promise(() => callback(''));
@@ -125,15 +125,15 @@ describe('Web3TorrentClient', () => {
     const mockInfoHash = '124203';
 
     beforeEach(() => {
-      web3torrent.peersList[mockInfoHash] = createMockTorrentPeers();
+      web3TorrentClient.peersList[mockInfoHash] = createMockTorrentPeers();
     });
 
     it('should return peers for a given torrent', () => {
-      expect(getTorrentPeers(mockInfoHash)).toEqual(web3torrent.peersList[mockInfoHash]);
+      expect(getTorrentPeers(mockInfoHash)).toEqual(web3TorrentClient.peersList[mockInfoHash]);
     });
 
     afterEach(() => {
-      web3torrent.peersList = {};
+      web3TorrentClient.peersList = {};
     });
   });
 });

--- a/packages/web3torrent/src/clients/web3torrent-client.ts
+++ b/packages/web3torrent/src/clients/web3torrent-client.ts
@@ -6,42 +6,44 @@ import {paymentChannelClient} from './payment-channel-client';
 import {defaultTrackers, INITIAL_BUDGET_AMOUNT, FUNDING_STRATEGY} from '../constants';
 import _ from 'lodash';
 
-export const web3torrent = new WebTorrentPaidStreamingClient({
+export const web3TorrentClient = new WebTorrentPaidStreamingClient({
   paymentChannelClient: paymentChannelClient,
   tracker: {announce: defaultTrackers}
 });
 
-export const Web3TorrentContext = React.createContext(web3torrent);
+export const Web3TorrentClientContext = React.createContext(web3TorrentClient);
 
-export const getTorrentPeers = infoHash => web3torrent.peersList[infoHash];
+export const getTorrentPeers = infoHash => web3TorrentClient.peersList[infoHash];
 
 const doesBudgetExist = async (): Promise<boolean> => {
-  const budget = await web3torrent.paymentChannelClient.getBudget();
+  const budget = await web3TorrentClient.paymentChannelClient.getBudget();
   return !!budget && !_.isEmpty(budget);
 };
 
 export const download: (
   torrent: WebTorrentAddInput
 ) => Promise<ExtendedTorrent> = async torrentData => {
-  await web3torrent.enable();
+  await web3TorrentClient.enable();
   if (FUNDING_STRATEGY !== 'Direct' && !(await doesBudgetExist())) {
-    await web3torrent.paymentChannelClient.createBudget(INITIAL_BUDGET_AMOUNT);
+    await web3TorrentClient.paymentChannelClient.createBudget(INITIAL_BUDGET_AMOUNT);
   }
 
   return new Promise((resolve, reject) =>
-    web3torrent.add(torrentData, (torrent: any) => resolve({...torrent, status: Status.Connecting}))
+    web3TorrentClient.add(torrentData, (torrent: any) =>
+      resolve({...torrent, status: Status.Connecting})
+    )
   );
 };
 
 export const upload: (input: WebTorrentSeedInput) => Promise<ExtendedTorrent> = async input => {
-  await web3torrent.enable();
+  await web3TorrentClient.enable();
   // TODO: This only checks if a budget exists, not if we have enough funds in it
   if (FUNDING_STRATEGY !== 'Direct' && !(await doesBudgetExist())) {
-    await web3torrent.paymentChannelClient.createBudget(INITIAL_BUDGET_AMOUNT);
+    await web3TorrentClient.paymentChannelClient.createBudget(INITIAL_BUDGET_AMOUNT);
   }
 
   return new Promise((resolve, reject) =>
-    web3torrent.seed(input, {...torrentNamer(input)}, (torrent: any) => {
+    web3TorrentClient.seed(input, {...torrentNamer(input)}, (torrent: any) => {
       resolve({
         ...torrent,
         status: Status.Seeding,
@@ -53,7 +55,7 @@ export const upload: (input: WebTorrentSeedInput) => Promise<ExtendedTorrent> = 
 
 export const cancel = (torrentId: string = '') => {
   return new Promise((resolve, reject) =>
-    web3torrent.cancel(torrentId, err => {
+    web3TorrentClient.cancel(torrentId, err => {
       if (err) {
         reject(err);
       } else {

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -3,7 +3,6 @@ import prettier from 'prettier-bytes';
 import React, {useContext} from 'react';
 import {ChannelState} from '../../../clients/payment-channel-client';
 import './ChannelsList.scss';
-import {Web3TorrentContext} from '../../../clients/web3torrent-client';
 import {prettyPrintWei, prettyPrintBytes} from '../../../utils/calculateWei';
 import {utils} from 'ethers';
 import {getPeerStatus} from '../../../utils/torrent-status-checker';
@@ -77,7 +76,6 @@ function channelIdToTableRow(
 }
 
 export const ChannelsList: React.FC<UploadInfoProps> = ({torrent, channels, mySigningAddress}) => {
-  const context = useContext(Web3TorrentContext);
   const channelsInfo = _.keys(channels)
     .filter(
       id => channels[id].payer === mySigningAddress || channels[id].beneficiary === mySigningAddress

--- a/packages/web3torrent/src/hooks/use-budget.ts
+++ b/packages/web3torrent/src/hooks/use-budget.ts
@@ -1,10 +1,10 @@
-import {web3torrent} from '../clients/web3torrent-client';
+import {web3TorrentClient} from '../clients/web3torrent-client';
 import {INITIAL_BUDGET_AMOUNT} from '../constants';
 import {useState, useEffect} from 'react';
 import {DomainBudget} from '@statechannels/client-api-schema';
 
 export function useBudget({ready}: {ready: boolean}) {
-  const {paymentChannelClient} = web3torrent;
+  const {paymentChannelClient} = web3TorrentClient;
 
   const [budget, setBudget] = useState<DomainBudget>(undefined);
   const [loading, setLoading] = useState(true);

--- a/packages/web3torrent/src/hooks/use-budget.ts
+++ b/packages/web3torrent/src/hooks/use-budget.ts
@@ -6,21 +6,17 @@ import {DomainBudget} from '@statechannels/client-api-schema';
 export function useBudget({ready}: {ready: boolean}) {
   const {paymentChannelClient} = web3torrent;
 
-  const [budget, setBudget] = useState<DomainBudget | undefined>(undefined);
+  const [budget, setBudget] = useState<DomainBudget>(undefined);
   const [loading, setLoading] = useState(true);
-  const [doInitialFetch, setDoInitialFetch] = useState(true);
   useEffect(() => {
     const getAndSetBudget = async () => {
       const budget = await paymentChannelClient.getBudget();
 
       setBudget(budget);
       setLoading(false);
-      setDoInitialFetch(false);
     };
-    if (ready && doInitialFetch) {
-      getAndSetBudget();
-    }
-  });
+    if (ready) getAndSetBudget();
+  }, [ready, paymentChannelClient]);
 
   const createBudget = async () => {
     setLoading(true);
@@ -28,6 +24,7 @@ export function useBudget({ready}: {ready: boolean}) {
     setBudget(paymentChannelClient.budgetCache);
     setLoading(false);
   };
+
   const closeBudget = async () => {
     setLoading(true);
     await paymentChannelClient.closeAndWithdraw();

--- a/packages/web3torrent/src/index.tsx
+++ b/packages/web3torrent/src/index.tsx
@@ -14,12 +14,12 @@ if (process.env.NODE_ENV === 'production') {
 
 import Drift from 'react-driftjs';
 
-import {web3torrent, Web3TorrentContext} from './clients/web3torrent-client';
+import {web3TorrentClient, Web3TorrentClientContext} from './clients/web3torrent-client';
 
 ReactDOM.render(
-  <Web3TorrentContext.Provider value={web3torrent}>
+  <Web3TorrentClientContext.Provider value={web3TorrentClient}>
     <App />
     {process.env.DRIFT_CHATBOX_APP_ID && <Drift appId={process.env.DRIFT_CHATBOX_APP_ID} />}
-  </Web3TorrentContext.Provider>,
+  </Web3TorrentClientContext.Provider>,
   document.getElementById('root')
 );

--- a/packages/web3torrent/src/pages/budgets/Budgets.tsx
+++ b/packages/web3torrent/src/pages/budgets/Budgets.tsx
@@ -1,6 +1,6 @@
 import React, {useContext} from 'react';
 import {DomainBudgetTable} from '../../components/domain-budget-table/DomainBudgetTable';
-import {Web3TorrentContext} from '../../clients/web3torrent-client';
+import {Web3TorrentClientContext} from '../../clients/web3torrent-client';
 import _ from 'lodash';
 import {Spinner} from '../../components/form/spinner/Spinner';
 import {FormButton} from '../../components/form';
@@ -27,9 +27,9 @@ export const Budgets: React.FC<Props> = props => {
 };
 
 const CurrentBudget: React.FC<Props> = props => {
-  const web3Torrent = useContext(Web3TorrentContext);
+  const web3TorrentClient = useContext(Web3TorrentClientContext);
 
-  const {channelCache, mySigningAddress: me} = web3Torrent.paymentChannelClient;
+  const {channelCache, mySigningAddress: me} = web3TorrentClient.paymentChannelClient;
   const {budget, loading, createBudget, closeBudget} = useBudget(props);
   const budgetExists = !!budget && !_.isEmpty(budget);
 

--- a/packages/web3torrent/src/pages/file/File.test.tsx
+++ b/packages/web3torrent/src/pages/file/File.test.tsx
@@ -33,7 +33,7 @@ describe('<File />', () => {
   });
 
   afterAll(() => {
-    Web3TorrentClient.web3torrent.destroy();
+    Web3TorrentClient.web3TorrentClient.destroy();
   });
 
   it('should render an download button', () => {

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -95,9 +95,7 @@ const File: React.FC<Props> = props => {
 
   const {mySigningAddress: me} = web3Torrent.paymentChannelClient;
   const {budget, closeBudget} = useBudget(props);
-  // TODO: We shouldn't have to check all these different conditions
-  const showBudget =
-    !!budget && !_.isEmpty(budget) && !!budget.budgets && budget.budgets.length > 0;
+  const showBudget = budget?.budgets?.length;
 
   return (
     <section className="section fill download">

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useContext, useEffect} from 'react';
 import {useParams} from 'react-router-dom';
-import {download, Web3TorrentContext} from '../../clients/web3torrent-client';
+import {download, Web3TorrentClientContext} from '../../clients/web3torrent-client';
 import {FormButton} from '../../components/form';
 import {TorrentInfo} from '../../components/torrent-info/TorrentInfo';
 import {DomainBudgetTable} from '../../components/domain-budget-table/DomainBudgetTable';
@@ -37,7 +37,7 @@ interface Props {
 }
 
 const File: React.FC<Props> = props => {
-  const web3Torrent = useContext(Web3TorrentContext);
+  const web3TorrentClient = useContext(Web3TorrentClientContext);
 
   const {infoHash} = useParams();
   const queryParams = useQuery();
@@ -49,7 +49,7 @@ const File: React.FC<Props> = props => {
   const torrentLength = Number(queryParams.get('length'));
 
   const [torrent, setTorrent] = useState<TorrentUI>(() =>
-    getTorrentUI(web3Torrent, {
+    getTorrentUI(web3TorrentClient, {
       infoHash,
       name: torrentName,
       length: torrentLength
@@ -59,22 +59,22 @@ const File: React.FC<Props> = props => {
   useEffect(() => {
     const onTorrentUpdate = () =>
       setTorrent(
-        getTorrentUI(web3Torrent, {
+        getTorrentUI(web3TorrentClient, {
           infoHash,
           name: torrentName,
           length: torrentLength
         })
       );
-    web3Torrent.addListener(
+    web3TorrentClient.addListener(
       WebTorrentPaidStreamingClient.torrentUpdatedEventName(infoHash),
       onTorrentUpdate
     );
     return () =>
-      web3Torrent.removeListener(
+      web3TorrentClient.removeListener(
         WebTorrentPaidStreamingClient.torrentUpdatedEventName(infoHash),
         onTorrentUpdate
       );
-  }, [infoHash, torrentLength, torrentName, web3Torrent]);
+  }, [infoHash, torrentLength, torrentName, web3TorrentClient]);
 
   useEffect(() => {
     const testResult = async () => {
@@ -89,11 +89,11 @@ const File: React.FC<Props> = props => {
 
   useEffect(() => {
     if (props.ready) {
-      web3Torrent.paymentChannelClient.getChannels().then(channels => setChannels(channels));
+      web3TorrentClient.paymentChannelClient.getChannels().then(channels => setChannels(channels));
     }
-  }, [props.ready, web3Torrent.paymentChannelClient]);
+  }, [props.ready, web3TorrentClient.paymentChannelClient]);
 
-  const {mySigningAddress: me} = web3Torrent.paymentChannelClient;
+  const {mySigningAddress: me} = web3TorrentClient.paymentChannelClient;
   const {budget, closeBudget} = useBudget(props);
   const showBudget = budget?.budgets?.length;
 

--- a/packages/web3torrent/src/pages/upload/Upload.test.tsx
+++ b/packages/web3torrent/src/pages/upload/Upload.test.tsx
@@ -34,7 +34,7 @@ describe('<Upload />', () => {
   });
 
   afterAll(() => {
-    Web3TorrentClient.web3torrent.destroy();
+    Web3TorrentClient.web3TorrentClient.destroy();
   });
 
   it('should render an Upload button', () => {

--- a/packages/web3torrent/src/utils/torrent-status-checker.test.ts
+++ b/packages/web3torrent/src/utils/torrent-status-checker.test.ts
@@ -1,4 +1,4 @@
-import {web3torrent} from '../clients/web3torrent-client';
+import {web3TorrentClient} from '../clients/web3torrent-client';
 import {Status, TorrentStaticData} from '../types';
 import {createMockTorrentUI, infoHash, createMockExtendedTorrent, pseAccount} from './test-utils';
 import {getFormattedETA, getStatus, getTorrentUI} from './torrent-status-checker';
@@ -16,20 +16,20 @@ describe('Torrent Status Checker', () => {
 
   beforeAll(() => {
     mockMetamask();
-    web3torrent.enable(); // without this step, we do not yet have a pseAccount and tests will fail accordingly
+    web3TorrentClient.enable(); // without this step, we do not yet have a pseAccount and tests will fail accordingly
   });
   beforeEach(() => {
     torrent = createMockExtendedTorrent();
   });
   afterAll(() => {
-    web3torrent.destroy();
+    web3TorrentClient.destroy();
   });
 
   describe('Main function', () => {
     it('should return a torrent with a status of Idle when the torrent is not live', () => {
-      const getSpy = jest.spyOn(web3torrent, 'get').mockImplementation(() => undefined);
+      const getSpy = jest.spyOn(web3TorrentClient, 'get').mockImplementation(() => undefined);
 
-      const result = getTorrentUI(web3torrent, staticData);
+      const result = getTorrentUI(web3TorrentClient, staticData);
 
       expect(getSpy).toHaveBeenCalledWith(infoHash);
       expect(result).toEqual(getStaticTorrentUI(staticData.infoHash));
@@ -50,12 +50,12 @@ describe('Torrent Status Checker', () => {
         paused: undefined
       };
 
-      const getSpy = jest.spyOn(web3torrent, 'get').mockImplementation(() => ({
+      const getSpy = jest.spyOn(web3TorrentClient, 'get').mockImplementation(() => ({
         ...torrent,
         ...inProgressTorrent
       }));
 
-      const result = getTorrentUI(web3torrent, staticData);
+      const result = getTorrentUI(web3TorrentClient, staticData);
       const expectedResult = {
         ...torrent,
         ...inProgressTorrent,
@@ -107,13 +107,13 @@ describe('Torrent Status Checker', () => {
         expect(
           getStatus(
             {
-              createdBy: web3torrent.pseAccount,
+              createdBy: web3TorrentClient.pseAccount,
               uploadSpeed: 1000,
               downloadSpeed: 0,
               progress: 50,
               done: false
             } as WebTorrent.Torrent,
-            web3torrent.pseAccount
+            web3TorrentClient.pseAccount
           )
         ).toEqual(Status.Seeding);
       });
@@ -127,7 +127,7 @@ describe('Torrent Status Checker', () => {
               progress: 100,
               done: true
             } as WebTorrent.Torrent,
-            web3torrent.pseAccount
+            web3TorrentClient.pseAccount
           )
         ).toEqual(Status.Completed);
       });
@@ -136,7 +136,7 @@ describe('Torrent Status Checker', () => {
         expect(
           getStatus(
             {uploadSpeed: 0, downloadSpeed: 0, progress: 0, done: false} as WebTorrent.Torrent,
-            web3torrent.pseAccount
+            web3TorrentClient.pseAccount
           )
         ).toEqual(Status.Connecting);
       });
@@ -150,7 +150,7 @@ describe('Torrent Status Checker', () => {
               progress: 10,
               done: false
             } as WebTorrent.Torrent,
-            web3torrent.pseAccount
+            web3TorrentClient.pseAccount
           )
         ).toEqual(Status.Downloading);
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -29634,6 +29634,18 @@ socket.io@^2.1.0:
     socket.io-client "2.3.0"
     socket.io-parser "~3.4.0"
 
+sockjs-client@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz#12fc9d6cb663da5739d3dc5fb6e8687da95cb177"
+  integrity sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==
+  dependencies:
+    debug "^3.2.5"
+    eventsource "^1.0.7"
+    faye-websocket "~0.11.1"
+    inherits "^2.0.3"
+    json3 "^3.3.2"
+    url-parse "^1.4.3"
+
 sockjs-client@1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.4.0.tgz#c9f2568e19c8fd8173b4997ea3420e0bb306c7d5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -29634,18 +29634,6 @@ socket.io@^2.1.0:
     socket.io-client "2.3.0"
     socket.io-parser "~3.4.0"
 
-sockjs-client@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz#12fc9d6cb663da5739d3dc5fb6e8687da95cb177"
-  integrity sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==
-  dependencies:
-    debug "^3.2.5"
-    eventsource "^1.0.7"
-    faye-websocket "~0.11.1"
-    inherits "^2.0.3"
-    json3 "^3.3.2"
-    url-parse "^1.4.3"
-
 sockjs-client@1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.4.0.tgz#c9f2568e19c8fd8173b4997ea3420e0bb306c7d5"


### PR DESCRIPTION
There are:
- a web3torrent client. This is a torrent manager.
- a web3 torrent. This is one torrent with payments.
- a wire. A torrent can have many wires.

This PR hopes to remove the mental overhead of remembering that `web3torrent` constants do not represent web3 torrents but instead represent the web3torrent client.

https://github.com/statechannels/monorepo/pull/1827 preceeds this PR.