### PR TITLE
[web3torrent] index peerList by channel id instead of peer id

### DIFF
--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -27,8 +27,8 @@ function channelIdToTableRow(
   const isBeneficiary = participantType === 'beneficiary';
   const wire = torrent.wires.find(
     wire =>
-      wire.paidStreamingExtension.peerChannelId === channelId ||
-      wire.paidStreamingExtension.pseChannelId === channelId
+      wire.paidStreamingExtension.leechingChannelId === channelId ||
+      wire.paidStreamingExtension.seedingChannelId === channelId
   );
   if (channel.status === 'closing') {
     channelButton = <button disabled>Closing ...</button>;

--- a/packages/web3torrent/src/library/paid-streaming-extension.ts
+++ b/packages/web3torrent/src/library/paid-streaming-extension.ts
@@ -15,10 +15,10 @@ export type PaidStreamingExtensionSerialized = Pick<
   PaidStreamingExtension,
   | 'pseAccount'
   | 'pseAddress'
-  | 'pseChannelId'
+  | 'seedingChannelId'
   | 'peerAccount'
   | 'peerOutcomeAddress'
-  | 'peerChannelId'
+  | 'leechingChannelId'
   | 'isForceChoking'
   | 'isBeingChoked'
   | 'blockedRequests'
@@ -37,8 +37,10 @@ export abstract class PaidStreamingExtension implements Extension {
   peerAccount?: string;
   peerOutcomeAddress?: string;
 
-  pseChannelId: string;
-  peerChannelId: string;
+  // channel that another peer uses to pay me.
+  seedingChannelId: string;
+  // channel that I use to pay another peer.
+  leechingChannelId: string;
 
   isForceChoking = false;
   isBeingChoked = false;
@@ -107,7 +109,7 @@ export abstract class PaidStreamingExtension implements Extension {
   stop() {
     if (!this.isForceChoking) {
       this.isForceChoking = true;
-      this.executeExtensionCommand(PaidStreamingExtensionNotices.STOP, this.pseChannelId);
+      this.executeExtensionCommand(PaidStreamingExtensionNotices.STOP, this.seedingChannelId);
     }
   }
 
@@ -145,10 +147,10 @@ export abstract class PaidStreamingExtension implements Extension {
     return {
       pseAccount: this.pseAccount,
       pseAddress: this.pseAddress,
-      pseChannelId: this.pseChannelId,
+      seedingChannelId: this.seedingChannelId,
       peerAccount: this.peerAccount,
       peerOutcomeAddress: this.peerOutcomeAddress,
-      peerChannelId: this.peerChannelId,
+      leechingChannelId: this.leechingChannelId,
       isForceChoking: this.isForceChoking,
       isBeingChoked: this.isBeingChoked,
       blockedRequests: this.blockedRequests
@@ -165,7 +167,7 @@ export abstract class PaidStreamingExtension implements Extension {
         break;
       case PaidStreamingExtensionNotices.STOP:
         log.info(`STOP received from ${this.peerAccount}`);
-        this.peerChannelId = data;
+        this.leechingChannelId = data;
         if (this.isBeingChoked) {
           this.ack();
           return;

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -139,12 +139,11 @@ export type PeerByTorrent = {
   wire: PaidStreamingWire | PeerWire;
   buffer: string;
   beneficiaryBalance: string;
-  channelId: string;
   uploaded: number;
 };
 
 export type TorrentPeers = {
-  [key: string /* PeerAccount */]: PeerByTorrent;
+  [key: string /* ChannelId */]: PeerByTorrent;
 };
 
 export type PeersByTorrent = {

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -163,11 +163,13 @@ declare module 'webtorrent' {
       callback: ({
         torrentPeers,
         torrentInfoHash,
-        peerAccount
+        peerAccount,
+        seedingChannelId
       }: {
         torrentPeers: TorrentPeers;
         torrentInfoHash: string;
         peerAccount: string;
+        seedingChannelId: string;
       }) => void
     ): this;
 

--- a/packages/web3torrent/src/utils/test-utils.ts
+++ b/packages/web3torrent/src/utils/test-utils.ts
@@ -46,7 +46,6 @@ export function createMockTorrentPeers(): TorrentPeers {
         uploaded: 4225
       },
       beneficiaryBalance: '50',
-      channelId: '0x0000000000000000000000000000001231927371',
       buffer: '50',
       uploaded: 4225
     },
@@ -57,7 +56,6 @@ export function createMockTorrentPeers(): TorrentPeers {
       wire: {
         uploaded: 52923
       },
-      channelId: '0x0000000000000000000000000000001231927371',
       uploaded: 52923
     }
   };


### PR DESCRIPTION
Lays the groundwork for https://github.com/statechannels/monorepo/issues/1735. Specifically, this should address https://github.com/statechannels/monorepo/issues/1735#issuecomment-630911254.

Also renaming `pseChannelId` to `seedingChannelId` and `peerChannelId` to `leechingChannelId`.