### PR TITLE
Turn off e2e-test-w3t-production alert

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,7 +422,6 @@ jobs:
       - run: (cd packages/e2e-tests && yarn jest web3torrent --runInBand --bail)
       - upload_logs:
           file: e2e-test-w3t-production-stats
-      - notify_slack
 
   push-master-to-deploy:
     working_directory: /home/circleci/project


### PR DESCRIPTION
The job has never passed. Once the job is passing, turn on the alert back on.