### PR TITLE
Refactors the cancel functions out of w3t-client

### DIFF
--- a/packages/web3torrent/src/clients/web3torrent-client.test.ts
+++ b/packages/web3torrent/src/clients/web3torrent-client.test.ts
@@ -3,7 +3,7 @@ import {PaidStreamingTorrent, WebTorrentAddInput, WebTorrentSeedInput} from '../
 import {TorrentCallback} from '../library/web3torrent-lib';
 import {Status} from '../types';
 import {createMockExtendedTorrent, createMockTorrentPeers, pseAccount} from '../utils/test-utils';
-import {download, getTorrentPeers, cancel, upload, web3TorrentClient} from './web3torrent-client';
+import {download, getTorrentPeers, upload, web3TorrentClient} from './web3torrent-client';
 import {getStatus} from '../utils/torrent-status-checker';
 
 describe('Web3TorrentClient', () => {
@@ -89,35 +89,6 @@ describe('Web3TorrentClient', () => {
 
     afterEach(() => {
       seedSpy.mockRestore();
-    });
-  });
-
-  describe('cancel()', () => {
-    let removeSpy: jest.SpyInstance<
-      Promise<void>,
-      [string | WebTorrent.Torrent | Buffer, (((err: string | Error) => void) | undefined)?]
-    >;
-
-    beforeEach(() => {
-      removeSpy = jest.spyOn(web3TorrentClient, 'cancel').mockImplementation(
-        (torrentInfoHash: string, callback?: (err: string | Error) => void): Promise<void> => {
-          if (callback) {
-            return new Promise(() => callback(''));
-          }
-          return new Promise(() => ({}));
-        }
-      );
-    });
-
-    it('should return the infohash of the paused client', async () => {
-      const mockInfoHash = '124203';
-      const result = await cancel(mockInfoHash);
-
-      expect(result).toEqual(mockInfoHash);
-    });
-
-    afterEach(() => {
-      removeSpy.mockRestore();
     });
   });
 

--- a/packages/web3torrent/src/clients/web3torrent-client.ts
+++ b/packages/web3torrent/src/clients/web3torrent-client.ts
@@ -53,19 +53,6 @@ export const upload: (input: WebTorrentSeedInput) => Promise<ExtendedTorrent> = 
   );
 };
 
-export const cancel = (torrentId: string = '') => {
-  return new Promise((resolve, reject) =>
-    web3TorrentClient.cancel(torrentId, err => {
-      if (err) {
-        reject(err);
-      } else {
-        // TODO: clean up channel info
-        resolve(torrentId);
-      }
-    })
-  );
-};
-
 const torrentNamer = (input: WebTorrentSeedInput) => {
   if ((input as FileList).length && (input as FileList).length > 1) {
     return {name: `various.zip`};

--- a/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.test.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.test.tsx
@@ -2,7 +2,7 @@ import Enzyme, {mount, ReactWrapper} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
 import {TorrentFile} from 'webtorrent';
-import * as Web3TorrentClient from '../../../clients/web3torrent-client';
+import * as Web3TorrentContext from '../../../clients/web3torrent-client';
 import {TorrentUI} from '../../../types';
 import {createMockTorrentUI} from '../../../utils/test-utils';
 import {DownloadInfo, DownloadInfoProps} from './DownloadInfo';
@@ -46,9 +46,9 @@ describe('<DownloadInfo />', () => {
     expect(cancelButton.exists()).toEqual(true);
   });
 
-  it('can call Web3TorrentClient.cancel() when clicking the Cancel button', () => {
+  it('can call web3TorrentClient.cancel() when clicking the Cancel button', () => {
     const removeSpy = jest
-      .spyOn(Web3TorrentClient, 'cancel')
+      .spyOn(Web3TorrentContext.web3TorrentClient, 'cancel')
       .mockImplementation(async (_?: string) => {
         /* nothing to see here */
       });

--- a/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.tsx
@@ -1,29 +1,32 @@
-import React from 'react';
-import {cancel} from '../../../clients/web3torrent-client';
+import React, {useContext} from 'react';
 import './DownloadInfo.scss';
 import {ProgressBar} from './progress-bar/ProgressBar';
 import {TorrentUI} from '../../../types';
+import {Web3TorrentClientContext} from '../../../clients/web3torrent-client';
 
 export type DownloadInfoProps = {torrent: TorrentUI};
 
-export const DownloadInfo: React.FC<DownloadInfoProps> = ({torrent}: DownloadInfoProps) => (
-  <section className="downloadingInfo">
-    {!(torrent.done || torrent.paused) && (
-      <>
-        <ProgressBar
-          downloaded={torrent.downloaded}
-          length={torrent.length}
-          status={torrent.status}
-        />
-        <button
-          id="cancel-download-button"
-          type="button"
-          className="button cancel"
-          onClick={() => cancel(torrent.infoHash)}
-        >
-          Cancel Download
-        </button>
-      </>
-    )}
-  </section>
-);
+export const DownloadInfo: React.FC<DownloadInfoProps> = ({torrent}: DownloadInfoProps) => {
+  const web3torrent = useContext(Web3TorrentClientContext);
+  return (
+    <section className="downloadingInfo">
+      {!(torrent.done || torrent.paused) && (
+        <>
+          <ProgressBar
+            downloaded={torrent.downloaded}
+            length={torrent.length}
+            status={torrent.status}
+          />
+          <button
+            id="cancel-download-button"
+            type="button"
+            className="button cancel"
+            onClick={() => web3torrent.cancel(torrent.infoHash)}
+          >
+            Cancel Download
+          </button>
+        </>
+      )}
+    </section>
+  );
+};

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -122,18 +122,18 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     return torrent;
   }
 
-  // TODO: refactor "pause" and "cancel" functions. It's an ugly mess right
-  pause(infoHash: string, callback?: (err?: Error | string) => void) {
+  pause(infoHash: string) {
     log.info('> Peer pauses download: Pause torrent, eventual close PaymentChannels');
     const torrent = this.torrents.find(t => t.infoHash === infoHash);
     if (torrent) {
       torrent.pause(); // the paymentChannelClosing is done at the moment of payment
+      this.emitTorrentUpdated(infoHash);
     } else {
-      return callback(new Error('No torrent found'));
+      throw new Error('No torrent found');
     }
   }
 
-  async cancel(infoHash: string, callback?: (err?: Error | string) => void) {
+  async cancel(infoHash: string) {
     log.info('> Cancelling download. Closing payment channels, and then removing torrent');
     const torrent = this.torrents.find(t => t.infoHash === infoHash);
     if (torrent) {
@@ -146,7 +146,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
         filesize: torrent.length
       });
     } else {
-      return callback(new Error('No torrent found'));
+      throw new Error('No torrent found');
     }
   }
 


### PR DESCRIPTION
Pretty much self-explanatory. The `cancel()` function in `web3torrent-client.ts` is useless, and it just adds noise to the code.