### PR TITLE
Use pipe: true on puppeteer

### DIFF
--- a/packages/e2e-tests/puppeteer/__tests__/optional/seed-download-cancel.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/optional/seed-download-cancel.test.ts
@@ -53,7 +53,7 @@ describe('Optional Integration Tests', () => {
     [
       {browser: browserA, metamask: metamaskA},
       {browser: browserB, metamask: metamaskB}
-    ] = await Promise.all([4, 5].map(async idx => await setUpBrowser(HEADLESS, idx, 0)));
+    ] = await Promise.all([4, 5].map(async idx => await setUpBrowser(HEADLESS, idx, 0, true)));
 
     browsers = [browserA, browserB];
 

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -170,6 +170,7 @@ export async function setUpBrowser(
     browser = await puppeteer.launch({
       headless,
       slowMo,
+      pipe: usePipe,
       devtools: !headless,
       // Keep code here for convenience... if you want to use redux-dev-tools
       // then download and unzip the release from Github and specify the location.

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -161,7 +161,8 @@ export async function setupFakeWeb3(page: Page, ganacheAccountIndex: number): Pr
 export async function setUpBrowser(
   headless: boolean,
   etherlimeAccountIndex?: number,
-  slowMo?: number
+  slowMo?: number,
+  usePipe = false
 ): Promise<{browser: Browser; metamask: dappeteer.Dappeteer}> {
   let browser: Browser;
   let metamask: dappeteer.Dappeteer;
@@ -201,6 +202,8 @@ export async function setUpBrowser(
     browser = await dappeteer.launch(puppeteer, {
       headless: false,
       slowMo,
+      pipe: usePipe,
+
       //, Needed to allow both windows to execute JS at the same time
       ignoreDefaultArgs: [
         '--disable-background-timer-throttling',


### PR DESCRIPTION
Based on [this comment](https://github.com/puppeteer/puppeteer/issues/2735#issuecomment-470309033) that I found after [my hunch](https://github.com/statechannels/monorepo/pull/1923#issuecomment-631478009) that Web3Torrent's usage of WebSockets was interfering with the puppeteer functionality. Passed locally several times in a row, but then recently stopped working.