### PR TITLE
Improved pino logging

### DIFF
--- a/packages/web3torrent/config/webpack.config.js
+++ b/packages/web3torrent/config/webpack.config.js
@@ -71,24 +71,27 @@ module.exports = function(webpackEnv) {
   // This is based on what CRA was doing
   const rawEnv = Object.keys(process.env)
     .filter(key => {
-      return [
-        'VERSION',
-        'CHAIN_NETWORK_ID',
-        'DRIFT_CHATBOX_ID',
-        'FAKE_CHANNEL_PROVIDER',
-        'FIREBASE_API_KEY',
-        'FIREBASE_PREFIX',
-        'FIREBASE_URL',
-        'FUNDING_STRATEGY',
-        'HUB_DESTINATION',
-        'LOG_LEVEL',
-        'NODE_ENV',
-        'SINGLE_ASSET_PAYMENT_CONTRACT_ADDRESS',
-        'TARGET_NETWORK',
-        'TRACKER_URL',
-        'TRACKER_URL_HTTP_PROTOCOL',
-        'WALLET_URL'
-      ].indexOf(key) > -1
+      return (
+        [
+          'VERSION',
+          'CHAIN_NETWORK_ID',
+          'DRIFT_CHATBOX_ID',
+          'FAKE_CHANNEL_PROVIDER',
+          'FIREBASE_API_KEY',
+          'FIREBASE_PREFIX',
+          'FIREBASE_URL',
+          'FUNDING_STRATEGY',
+          'HUB_DESTINATION',
+          'LOG_DESTINATION',
+          'LOG_LEVEL',
+          'NODE_ENV',
+          'SINGLE_ASSET_PAYMENT_CONTRACT_ADDRESS',
+          'TARGET_NETWORK',
+          'TRACKER_URL',
+          'TRACKER_URL_HTTP_PROTOCOL',
+          'WALLET_URL'
+        ].indexOf(key) > -1
+      );
     })
     .reduce(
       (env, key) => {
@@ -567,6 +570,7 @@ module.exports = function(webpackEnv) {
       // It is absolutely essential that NODE_ENV is set to production
       // during a production build.
       // Otherwise React will be compiled in the very slow development mode.
+
       new webpack.DefinePlugin({
         // This is a bit messy, we should clean this up
         ['process.env']: {

--- a/packages/web3torrent/src/logger.ts
+++ b/packages/web3torrent/src/logger.ts
@@ -66,7 +66,7 @@ const appendAndCallToConsoleFn = (consoleFn: {(message?: any, ...optionalParams:
 
   // So as to not overwrite the `name` property from xstate-wallet (and later, channel-provider),
   // we only call `addName` on objects that we know came from web3torrent.
-  logBlob.append(JSON.stringify(withName));
+  logBlob.append(withName);
   if (LOG_TO_FILE) consoleFn(withName);
   else consoleFn(o.msg, _.omit(o, 'msg'));
 };

--- a/packages/web3torrent/src/logger.ts
+++ b/packages/web3torrent/src/logger.ts
@@ -31,15 +31,6 @@ const getCircularReplacer = () => {
 };
 
 const serializeLogObject = o => JSON.stringify(o, getCircularReplacer()) + '\n';
-const transformLogEvent = logEvent => ({
-  // For some reason, the shape of logEvent and the shape that pino normally prints are different:
-  // - there is a `ts` property instead of a `timestamp` property
-  // - The `level` property is of shape {label: string, value: number}
-  // This transformation makes the resulting object parseable by pino-pretty
-  ..._.omit(logEvent, 'ts'),
-  level: logEvent.level.value,
-  time: logEvent.ts
-});
 class LogBlob {
   private parts = [];
   private _blob?: Blob;
@@ -52,7 +43,7 @@ class LogBlob {
   }
 
   append(part) {
-    this.parts.push(transformLogEvent(part));
+    this.parts.push(part);
     this._blob = undefined;
   }
 
@@ -68,17 +59,29 @@ class LogBlob {
 
 const logBlob = new LogBlob();
 
-// So as to not overwrite the `name` property from xstate-wallet (and later, channel-provider),
-// we only call `addName` on objects that we know came from web3torrent.
-const addName = o => ({...o, name});
-let browser: any = IS_BROWSER_CONTEXT
-  ? {transmit: {send: (__, logEvent) => logBlob.append(addName(logEvent))}}
-  : undefined;
+const appendAndCallToConsoleFn = (consoleFn: {(message?: any, ...optionalParams: any[]): void}) => (
+  o: any
+) => {
+  const withName = {...o, name};
 
-if (browser && LOG_TO_FILE) {
-  // TODO: Use the logBlob instead of writing to the browser logs
-  browser = {...browser, write: o => console.log(serializeLogObject(addName(o)))};
-}
+  // So as to not overwrite the `name` property from xstate-wallet (and later, channel-provider),
+  // we only call `addName` on objects that we know came from web3torrent.
+  logBlob.append(JSON.stringify(withName));
+  if (LOG_TO_FILE) consoleFn(withName);
+  else consoleFn(o.msg, _.omit(o, 'msg'));
+};
+
+const browser: any = IS_BROWSER_CONTEXT
+  ? {
+      write: {
+        error: appendAndCallToConsoleFn(console.error),
+        warn: appendAndCallToConsoleFn(console.warn),
+        info: appendAndCallToConsoleFn(console.info),
+        debug: appendAndCallToConsoleFn(console.debug),
+        trace: appendAndCallToConsoleFn(console.trace)
+      }
+    }
+  : undefined;
 
 const prettyPrint = LOG_TO_CONSOLE ? {translateTime: true} : false;
 

--- a/packages/xstate-wallet/src/logger.ts
+++ b/packages/xstate-wallet/src/logger.ts
@@ -1,6 +1,7 @@
 import pino from 'pino';
 
 import {LOG_DESTINATION, ADD_LOGS, NODE_ENV} from './config';
+import _ from 'lodash';
 
 // TODO: Is there a better way to determine if we're in a browser context?
 const IS_BROWSER_CONTEXT = NODE_ENV !== 'test';
@@ -13,27 +14,30 @@ const name = 'xstate-wallet';
 const destination =
   LOG_TO_FILE && !IS_BROWSER_CONTEXT ? pino.destination(LOG_DESTINATION) : undefined;
 
-const serializeLogEvent = o => JSON.stringify({...o, name});
+const postMessageAndCallConsoleFn = (consoleFn: {
+  (message?: any, ...optionalParams: any[]): void;
+}) => (o: any) => {
+  const withName = JSON.stringify({...o, name});
 
-let browser: any = IS_BROWSER_CONTEXT
+  // The simplest way to give users/developers easy access to the logs in a single place is to
+  // make the application aware of all the pino logs via postMessage
+  // Then, the application can package up all the logs into a single file
+  window.parent.postMessage({type: 'PINO_LOG', logEvent: JSON.parse(withName)}, '*');
+  if (LOG_TO_FILE) consoleFn(withName);
+  else consoleFn(o.msg, _.omit(o, 'msg'));
+};
+
+const browser: any = IS_BROWSER_CONTEXT
   ? {
-      transmit: {
-        send: (_, logEvent) =>
-          // The simplest way to give users/developers easy access to the logs in a single place is to
-          // make the application aware of all the pino logs via postMessage
-          // Then, the application can package up all the logs into a single file
-          window.parent.postMessage(
-            {type: 'PINO_LOG', logEvent: {...JSON.parse(JSON.stringify(logEvent)), name}},
-            '*'
-          )
+      write: {
+        error: postMessageAndCallConsoleFn(console.error),
+        warn: postMessageAndCallConsoleFn(console.warn),
+        info: postMessageAndCallConsoleFn(console.info),
+        debug: postMessageAndCallConsoleFn(console.debug),
+        trace: postMessageAndCallConsoleFn(console.trace)
       }
     }
   : undefined;
-
-if (browser && LOG_TO_FILE) {
-  // TODO: Use the logBlob instead of writing to the browser logs
-  browser = {...browser, write: o => console.log(serializeLogEvent(o))};
-}
 
 const prettyPrint = LOG_TO_CONSOLE ? {translateTime: true} : false;
 


### PR DESCRIPTION
I was using the `transmit` option in #1829 and #1836

While investigating around #1839, I realized that I could use the `write` option in any case.

This means
- I don't have to transform the logEvent thata `transmit` gives you: http://getpino.io/#/docs/browser?id=transmit-object
- I can keep the same console formatting (yellow for warn, red for error, etc) by passing an object for `write`: http://getpino.io/#/docs/browser?id=write-function-object

Sample:

<img width="1680" alt="Screen Shot 2020-05-13 at 6 40 34 PM" src="https://user-images.githubusercontent.com/8432675/81883161-5934b880-9549-11ea-99d6-1a1f25fd9376.png">


[web3torrent.Thu, 14 May 2020 01_40_47 GMT.f0abd39f4.0x32cEE11c2c29a3CC1A9b1cE3D671D7BaC54cFEdc.pino.log](https://github.com/statechannels/monorepo/files/4625576/web3torrent.Thu.14.May.2020.01_40_47.GMT.f0abd39f4.0x32cEE11c2c29a3CC1A9b1cE3D671D7BaC54cFEdc.pino.log)
