### PR TITLE
Downloadable logs part 2

### DIFF
--- a/packages/channel-provider/src/logger.ts
+++ b/packages/channel-provider/src/logger.ts
@@ -15,6 +15,9 @@ let browser: any = IS_BROWSER_CONTEXT
   ? {
       transmit: {
         send: (_: any, logEvent: any) =>
+          // The simplest way to give users/developers easy access to the logs in a single place is to
+          // make the application aware of all the pino logs via postMessage
+          // Then, the application can package up all the logs into a single file
           window.postMessage(
             {type: 'PINO_LOG', logEvent: JSON.parse(JSON.stringify({...logEvent, name}))},
             '*'

--- a/packages/channel-provider/src/logger.ts
+++ b/packages/channel-provider/src/logger.ts
@@ -4,15 +4,26 @@ import pino from 'pino';
 const LOG_TO_CONSOLE = process.env.LOG_DESTINATION === 'console';
 // eslint-disable-next-line no-undef
 const LOG_TO_FILE = process.env.LOG_DESTINATION && !LOG_TO_CONSOLE;
+// eslint-disable-next-line no-undef
+const IS_BROWSER_CONTEXT = process.env.NODE_ENV !== 'test';
 
 const name = 'channel-provider';
 
-// If we are in a browser, but we want to LOG_TO_FILE, we assume that the
-// log statements are meant to be stored as JSON objects
-// So, we log serialized objects, appending the name (which the pino browser-api appears to remove?)
-const browser = LOG_TO_FILE
-  ? {write: (o: any) => console.log(JSON.stringify({...o, name}))}
+const serializeLogEvent = (o: any) => JSON.stringify({...o, name});
+
+let browser: any = IS_BROWSER_CONTEXT
+  ? {
+      transmit: {
+        send: (e: any, logEvent: any) =>
+          window.postMessage({type: 'PINO_LOG', logEvent: {...logEvent, name}}, '*')
+      }
+    }
   : undefined;
+
+if (browser && LOG_TO_FILE) {
+  // TODO: Use the logBlob instead of writing to the browser logs
+  browser = {...browser, write: (o: any) => console.log(serializeLogEvent(o))};
+}
 
 const prettyPrint = LOG_TO_CONSOLE ? {translateTime: true} : false;
 

--- a/packages/channel-provider/src/logger.ts
+++ b/packages/channel-provider/src/logger.ts
@@ -14,7 +14,7 @@ const serializeLogEvent = (o: any) => JSON.stringify({...o, name});
 let browser: any = IS_BROWSER_CONTEXT
   ? {
       transmit: {
-        send: (e: any, logEvent: any) =>
+        send: (_: any, logEvent: any) =>
           window.postMessage({type: 'PINO_LOG', logEvent: {...logEvent, name}}, '*')
       }
     }

--- a/packages/channel-provider/src/logger.ts
+++ b/packages/channel-provider/src/logger.ts
@@ -15,7 +15,10 @@ let browser: any = IS_BROWSER_CONTEXT
   ? {
       transmit: {
         send: (_: any, logEvent: any) =>
-          window.postMessage({type: 'PINO_LOG', logEvent: {...logEvent, name}}, '*')
+          window.postMessage(
+            {type: 'PINO_LOG', logEvent: JSON.parse(JSON.stringify({...logEvent, name}))},
+            '*'
+          )
       }
     }
   : undefined;

--- a/packages/web3torrent/src/logger.ts
+++ b/packages/web3torrent/src/logger.ts
@@ -43,6 +43,13 @@ const transformLogEvent = logEvent => ({
 class LogBlob {
   private parts = [];
   private _blob?: Blob;
+  constructor() {
+    window.addEventListener('message', event => {
+      if (event.data?.type === 'PINO_LOG') {
+        this.append(event.data.logEvent);
+      }
+    });
+  }
 
   append(part) {
     this.parts.push(transformLogEvent(part));

--- a/packages/web3torrent/src/logger.ts
+++ b/packages/web3torrent/src/logger.ts
@@ -29,17 +29,31 @@ const getCircularReplacer = () => {
     return value;
   };
 };
+
+const serializeLogObject = o => JSON.stringify(o, getCircularReplacer()) + '\n';
+const transformLogEvent = logEvent => ({
+  // For some reason, the shape of logEvent and the shape that pino normally prints are different:
+  // - there is a `ts` property instead of a `timestamp` property
+  // - The `level` property is of shape {label: string, value: number}
+  // This transformation makes the resulting object parseable by pino-pretty
+  ..._.omit(logEvent, 'ts'),
+  level: logEvent.level.value,
+  time: logEvent.ts
+});
 class LogBlob {
   private parts = [];
   private _blob?: Blob;
 
   append(part) {
-    this.parts.push(part);
+    this.parts.push(transformLogEvent(part));
     this._blob = undefined;
   }
 
   get blob() {
-    if (!this._blob) this._blob = new Blob(this.parts, {type: 'text/plain'});
+    if (!this._blob)
+      this._blob = new Blob(_.sortBy(this.parts, o => o.time).map(serializeLogObject), {
+        type: 'text/plain'
+      });
 
     return this._blob;
   }
@@ -47,35 +61,22 @@ class LogBlob {
 
 const logBlob = new LogBlob();
 
-const serializeLogEvent = o => JSON.stringify({...o, name}, getCircularReplacer());
-
+// So as to not overwrite the `name` property from xstate-wallet (and later, channel-provider),
+// we only call `addName` on objects that we know came from web3torrent.
+const addName = o => ({...o, name});
 let browser: any = IS_BROWSER_CONTEXT
-  ? {
-      transmit: {
-        send: (_logEvent, logEvent) =>
-          logBlob.append(
-            serializeLogEvent({
-              // For some reason, the shape of logEvent and the shape that pino normally prints are different:
-              // - there is a `ts` property instead of a `timestamp` property
-              // - The `level` property is of shape {label: string, value: number}
-              ..._.omit(logEvent, 'ts'),
-              level: logEvent.level.value,
-              time: logEvent.ts
-            }) + '\n'
-          )
-      }
-    }
+  ? {transmit: {send: (__, logEvent) => logBlob.append(addName(logEvent))}}
   : undefined;
 
 if (browser && LOG_TO_FILE) {
   // TODO: Use the logBlob instead of writing to the browser logs
-  browser = {...browser, write: o => console.log(serializeLogEvent(o))};
+  browser = {...browser, write: o => console.log(serializeLogObject(addName(o)))};
 }
 
 const prettyPrint = LOG_TO_CONSOLE ? {translateTime: true} : false;
 
 const level = LOG_LEVEL;
-const opts = {name, prettyPrint, browser, level};
+const opts = {prettyPrint, browser, level};
 
 export const logger = destination ? pino(opts, destination) : pino(opts);
 

--- a/packages/xstate-wallet/src/logger.ts
+++ b/packages/xstate-wallet/src/logger.ts
@@ -19,7 +19,10 @@ let browser: any = IS_BROWSER_CONTEXT
   ? {
       transmit: {
         send: (_, logEvent) =>
-          window.parent.postMessage({type: 'PINO_LOG', logEvent: {...logEvent, name}}, '*')
+          window.parent.postMessage(
+            {type: 'PINO_LOG', logEvent: {...JSON.parse(JSON.stringify(logEvent)), name}},
+            '*'
+          )
       }
     }
   : undefined;

--- a/packages/xstate-wallet/src/logger.ts
+++ b/packages/xstate-wallet/src/logger.ts
@@ -19,6 +19,9 @@ let browser: any = IS_BROWSER_CONTEXT
   ? {
       transmit: {
         send: (_, logEvent) =>
+          // The simplest way to give users/developers easy access to the logs in a single place is to
+          // make the application aware of all the pino logs via postMessage
+          // Then, the application can package up all the logs into a single file
           window.parent.postMessage(
             {type: 'PINO_LOG', logEvent: {...JSON.parse(JSON.stringify(logEvent)), name}},
             '*'

--- a/packages/xstate-wallet/src/logger.ts
+++ b/packages/xstate-wallet/src/logger.ts
@@ -13,13 +13,21 @@ const name = 'xstate-wallet';
 const destination =
   LOG_TO_FILE && !IS_BROWSER_CONTEXT ? pino.destination(LOG_DESTINATION) : undefined;
 
-// If we are in a browser, but we want to LOG_TO_FILE, we assume that the
-// log statements are meant to be stored as JSON objects
-// So, we log serialized objects, appending the name (which the pino browser-api appears to remove?)
-const browser =
-  LOG_TO_FILE && IS_BROWSER_CONTEXT
-    ? {write: o => console.log(JSON.stringify({...o, name}))}
-    : undefined;
+const serializeLogEvent = o => JSON.stringify({...o, name});
+
+let browser: any = IS_BROWSER_CONTEXT
+  ? {
+      transmit: {
+        send: (_, logEvent) =>
+          window.parent.postMessage({type: 'PINO_LOG', logEvent: {...logEvent, name}}, '*')
+      }
+    }
+  : undefined;
+
+if (browser && LOG_TO_FILE) {
+  // TODO: Use the logBlob instead of writing to the browser logs
+  browser = {...browser, write: o => console.log(serializeLogEvent(o))};
+}
 
 const prettyPrint = LOG_TO_CONSOLE ? {translateTime: true} : false;
 


### PR DESCRIPTION
Expands on https://github.com/statechannels/monorepo/pull/1829.

Now, channel-provider and xstate-wallet logs are also downloaded by the `downloadWeb3torrentLogs()` function

[web3torrent.Wed, 13 May 2020 21_55_06 GMT.36df83790.0x32cEE11c2c29a3CC1A9b1cE3D671D7BaC54cFEdc.pino.log](https://github.com/statechannels/monorepo/files/4624960/web3torrent.Wed.13.May.2020.21_55_06.GMT.36df83790.0x32cEE11c2c29a3CC1A9b1cE3D671D7BaC54cFEdc.pino.log)

The simplest way to connect xstate-wallet logs to web3torrent logs was to post a message to the web3torrent's window on xstate-wallet log events.

Given that pattern, the simplest way to also include the channel-provider logs was to post a message to `window` on channel-provider log events.

## Future improvements
- [ ] Abstract the utilities here into a devtools utility
- [ ] Download the logBlob in the integration tests, rather than peek on console logs.