### PR TITLE
Update version of CircleCI dependency cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ defaults: &defaults
 
 save_dep: &save_dep
   save_cache:
-    key: v3-dependency-cache-{{ checksum "yarn.lock" }}
+    key: v4-dependency-cache-{{ checksum "yarn.lock" }}
     paths:
       - node_modules
       - packages/channel-client/node_modules


### PR DESCRIPTION
[Broke deploy](https://app.circleci.com/pipelines/github/statechannels/monorepo/6431/workflows/04ed0bfd-5d1c-4d88-80b7-d82970320659/jobs/27017)

![https://media1.tenor.com/images/308c7c7655c8ccd2f484e0a6396307aa/tenor.gif?itemid=15029338](https://media1.tenor.com/images/308c7c7655c8ccd2f484e0a6396307aa/tenor.gif?itemid=15029338)