### PR TITLE
Decrease size of e2e w3t file

### DIFF
--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -363,7 +363,7 @@ export async function waitForClosingChannel(page: Page): Promise<void> {
 export async function prepareStubUploadFile(path: string): Promise<void> {
   const uniqueContent = Date.now();
   console.log(`Make Stub file with seed ${Date.now()}`);
-  const content = `web3torrent-${uniqueContent}\n`.repeat(50000);
+  const content = `web3torrent-${uniqueContent}\n`.repeat(100_000);
   await writeFile(path, Buffer.from(content));
 }
 

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -363,7 +363,7 @@ export async function waitForClosingChannel(page: Page): Promise<void> {
 export async function prepareStubUploadFile(path: string): Promise<void> {
   const uniqueContent = Date.now();
   console.log(`Make Stub file with seed ${Date.now()}`);
-  const content = `web3torrent-${uniqueContent}\n`.repeat(500000);
+  const content = `web3torrent-${uniqueContent}\n`.repeat(50000);
   await writeFile(path, Buffer.from(content));
 }
 

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -360,10 +360,10 @@ export async function waitForClosingChannel(page: Page): Promise<void> {
   await closingIframeB.waitForSelector(closingText);
 }
 
-export async function prepareStubUploadFile(path: string): Promise<void> {
+export async function prepareStubUploadFile(path: string, repeats = 100_000): Promise<void> {
   const uniqueContent = Date.now();
   console.log(`Make Stub file with seed ${Date.now()}`);
-  const content = `web3torrent-${uniqueContent}\n`.repeat(100_000);
+  const content = `web3torrent-${uniqueContent}\n`.repeat(repeats);
   await writeFile(path, Buffer.from(content));
 }
 

--- a/packages/persistent-seeder/package.json
+++ b/packages/persistent-seeder/package.json
@@ -13,12 +13,12 @@
     "@types/puppeteer": "2.0.1",
     "@typescript-eslint/eslint-plugin": "2.18.0",
     "@typescript-eslint/parser": "2.18.0",
+    "dappeteer": "^1.0.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.10.0",
     "eslint-plugin-import": "2.20.0",
     "eslint-plugin-jest": "23.6.0",
     "eslint-plugin-prettier": "3.1.2",
-    "dappeteer": "^1.0.0",
     "puppeteer": "2.1.1",
     "ts-node": "8.9.1",
     "typescript": "3.7.5"


### PR DESCRIPTION
[This](https://app.circleci.com/pipelines/github/statechannels/monorepo/6548/workflows/c71f67cf-a559-4388-ae32-81a05cb83bc5/jobs/27873/steps) job failed because 30 seconds wasn't enough for the download. I don't think we lose much going from 12 MB to ~1.3 MB.