### PR TITLE
[rps, ,e2e] Unskip bResigns step

### DIFF
--- a/packages/e2e-tests/puppeteer/__tests__/rps/rps.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/rps/rps.test.ts
@@ -60,15 +60,13 @@ describe('completes game 1 (challenge by A, challenge by B, resign by B) and beg
   });
 
   it('works', async () => {
+    console.log('logging in..');
+    await login(rpsTabA, rpsTabB);
     console.log('approving MetaMask..');
     await Promise.all([
       waitAndApproveMetaMask(rpsTabA, metamaskA),
       waitAndApproveMetaMask(rpsTabB, metamaskB)
     ]);
-    await rpsTabA.bringToFront();
-    await rpsTabB.bringToFront();
-    console.log('logging in..');
-    await login(rpsTabA, rpsTabB);
     console.log('starting first game...');
     await startFundAndPlaySingleMove(rpsTabA, metamaskA, rpsTabB, metamaskB);
     // xstate wallet does not fully support challenging yet

--- a/packages/e2e-tests/puppeteer/__tests__/rps/rps.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/rps/rps.test.ts
@@ -67,6 +67,8 @@ describe('completes game 1 (challenge by A, challenge by B, resign by B) and beg
       waitAndApproveMetaMask(rpsTabA, metamaskA),
       waitAndApproveMetaMask(rpsTabB, metamaskB)
     ]);
+    await rpsTabA.bringToFront();
+    await rpsTabB.bringToFront();
     console.log('starting first game...');
     await startFundAndPlaySingleMove(rpsTabA, metamaskA, rpsTabB, metamaskB);
     // xstate wallet does not fully support challenging yet
@@ -76,8 +78,8 @@ describe('completes game 1 (challenge by A, challenge by B, resign by B) and beg
     // await bChallenges(rpsTabA, rpsTabB);
     console.log('B resigning...');
     await bResigns(rpsTabA, metamaskA, rpsTabB, metamaskB);
-    console.log('starting second game...');
-    return await startFundAndPlaySingleMove(rpsTabA, metamaskA, rpsTabB, metamaskB);
+    // console.log('starting second game...'); // Starting a second game does not yet work
+    // return await startFundAndPlaySingleMove(rpsTabA, metamaskA, rpsTabB, metamaskB);
     // (ultimate and intermediate) test success implied by promises resolving
     // therefore no assertions needed in this test
   });

--- a/packages/e2e-tests/puppeteer/__tests__/rps/rps.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/rps/rps.test.ts
@@ -9,7 +9,7 @@ import {
   setupFakeWeb3,
   takeScreenshot
 } from '../../helpers';
-import {login, startFundAndPlaySingleMove} from '../../scripts/rps';
+import {login, startFundAndPlaySingleMove, bResigns} from '../../scripts/rps';
 import {Dappeteer} from 'dappeteer';
 import {USE_DAPPETEER, CLOSE_BROWSERS} from '../../constants';
 
@@ -70,16 +70,16 @@ describe('completes game 1 (challenge by A, challenge by B, resign by B) and beg
     console.log('logging in..');
     await login(rpsTabA, rpsTabB);
     console.log('starting first game...');
-    return await startFundAndPlaySingleMove(rpsTabA, metamaskA, rpsTabB, metamaskB);
+    await startFundAndPlaySingleMove(rpsTabA, metamaskA, rpsTabB, metamaskB);
     // xstate wallet does not fully support challenging yet
     // console.log('A challenging...');
     // await aChallenges(rpsTabA, rpsTabB);
     // console.log('B challenging...');
     // await bChallenges(rpsTabA, rpsTabB);
-    // console.log('B resigning...');
-    // await bResigns(rpsTabA, rpsTabB);
-    // console.log('starting second game...');
-    // return await startFundAndPlaySingleMove(rpsTabA, metamaskA, rpsTabB, metamaskB);
+    console.log('B resigning...');
+    await bResigns(rpsTabA, metamaskA, rpsTabB, metamaskB);
+    console.log('starting second game...');
+    return await startFundAndPlaySingleMove(rpsTabA, metamaskA, rpsTabB, metamaskB);
     // (ultimate and intermediate) test success implied by promises resolving
     // therefore no assertions needed in this test
   });

