### PR TITLE
[web3torrent] always ask for payment on stop signal

### DIFF
--- a/packages/web3torrent/src/library/paid-streaming-extension.ts
+++ b/packages/web3torrent/src/library/paid-streaming-extension.ts
@@ -107,10 +107,8 @@ export abstract class PaidStreamingExtension implements Extension {
   }
 
   stop() {
-    if (!this.isForceChoking) {
-      this.isForceChoking = true;
-      this.executeExtensionCommand(PaidStreamingExtensionNotices.STOP, this.seedingChannelId);
-    }
+    this.isForceChoking = true;
+    this.executeExtensionCommand(PaidStreamingExtensionNotices.STOP, this.seedingChannelId);
   }
 
   start() {


### PR DESCRIPTION
Consider the start signal logic: https://github.com/statechannels/monorepo/blob/176ce6ce8cd0fc23ede590cf979aab88d51e5a61/packages/web3torrent/src/library/paid-streaming-extension.ts#L114-L122

1. Start signal is sent. This is an asynchronous network operation.
1. Blocked requests are processed.

What happens if the seeder has been paid for 4 requests, but 5 requests are blocked. Then a stop signal is sent while trying to process the 5th requests. So the flow is:
1. Start signal is sent. This is an asynchronous network operation.
1. 4 blocked requests are processed.
1. A stop signal is sent. This is an asynchronous network operation.
1. 5th request is added to the blocked queue.

Is the start signal guaranteed to arrive before the stop signal? That depends on webtorrent implementation. And to be frank, I am not sure 🤷 

What happens if the stop signal arrives before the start signal? Well, the leecher will ignore the stop signal and not make a payment. The leecher will then get the start signal and start making further requests. And the seeder won't ask for more payments 💵 . And we'll have a deadlock 🔒 

With this PR, every time stop is called, the leecher will be asked for a payment.
