### PR TITLE
Remove default setting of NODE_ENV=test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ orbs:
 
 defaults: &defaults
   environment:
-    NODE_ENV: test
     USE_NATIVE_SOLC: true
   working_directory: /home/circleci/project
   resource_class: medium


### PR DESCRIPTION
I think this has been _overriding_ the settings we've had on CI and there seems to be no rationale for why it should be a default setting.