### PR TITLE
Remove page.evaluate and page.exposeFunction from cancel test

### DIFF
--- a/packages/e2e-tests/puppeteer/__tests__/optional/seed-download-cancel.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/optional/seed-download-cancel.test.ts
@@ -17,14 +17,12 @@ import {
   setUpBrowser,
   setupLogging,
   waitAndOpenChannel,
-  waitForNthState,
   waitForFinishedOrCanceledDownload,
   waitAndApproveDeposit,
   waitAndApproveDepositWithHub,
   setupFakeWeb3,
   takeScreenshot,
-  waitForTransactionIfNecessary,
-  waitForClosedState
+  waitForTransactionIfNecessary
 } from '../../helpers';
 
 import {uploadFile, startDownload, cancelDownload} from '../../scripts/web3torrent';
@@ -75,7 +73,7 @@ describe('Optional Integration Tests', () => {
     await forEachBrowser(async b => CLOSE_BROWSERS && b && b.close());
   });
 
-  it('Optional - Torrent a file - Cancelling at State N°10', async () => {
+  it('Optional - Torrent a file - Cancelling', async () => {
     await web3tTabA.goto(WEB3TORRENT_URL + '/upload', {waitUntil: 'load'});
     await web3tTabA.bringToFront();
 
@@ -96,17 +94,12 @@ describe('Optional Integration Tests', () => {
       await waitAndApproveDeposit(web3tTabB, metamaskB);
     }
 
-    const listenFor10thState = waitForNthState(web3tTabB, 10);
-
     await waitForTransactionIfNecessary(web3tTabB);
 
     // Let the download continue for some time
     console.log('Downloading');
 
-    await listenFor10thState;
-    console.log('Got until 10th state');
-
-    const listenForClosedState = forEachTab(waitForClosedState);
+    await web3tTabB.waitForSelector('.positive.downloading');
 
     console.log('B cancels download');
     await cancelDownload(web3tTabB);
@@ -117,8 +110,8 @@ describe('Optional Integration Tests', () => {
     console.log('Wait for the "Restart Download" button to appear');
     await waitForFinishedOrCanceledDownload(web3tTabB);
 
-    console.log('Wait for the ChannelUpdated "closed" state');
-    await listenForClosedState;
+    console.log('Wait for the "closed" state');
+    await forEachTab(tab => tab.waitForSelector('.channel.closed'));
 
     console.log('Checking exchanged amount between downloader and uploader...');
     const earnedColumn = await web3tTabA.waitForSelector('td.earned');

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -59,7 +59,7 @@ function channelIdToTableRow(
 
   return (
     <tr className="peerInfo" key={channelId}>
-      <td className="channel">
+      <td className={`channel ${channel.status}`}>
         <button disabled>{channel.status}</button>
         {/* temporal thing to show the true state instead of a parsed one */}
       </td>

--- a/packages/web3torrent/src/components/torrent-info/download-info/progress-bar/ProgressBar.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-info/progress-bar/ProgressBar.tsx
@@ -6,12 +6,15 @@ import {TorrentUI} from '../../../../types';
 export type ProgressBarProps = Pick<TorrentUI, 'downloaded' | 'length' | 'status'>;
 
 export const ProgressBar: React.FC<ProgressBarProps> = ({downloaded, length, status}) => {
+  let classStatus: string;
+  if (downloaded === length) {
+    classStatus = 'complete';
+  } else if (downloaded > 0 && downloaded < length) {
+    classStatus = 'downloading';
+  }
   return (
     <div className="progress-bar">
-      <div
-        className={`positive ${downloaded === length ? ' complete' : ''}`}
-        style={{width: `${(downloaded / length) * 100}%`}}
-      >
+      <div className={`positive ${classStatus}`} style={{width: `${(downloaded / length) * 100}%`}}>
         <span className="bar-progress">
           {prettier(downloaded)}/{prettier(length)}
         </span>


### PR DESCRIPTION
So, I still saw the same errors that #1922 was supposed to fix even after applying the changes.

As an experiment, I removed all usages of the `doneWhen` helper and now rely solely on the UI.

The test still throws this `Object` error alongside `Protocol error (Runtime.callFunctionOn): Target closed.`

However, in an interesting twist, if I run it with `USE_DAPPETEER=true`, it never fails.