### PR TITLE
Wait a little bit longer on Ropsten e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,7 +420,7 @@ jobs:
           file: e2e-test-w3t-production-stats
       - attach_workspace:
           at: /home/circleci/project
-      - run: (cd packages/e2e-tests && yarn jest web3torrent --runInBand --bail)
+      - run: (cd packages/e2e-tests && yarn jest seed-download withdraw --runInBand --bail)
       - store_artifacts:
           path: /tmp/seed-download.pino.log
       - store_artifacts:

--- a/packages/e2e-tests/puppeteer/__tests__/web3torrent/seed-download.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/web3torrent/seed-download.test.ts
@@ -23,7 +23,8 @@ import {
   setupFakeWeb3,
   waitForWalletToBeHidden,
   waitForClosedState,
-  takeScreenshot
+  takeScreenshot,
+  waitForTransactionIfNecessary
 } from '../../helpers';
 
 import {uploadFile, startDownload, cancelDownload} from '../../scripts/web3torrent';
@@ -91,6 +92,8 @@ describe('Web3-Torrent Integration Tests', () => {
 
     if (USES_VIRTUAL_FUNDING) await waitAndApproveDepositWithHub(web3tTabB, metamaskB);
     else waitAndApproveDeposit(web3tTabB, metamaskB);
+
+    await waitForTransactionIfNecessary(web3tTabB);
 
     // Let the download continue for some time
     console.log('Downloading');

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -15,7 +15,7 @@ export const waitForWalletToBeDisplayed = async (page: Page): Promise<void> => {
 
 export const waitForWalletToBeHidden = async (page: Page): Promise<void> => {
   const walletIframe = page.frames()[1];
-  await walletIframe.waitForSelector(':root', {hidden: true, timeout: 30_000});
+  await walletIframe.waitForSelector(':root', {hidden: true, timeout: TX_WAIT_TIMEOUT});
 };
 
 export async function setupLogging(

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -244,6 +244,14 @@ export async function waitAndApproveMetaMask(
   await page.bringToFront();
 }
 
+export async function waitForTransactionIfNecessary(page: Page): Promise<void> {
+  const walletIFrame = page.frames()[1];
+  const sel = await walletIFrame.waitForSelector('#wait-for-transaction', {timeout: 1000});
+  if (sel) {
+    await new Promise(r => setTimeout(r, TX_WAIT_TIMEOUT));
+  }
+}
+
 export async function waitAndApproveDepositWithHub(
   page: Page,
   metamask: dappeteer.Dappeteer

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -246,8 +246,14 @@ export async function waitAndApproveMetaMask(
 
 export async function waitForTransactionIfNecessary(page: Page): Promise<void> {
   const walletIFrame = page.frames()[1];
-  const sel = await walletIFrame.waitForSelector('#wait-for-transaction', {timeout: 1000});
-  if (sel) await waitForWalletToBeHidden(page);
+  try {
+    await walletIFrame.waitForSelector('#wait-for-transaction', {timeout: 1000});
+  } catch (e) {
+    if (e instanceof puppeteer.errors.TimeoutError) return;
+    else throw e;
+  }
+  console.log('Waiting for transaction to be mined');
+  await waitForWalletToBeHidden(page);
 }
 
 export async function waitAndApproveDepositWithHub(

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -247,9 +247,7 @@ export async function waitAndApproveMetaMask(
 export async function waitForTransactionIfNecessary(page: Page): Promise<void> {
   const walletIFrame = page.frames()[1];
   const sel = await walletIFrame.waitForSelector('#wait-for-transaction', {timeout: 1000});
-  if (sel) {
-    await new Promise(r => setTimeout(r, TX_WAIT_TIMEOUT));
-  }
+  if (sel) await waitForWalletToBeHidden(page);
 }
 
 export async function waitAndApproveDepositWithHub(

--- a/packages/xstate-wallet/src/ui/approve-budget-and-fund-workflow.tsx
+++ b/packages/xstate-wallet/src/ui/approve-budget-and-fund-workflow.tsx
@@ -90,7 +90,7 @@ export const ApproveBudgetAndFund = (props: Props) => {
 
       <Text pb={2}>Waiting for your transaction to be mined.</Text>
 
-      <Text>
+      <Text id="wait-for-transaction">
         Click{' '}
         <Link target="_blank" href={`https://ropsten.etherscan.io/tx/${transactionId}`}>
           here

--- a/packages/xstate-wallet/src/ui/close-ledger-and-withdraw.tsx
+++ b/packages/xstate-wallet/src/ui/close-ledger-and-withdraw.tsx
@@ -75,7 +75,7 @@ export const CloseLedgerAndWithdraw = (props: Props) => {
 
       <Text pb={2}>Waiting for your transaction to be mined.</Text>
 
-      <Text>
+      <Text id="wait-for-transaction">
         Click{' '}
         <Link target="_blank" href={`https://ropsten.etherscan.io/tx/${transactionId}`}>
           here


### PR DESCRIPTION
[Screenshot](https://27335-209829093-gh.circle-artifacts.com/0/home/circleci/project/packages/e2e-tests/screenshots/seed-download.1.png) made it clear the downloader is waiting on their transaction to be mined:

![image](https://user-images.githubusercontent.com/1933029/81982837-6365be00-9600-11ea-91d8-76a8d2f45047.png)


So this adds a wait if that UI is still up after the approve budget and fund UI helper returns (which returns after the deposit transaction is _submitted_ not mined).