### PR TITLE
[web3torrent] blockPeer vs stop

### DIFF
--- a/packages/web3torrent/src/library/client-seeding.test.ts
+++ b/packages/web3torrent/src/library/client-seeding.test.ts
@@ -86,7 +86,9 @@ describe('Seeding and Leeching', () => {
   it('should reach a ready-for-leeching, choked state', done => {
     seeder.seed(defaultFile as File, defaultSeedingOptions(), seededTorrent => {
       seeder.once(ClientEvents.PEER_STATUS_CHANGED, ({torrentPeers}) => {
-        expect(torrentPeers[`${leecherA.pseAccount}`].allowed).toEqual(false);
+        expect(
+          torrentPeers[leecherA.pseAccount].wire.paidStreamingExtension.isForceChoking
+        ).toEqual(true);
         done();
       });
       leecherA.add(seededTorrent.magnetURI, {store: MemoryChunkStore});
@@ -97,7 +99,9 @@ describe('Seeding and Leeching', () => {
     seeder.seed(defaultFile as File, defaultSeedingOptions(), seededTorrent => {
       seeder.once(ClientEvents.PEER_STATUS_CHANGED, ({peerAccount}) => {
         seeder.once(ClientEvents.PEER_STATUS_CHANGED, ({torrentPeers}) => {
-          expect(torrentPeers[`${leecherA.pseAccount}`].allowed).toEqual(true);
+          expect(
+            torrentPeers[leecherA.pseAccount].wire.paidStreamingExtension.isForceChoking
+          ).toEqual(true);
         });
         seeder.togglePeer(seededTorrent.infoHash, peerAccount);
 

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -137,7 +137,6 @@ export type PeerWire = Pick<PaidStreamingWire, 'uploaded'>;
 export type PeerByTorrent = {
   id: string;
   wire: PaidStreamingWire | PeerWire;
-  allowed: boolean;
   buffer: string;
   beneficiaryBalance: string;
   channelId: string;

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -171,6 +171,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     log.info({from: Object.keys(this.peersList), peerAccount}, '<< unblockedPeer: finish');
   }
 
+  // Note, this is only used by unit tests.
   togglePeer(torrentInfoHash: string, peerAccount: string) {
     const {wire} = this.peersList[torrentInfoHash][peerAccount];
     if (!(wire as PaidStreamingWire).paidStreamingExtension.isForceChoking) {

--- a/packages/web3torrent/src/utils/test-utils.ts
+++ b/packages/web3torrent/src/utils/test-utils.ts
@@ -42,7 +42,6 @@ export function createMockTorrentPeers(): TorrentPeers {
   return {
     '7595267661936611': {
       id: '7595267661936611',
-      allowed: true,
       wire: {
         uploaded: 4225
       },
@@ -53,7 +52,6 @@ export function createMockTorrentPeers(): TorrentPeers {
     },
     '5589113806923374': {
       id: '5589113806923374',
-      allowed: true,
       buffer: '50',
       beneficiaryBalance: '50',
       wire: {


### PR DESCRIPTION
Currently, there are 2 ways to block a wire:
- web3torrent client `blockPeer` method.
- `paidStreamingExtension` `stop` method.

There are also 2 properties that manage the state of whether a peer is blocked.
- `PeerByTorrent` `allowed` field. 
- `paidStreamingExtension` `isForceChoking`.

The goal of this PR is to ensure that state is only stored once to avoid tricky race conditions. With this PR:
- All state on whether a peer is being blocked is managed by the wire's `paidStreamingExtension` via the `isForceChoking` property.
- `blockPeer` does not do any state management outside of `stop`.