--- a/packages/e2e-tests/puppeteer/scripts/rps.ts
+++ b/packages/e2e-tests/puppeteer/scripts/rps.ts
@@ -130,12 +130,8 @@ export async function bResigns(
     //   // App & Wallet left in a 'clean' no-game state
     // } else {
 
-    // TODO B never sees the wallet nor sends a tx
-    // await waitForWalletToBeDisplayed(page);
-    // await page.waitFor(2000); // Give the wallet some time to prepare the transaction TODO once UI is fixed, we can await a visual cue that the tx is ready to be confirmed
-    // await metamask.confirmTransaction({gas: 20, gasLimit: 50000});
-    // await page.bringToFront();
-    // await waitForWalletToBeHidden(page);
+    await waitForWalletToBeDisplayed(page);
+    await waitForWalletToBeHidden(page); // We do not send a transaction as Player B
 
     await waitForAndClickButton(page, page.mainFrame(), '#resigned-ok');
     await waitForAndClickButton(page, page.mainFrame(), '#exit');

--- a/packages/e2e-tests/puppeteer/scripts/rps.ts
+++ b/packages/e2e-tests/puppeteer/scripts/rps.ts
@@ -5,9 +5,10 @@ import {
   setUpBrowser,
   setupLogging,
   waitAndApproveMetaMask,
-  waitAndApproveDeposit
+  waitAndApproveDeposit,
+  waitForWalletToBeDisplayed,
+  waitForWalletToBeHidden
 } from '../helpers';
-import {getEnvBool} from '@statechannels/devtools';
 import {Dappeteer} from 'dappeteer';
 
 export async function login(rpsTabA: Page, rpsTabB: Page): Promise<boolean> {
@@ -110,40 +111,54 @@ export async function bChallenges(rpsTabA: Page, rpsTabB: Page): Promise<boolean
   return true;
 }
 
-export async function bResigns(rpsTabA: Page, rpsTabB: Page): Promise<boolean> {
-  const virtual = getEnvBool('USE_VIRTUAL_FUNDING', false);
-  async function playerB(page: Page): Promise<void> {
-    const walletIFrame = page.frames()[1];
+export async function bResigns(
+  rpsTabA: Page,
+  metamaskA: Dappeteer,
+  rpsTabB: Page,
+  metamaskB: Dappeteer
+): Promise<boolean> {
+  // const virtual = getEnvBool('USE_VIRTUAL_FUNDING', false);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async function playerB(page: Page, _metamask: Dappeteer): Promise<void> {
+    await waitForAndClickButton(page, page.mainFrame(), '#resign:not([disabled])');
+    // unsupported for now
+    // if (virtual) {
+    //   await waitForAndClickButton(page, walletIFrame, '#approve-withdraw');
+    //   await waitForAndClickButton(page, walletIFrame, '#ok');
+    //   await waitForAndClickButton(page, page.mainFrame(), '#resigned-ok');
+    //   await waitForAndClickButton(page, page.mainFrame(), '#exit');
+    //   // App & Wallet left in a 'clean' no-game state
+    // } else {
 
-    await waitForAndClickButton(page, page.mainFrame(), '#resign');
-    await waitForAndClickButton(page, walletIFrame, '#yes');
+    // TODO B never sees the wallet nor sends a tx
+    // await waitForWalletToBeDisplayed(page);
+    // await page.waitFor(2000); // Give the wallet some time to prepare the transaction TODO once UI is fixed, we can await a visual cue that the tx is ready to be confirmed
+    // await metamask.confirmTransaction({gas: 20, gasLimit: 50000});
+    // await page.bringToFront();
+    // await waitForWalletToBeHidden(page);
 
-    if (virtual) {
-      await waitForAndClickButton(page, walletIFrame, '#approve-withdraw');
-      await waitForAndClickButton(page, walletIFrame, '#ok');
-      await waitForAndClickButton(page, page.mainFrame(), '#resigned-ok');
-      await waitForAndClickButton(page, page.mainFrame(), '#exit');
-      // App & Wallet left in a 'clean' no-game state
-    } else {
-      await waitForAndClickButton(page, walletIFrame, '#ok');
-      await waitForAndClickButton(page, page.mainFrame(), '#resigned-ok');
-      await waitForAndClickButton(page, page.mainFrame(), '#exit');
-      // App & Wallet left in a 'clean' no-game state
-    }
+    await waitForAndClickButton(page, page.mainFrame(), '#resigned-ok');
+    await waitForAndClickButton(page, page.mainFrame(), '#exit');
+    // App & Wallet left in a 'clean' no-game state
+    // }
   }
 
-  async function playerA(page: Page): Promise<void> {
+  async function playerA(page: Page, metamask: Dappeteer): Promise<void> {
+    await page.waitFor(1000);
     await playMove(page, 'rock');
-    const walletIFrame = page.frames()[1];
-    await waitForAndClickButton(page, walletIFrame, '#yes');
-    await waitForAndClickButton(page, walletIFrame, '#approve-withdraw');
-    await waitForAndClickButton(page, walletIFrame, '#ok');
+
+    await waitForWalletToBeDisplayed(page);
+    await page.waitFor(2000); // Give the wallet some time to prepare the transaction TODO once UI is fixed, we can await a visual cue that the tx is ready to be confirmed
+    await metamask.confirmTransaction({gas: 20, gasLimit: 50000});
+    await page.bringToFront();
+    await waitForWalletToBeHidden(page);
+
     await waitForAndClickButton(page, page.mainFrame(), '#resigned-ok');
     await waitForAndClickButton(page, page.mainFrame(), '#exit');
     // App & Wallet left in a 'clean' no-game state
   }
 
-  await Promise.all([playerA(rpsTabA), playerB(rpsTabB)]);
+  await Promise.all([playerA(rpsTabA, metamaskA), playerB(rpsTabB, metamaskB)]);
   return true;
 }
 

--- a/packages/rps/src/__stories__/index.tsx
+++ b/packages/rps/src/__stories__/index.tsx
@@ -80,7 +80,11 @@ export function siteStateFromLocalState<T extends states.LocalState>(
 storiesOf('Setup', module)
   .add('Loading Page', () => <LoadingPage />)
   .add('Home Page', () => (
-    <HomePage login={() => alert('login')} metamaskState={initialState.metamask} />
+    <HomePage
+      walletReady={true}
+      login={() => alert('login')}
+      metamaskState={initialState.metamask}
+    />
   ))
   .add('Profile Modal', testState(initialState));
 

--- a/packages/rps/src/components/HomePage.tsx
+++ b/packages/rps/src/components/HomePage.tsx
@@ -4,13 +4,15 @@ import {Button} from 'reactstrap';
 import ConnectionBanner from '@rimble/connection-banner';
 import {MetamaskState} from 'src/redux/metamask/state';
 interface Props {
+  walletReady: boolean;
   metamaskState: MetamaskState;
   login: () => any;
 }
 
-const HomePage: React.SFC<Props> = ({login, metamaskState}) => {
+const HomePage: React.SFC<Props> = ({walletReady, login, metamaskState}) => {
   const currentNetwork = Number(metamaskState.network);
   const targetNetwork = Number(process.env.CHAIN_NETWORK_ID);
+  const buttonDisabled = currentNetwork !== targetNetwork || !walletReady;
   return (
     <div>
       <div className="homePage">
@@ -23,9 +25,9 @@ const HomePage: React.SFC<Props> = ({login, metamaskState}) => {
             className="cog-button homePage-loginButton"
             id="start-playing"
             onClick={login}
-            disabled={currentNetwork !== targetNetwork}
+            disabled={buttonDisabled}
           >
-            Start Playing!
+            {buttonDisabled ? 'Waiting for Wallet' : 'Start Playing!'}
           </Button>
         </div>
       </div>

--- a/packages/rps/src/containers/HomePageContainer.tsx
+++ b/packages/rps/src/containers/HomePageContainer.tsx
@@ -5,6 +5,7 @@ import * as loginActions from '../redux/login/actions';
 import {SiteState} from 'src/redux/reducer';
 
 const mapStateToProps = (siteState: SiteState) => ({
+  walletReady: !siteState.wallet.loading,
   metamaskState: siteState.metamask,
 });
 

--- a/packages/rps/src/redux/game/saga.ts
+++ b/packages/rps/src/redux/game/saga.ts
@@ -70,7 +70,7 @@ function* gameSagaRun(client: RPSChannelClient) {
 
   switch (localState.type) {
     case 'Setup.NeedAddress':
-      // yield call([window.channelProvider, 'enable']); // no longer need this
+      yield call([window.channelProvider, 'enable']);
       yield put(
         a.gotAddressFromWallet(
           window.channelProvider.signingAddress,

--- a/packages/rps/src/redux/store.ts
+++ b/packages/rps/src/redux/store.ts
@@ -1,5 +1,5 @@
 import {applyMiddleware, compose, createStore} from 'redux';
-import {fork, take, call} from 'redux-saga/effects';
+import {fork, take} from 'redux-saga/effects';
 import createSagaMiddleware from 'redux-saga';
 
 import reducer from './reducer';
@@ -49,8 +49,6 @@ function* rootSaga() {
   } else if (process.env.AUTO_OPPONENT === 'B') {
     yield fork(autoOpponent, 'B', client);
   } else {
-    yield call([window.channelProvider, 'enable']);
-
     setupFirebase(client, window.channelProvider.signingAddress);
 
     // RPS only supports a directly funded channel, for now


### PR DESCRIPTION
Since #1834 got merged, we are now able to have Player B resign and both players back to the lobby. Starting a new game does not yet work. 

Additional tweaks:

- push approve metamask flow to after a user click (avoids immediate MM popup which is considered bad UX)
- prevent user logging in until wallet is ready

There is still much work to do:
- Get a second game working
- Add `aResigns` step
- improve UX: currently A's wallet doesn't inform that your opponent resigned, and submits the transaction without your approval . Similarly B's wallet does not explain that the other user is submitting the withdrawal transaction.
