### PR TITLE
Use JEST_WORKER_ID to detect IS_BROWSER_CONTEXT

### DIFF
--- a/packages/channel-provider/src/logger.ts
+++ b/packages/channel-provider/src/logger.ts
@@ -6,7 +6,7 @@ const LOG_TO_CONSOLE = process.env.LOG_DESTINATION === 'console';
 // eslint-disable-next-line no-undef
 const LOG_TO_FILE = process.env.LOG_DESTINATION && !LOG_TO_CONSOLE;
 // eslint-disable-next-line no-undef
-const IS_BROWSER_CONTEXT = process.env.NODE_ENV !== 'test';
+const IS_BROWSER_CONTEXT = process.env.JEST_WORKER_ID === undefined;
 
 const name = 'channel-provider';
 

--- a/packages/web3torrent/src/logger.ts
+++ b/packages/web3torrent/src/logger.ts
@@ -2,7 +2,7 @@ import pino from 'pino';
 import {LOG_DESTINATION, ADD_LOGS, LOG_LEVEL, VERSION} from './constants';
 import _ from 'lodash';
 
-const IS_BROWSER_CONTEXT = process.env.JEST_WORKER_ID !== undefined;
+const IS_BROWSER_CONTEXT = process.env.JEST_WORKER_ID === undefined;
 const LOG_TO_CONSOLE = LOG_DESTINATION === 'console';
 const LOG_TO_FILE = ADD_LOGS && !LOG_TO_CONSOLE;
 

--- a/packages/web3torrent/src/logger.ts
+++ b/packages/web3torrent/src/logger.ts
@@ -2,8 +2,7 @@ import pino from 'pino';
 import {LOG_DESTINATION, ADD_LOGS, LOG_LEVEL, VERSION} from './constants';
 import _ from 'lodash';
 
-// TODO: Is there a better way to determine if we're in a browser context?
-const IS_BROWSER_CONTEXT = process.env.NODE_ENV !== 'test';
+const IS_BROWSER_CONTEXT = process.env.JEST_WORKER_ID !== undefined;
 const LOG_TO_CONSOLE = LOG_DESTINATION === 'console';
 const LOG_TO_FILE = ADD_LOGS && !LOG_TO_CONSOLE;
 

--- a/packages/xstate-wallet/src/config.ts
+++ b/packages/xstate-wallet/src/config.ts
@@ -44,6 +44,8 @@ export const USE_INDEXED_DB = getBool(process.env.USE_INDEXED_DB);
 
 export const CHALLENGE_DURATION = bigNumberify(process.env.CHALLENGE_DURATION || '0x12c');
 
+export const JEST_WORKER_ID: string | undefined = process.env.JEST_WORKER_ID;
+
 // TODO: Embed this inside logger.ts
 export const ADD_LOGS = !!LOG_DESTINATION;
 

--- a/packages/xstate-wallet/src/logger.ts
+++ b/packages/xstate-wallet/src/logger.ts
@@ -1,10 +1,9 @@
 import pino from 'pino';
 
-import {LOG_DESTINATION, ADD_LOGS, NODE_ENV} from './config';
+import {LOG_DESTINATION, ADD_LOGS, JEST_WORKER_ID} from './config';
 import _ from 'lodash';
 
-// TODO: Is there a better way to determine if we're in a browser context?
-const IS_BROWSER_CONTEXT = NODE_ENV !== 'test';
+const IS_BROWSER_CONTEXT = JEST_WORKER_ID !== undefined;
 
 const LOG_TO_CONSOLE = LOG_DESTINATION === 'console';
 const LOG_TO_FILE = ADD_LOGS && !LOG_TO_CONSOLE;

--- a/packages/xstate-wallet/src/logger.ts
+++ b/packages/xstate-wallet/src/logger.ts
@@ -3,7 +3,7 @@ import pino from 'pino';
 import {LOG_DESTINATION, ADD_LOGS, JEST_WORKER_ID} from './config';
 import _ from 'lodash';
 
-const IS_BROWSER_CONTEXT = JEST_WORKER_ID !== undefined;
+const IS_BROWSER_CONTEXT = JEST_WORKER_ID === undefined;
 
 const LOG_TO_CONSOLE = LOG_DESTINATION === 'console';
 const LOG_TO_FILE = ADD_LOGS && !LOG_TO_CONSOLE;


### PR DESCRIPTION
Logs are missing in [important jobs](https://app.circleci.com/pipelines/github/statechannels/monorepo/6600/workflows/ba81f5a6-137a-4813-b112-5b71fdc7cc68/jobs/28304/artifacts) because of an awkward environment variable.