### PR TITLE
[web3torrent] Channels display number of payments

### DIFF
--- a/.env.circle-integration-w3t-with-hub
+++ b/.env.circle-integration-w3t-with-hub
@@ -10,12 +10,12 @@ USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 
 # For e2e-test
 BROWSER_LOG_DESTINATION = 'browser.log'
-HEADLESS = 'false'
+HEADLESS = 'true'
 USE_DAPPETEER = 'false'
 TARGET_NETWORK = 'localhost'
 WEB3TORRENT_URL = 'http://localhost:3000'
 SCREENSHOT_DIR = 'screenshots'
-CLOSE_BROWSERS = 'false'
+CLOSE_BROWSERS = 'true'
 
 ## simple-hub
 SIMPLE_HUB_DEPLOYER_ACCOUNT_INDEX = '1'

--- a/.env.circle-integration-w3t-with-hub
+++ b/.env.circle-integration-w3t-with-hub
@@ -10,12 +10,12 @@ USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 
 # For e2e-test
 BROWSER_LOG_DESTINATION = 'browser.log'
-HEADLESS = 'true'
+HEADLESS = 'false'
 USE_DAPPETEER = 'false'
 TARGET_NETWORK = 'localhost'
 WEB3TORRENT_URL = 'http://localhost:3000'
 SCREENSHOT_DIR = 'screenshots'
-CLOSE_BROWSERS = 'true'
+CLOSE_BROWSERS = 'false'
 
 ## simple-hub
 SIMPLE_HUB_DEPLOYER_ACCOUNT_INDEX = '1'

--- a/packages/web3torrent/package.json
+++ b/packages/web3torrent/package.json
@@ -15,6 +15,7 @@
   ],
   "dependencies": {
     "@babel/core": "7.8.3",
+    "@material-ui/core": "^4.9.14",
     "@rimble/connection-banner": "1.2.3",
     "@sentry/browser": "5.15.5",
     "@statechannels/channel-client": "0.0.1",
@@ -63,6 +64,7 @@
     "react-router-dom": "5.1.0",
     "resolve": "1.15.0",
     "resolve-url-loader": "3.1.0",
+    "rimble-ui": "^0.14.0",
     "rxjs": "6.5.4",
     "sass-loader": "8.0.2",
     "semver": "6.3.0",

--- a/packages/web3torrent/package.json
+++ b/packages/web3torrent/package.json
@@ -57,6 +57,7 @@
     "prettier-bytes": "1.0.4",
     "react": "16.12.0",
     "react-app-polyfill": "^1.0.3",
+    "react-circular-progressbar": "^2.0.3",
     "react-dev-utils": "^9.0.4",
     "react-dom": "16.12.0",
     "react-driftjs": "^1.1.10",

--- a/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.scss
+++ b/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.scss
@@ -32,6 +32,7 @@ table.domain-budget-table {
       flex-direction: row;
       width: 100%;
       border-bottom: 1px solid $c-mediumgrey;
+      max-height: 40px;
 
       &:last-child {
         border-bottom: 0px solid transparent;
@@ -53,4 +54,8 @@ table.domain-budget-table {
       }
     }
   }
+}
+
+.CircularProgressbar {
+  height: 40px;
 }

--- a/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.scss
+++ b/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.scss
@@ -41,15 +41,15 @@ table.domain-budget-table {
         min-width: 50px;
         padding: 5px 5px;
         vertical-align: middle;
-        text-align: left;
+        text-align: center;
       }
 
-      td.budget-number {
-        width: 40%;
-      }
-
-      td.budget-button {
-        width: 20%;
+      td.budget-number,
+      td.budget-identity,
+      td.budget-button,
+      td.budget-spent,
+      td.budget-recieved {
+        width: 25%;
       }
     }
   }

--- a/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.scss
+++ b/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.scss
@@ -48,7 +48,7 @@ table.domain-budget-table {
       td.budget-identity,
       td.budget-button,
       td.budget-spent,
-      td.budget-recieved {
+      td.budget-received {
         width: 25%;
       }
     }

--- a/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
+++ b/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
@@ -82,8 +82,8 @@ export const DomainBudgetTable: React.FC<DomainBudgetTableProps> = props => {
             </td>
             <td className="budget-identity">
               <Tooltip message={window.channelProvider.selectedAddress.toLowerCase()}>
-                <Badge badgeContent={0} overlap={'rectangle'} showZero={false} max={999}>
-                  <Avatar variant="rounded">
+                <Badge badgeContent={0} overlap={'circle'} showZero={false} max={999}>
+                  <Avatar>
                     <Blockie
                       opts={{
                         seed: window.channelProvider.selectedAddress.toLowerCase(),

--- a/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
+++ b/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
@@ -5,7 +5,7 @@ import {prettyPrintWei} from '../../utils/calculateWei';
 import {utils} from 'ethers';
 import './DomainBudgetTable.scss';
 import {track} from '../../analytics';
-import {Avatar} from '@material-ui/core';
+import {Avatar, Badge} from '@material-ui/core';
 import {Blockie, Tooltip} from 'rimble-ui';
 
 const bigNumberify = utils.bigNumberify;
@@ -66,18 +66,20 @@ export const DomainBudgetTable: React.FC<DomainBudgetTableProps> = props => {
             <td className="budget-identity">
               <span>
                 <Tooltip message={window.channelProvider.selectedAddress}>
-                  <Avatar>
-                    <Blockie
-                      opts={{
-                        seed: window.channelProvider.selectedAddress,
-                        color: '#2728e2',
-                        bgcolor: '#46A5D0',
-                        size: 15,
-                        scale: 3,
-                        spotcolor: '#000'
-                      }}
-                    />
-                  </Avatar>
+                  <Badge badgeContent={0} overlap={'circle'} showZero={false} max={999}>
+                    <Avatar>
+                      <Blockie
+                        opts={{
+                          seed: window.channelProvider.selectedAddress,
+                          color: '#2728e2',
+                          bgcolor: '#46A5D0',
+                          size: 15,
+                          scale: 3,
+                          spotcolor: '#000'
+                        }}
+                      />
+                    </Avatar>
+                  </Badge>
                 </Tooltip>
               </span>
             </td>

--- a/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
+++ b/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
@@ -5,6 +5,8 @@ import {prettyPrintWei} from '../../utils/calculateWei';
 import {utils} from 'ethers';
 import './DomainBudgetTable.scss';
 import {track} from '../../analytics';
+import {Avatar} from '@material-ui/core';
+import {Blockie, Tooltip} from 'rimble-ui';
 
 const bigNumberify = utils.bigNumberify;
 
@@ -43,6 +45,7 @@ export const DomainBudgetTable: React.FC<DomainBudgetTableProps> = props => {
         <thead>
           <tr className="budget-info">
             <td className="budget-button">Wallet Action</td>
+            <td className="budget-identity">Identity</td>
             <td className="budget-number"> Spent / Budget </td>
             <td className="budget-number"> Earned / Budget </td>
           </tr>
@@ -59,6 +62,22 @@ export const DomainBudgetTable: React.FC<DomainBudgetTableProps> = props => {
               >
                 Withdraw
               </button>
+            </td>
+            <td className="budget-identity">
+              <Tooltip message={window.channelProvider.selectedAddress}>
+                <Avatar>
+                  <Blockie
+                    opts={{
+                      seed: window.channelProvider.selectedAddress,
+                      color: '#2728e2',
+                      bgcolor: '#46A5D0',
+                      size: 15,
+                      scale: 3,
+                      spotcolor: '#000'
+                    }}
+                  />
+                </Avatar>
+              </Tooltip>
             </td>
             <td className="budget-number">
               {' '}

--- a/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
+++ b/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
@@ -64,26 +64,28 @@ export const DomainBudgetTable: React.FC<DomainBudgetTableProps> = props => {
               </button>
             </td>
             <td className="budget-identity">
-              <Tooltip message={window.channelProvider.selectedAddress}>
-                <Avatar>
-                  <Blockie
-                    opts={{
-                      seed: window.channelProvider.selectedAddress,
-                      color: '#2728e2',
-                      bgcolor: '#46A5D0',
-                      size: 15,
-                      scale: 3,
-                      spotcolor: '#000'
-                    }}
-                  />
-                </Avatar>
-              </Tooltip>
+              <span>
+                <Tooltip message={window.channelProvider.selectedAddress}>
+                  <Avatar>
+                    <Blockie
+                      opts={{
+                        seed: window.channelProvider.selectedAddress,
+                        color: '#2728e2',
+                        bgcolor: '#46A5D0',
+                        size: 15,
+                        scale: 3,
+                        spotcolor: '#000'
+                      }}
+                    />
+                  </Avatar>
+                </Tooltip>
+              </span>
             </td>
-            <td className="budget-number">
+            <td className="budget-sent">
               {' '}
               {`${prettyPrintWei(spent)} / ${prettyPrintWei(spendBudget)}`}{' '}
             </td>
-            <td className="budget-number">
+            <td className="budget-received">
               {' '}
               {`${prettyPrintWei(received)} / ${prettyPrintWei(receiveBudget)}`}{' '}
             </td>

--- a/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
+++ b/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
@@ -39,8 +39,6 @@ export const DomainBudgetTable: React.FC<DomainBudgetTableProps> = props => {
 
   const receiveBudget = bigNumberify(budgetCache.budgets[0].availableReceiveCapacity);
 
-  // TODO remove this. currently the budget is equivalent to 1 petabyte. this would bring it down to 1 MB
-  const BUDGET_HACK = 1e9;
   const inverseSpentFraction = spent.gt(0) ? spendBudget.div(spent).toNumber() : undefined;
   const spentFraction = inverseSpentFraction ? 1 / inverseSpentFraction : 0;
   const inverseRecievedFraction = received.gt(0)
@@ -93,12 +91,12 @@ export const DomainBudgetTable: React.FC<DomainBudgetTableProps> = props => {
               </span>
             </td>
             <td className="budget-spent">
-              <CircularProgress variant="static" value={100 * spentFraction * BUDGET_HACK} />
-              {`${(100 * spentFraction * BUDGET_HACK).toFixed(0)} %`}
+              <CircularProgress variant="static" value={100 * spentFraction} />
+              {`${(100 * spentFraction).toFixed(0)} %`}
             </td>
             <td className="budget-received">
-              <CircularProgress variant="static" value={100 * receiveFraction * BUDGET_HACK} />
-              {`${(100 * receiveFraction * BUDGET_HACK).toFixed(0)} %`}
+              <CircularProgress variant="static" value={100 * receiveFraction} />
+              {`${(100 * receiveFraction).toFixed(0)} %`}
             </td>
           </tr>
         </tbody>

--- a/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
+++ b/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
@@ -71,24 +71,22 @@ export const DomainBudgetTable: React.FC<DomainBudgetTableProps> = props => {
               </button>
             </td>
             <td className="budget-identity">
-              <span>
-                <Tooltip message={window.channelProvider.selectedAddress}>
-                  <Badge badgeContent={0} overlap={'circle'} showZero={false} max={999}>
-                    <Avatar>
-                      <Blockie
-                        opts={{
-                          seed: window.channelProvider.selectedAddress.toLowerCase(),
-                          color: '#2728e2',
-                          bgcolor: '#46A5D0',
-                          size: 15,
-                          scale: 3,
-                          spotcolor: '#000'
-                        }}
-                      />
-                    </Avatar>
-                  </Badge>
-                </Tooltip>
-              </span>
+              <Tooltip message={window.channelProvider.selectedAddress.toLowerCase()}>
+                <Badge badgeContent={0} overlap={'rectangle'} showZero={false} max={999}>
+                  <Avatar variant="rounded">
+                    <Blockie
+                      opts={{
+                        seed: window.channelProvider.selectedAddress.toLowerCase(),
+                        color: '#2728e2',
+                        bgcolor: '#46A5D0',
+                        size: 15,
+                        scale: 3,
+                        spotcolor: '#000'
+                      }}
+                    />
+                  </Avatar>
+                </Badge>
+              </Tooltip>
             </td>
             <td className="budget-spent">
               <CircularProgress variant="static" value={100 * spentFraction} />

--- a/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
+++ b/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
@@ -1,12 +1,22 @@
 import React from 'react';
 import {DomainBudget} from '@statechannels/client-api-schema';
 import {ChannelState} from '../../clients/payment-channel-client';
-import {prettyPrintWei} from '../../utils/calculateWei';
 import {utils} from 'ethers';
+import {CircularProgressbar, buildStyles} from 'react-circular-progressbar';
+import 'react-circular-progressbar/dist/styles.css';
 import './DomainBudgetTable.scss';
 import {track} from '../../analytics';
-import {Avatar, Badge, CircularProgress} from '@material-ui/core';
+import {Avatar, Badge} from '@material-ui/core';
 import {Blockie, Tooltip} from 'rimble-ui';
+
+const styles = {
+  ...buildStyles({
+    pathColor: '#ea692b',
+    textColor: '#ea692b'
+  }),
+  width: 40,
+  marginTop: -5
+};
 
 const bigNumberify = utils.bigNumberify;
 
@@ -89,12 +99,18 @@ export const DomainBudgetTable: React.FC<DomainBudgetTableProps> = props => {
               </Tooltip>
             </td>
             <td className="budget-spent">
-              <CircularProgress variant="static" value={100 * spentFraction} />
-              {`${(100 * spentFraction).toFixed(0)} %`}
+              <CircularProgressbar
+                value={100 * spentFraction}
+                text={`${(100 * spentFraction).toFixed(1)}%`}
+                styles={styles}
+              />
             </td>
             <td className="budget-received">
-              <CircularProgress variant="static" value={100 * receiveFraction} />
-              {`${(100 * receiveFraction).toFixed(0)} %`}
+              <CircularProgressbar
+                value={100 * receiveFraction}
+                text={`${(100 * receiveFraction).toFixed(1)}%`}
+                styles={styles}
+              />
             </td>
           </tr>
         </tbody>

--- a/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
+++ b/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
@@ -77,7 +77,7 @@ export const DomainBudgetTable: React.FC<DomainBudgetTableProps> = props => {
                     <Avatar>
                       <Blockie
                         opts={{
-                          seed: window.channelProvider.selectedAddress,
+                          seed: window.channelProvider.selectedAddress.toLowerCase(),
                           color: '#2728e2',
                           bgcolor: '#46A5D0',
                           size: 15,

--- a/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
+++ b/packages/web3torrent/src/components/domain-budget-table/DomainBudgetTable.tsx
@@ -5,7 +5,7 @@ import {prettyPrintWei} from '../../utils/calculateWei';
 import {utils} from 'ethers';
 import './DomainBudgetTable.scss';
 import {track} from '../../analytics';
-import {Avatar, Badge} from '@material-ui/core';
+import {Avatar, Badge, CircularProgress} from '@material-ui/core';
 import {Blockie, Tooltip} from 'rimble-ui';
 
 const bigNumberify = utils.bigNumberify;
@@ -38,6 +38,15 @@ export const DomainBudgetTable: React.FC<DomainBudgetTableProps> = props => {
   const spendBudget = bigNumberify(budgetCache.budgets[0].availableSendCapacity);
 
   const receiveBudget = bigNumberify(budgetCache.budgets[0].availableReceiveCapacity);
+
+  // TODO remove this. currently the budget is equivalent to 1 petabyte. this would bring it down to 1 MB
+  const BUDGET_HACK = 1e9;
+  const inverseSpentFraction = spent.gt(0) ? spendBudget.div(spent).toNumber() : undefined;
+  const spentFraction = inverseSpentFraction ? 1 / inverseSpentFraction : 0;
+  const inverseRecievedFraction = received.gt(0)
+    ? receiveBudget.div(received).toNumber()
+    : undefined;
+  const receiveFraction = inverseRecievedFraction ? 1 / inverseRecievedFraction : 0;
 
   return (
     <>
@@ -83,13 +92,13 @@ export const DomainBudgetTable: React.FC<DomainBudgetTableProps> = props => {
                 </Tooltip>
               </span>
             </td>
-            <td className="budget-sent">
-              {' '}
-              {`${prettyPrintWei(spent)} / ${prettyPrintWei(spendBudget)}`}{' '}
+            <td className="budget-spent">
+              <CircularProgress variant="static" value={100 * spentFraction * BUDGET_HACK} />
+              {`${(100 * spentFraction * BUDGET_HACK).toFixed(0)} %`}
             </td>
             <td className="budget-received">
-              {' '}
-              {`${prettyPrintWei(received)} / ${prettyPrintWei(receiveBudget)}`}{' '}
+              <CircularProgress variant="static" value={100 * receiveFraction * BUDGET_HACK} />
+              {`${(100 * receiveFraction * BUDGET_HACK).toFixed(0)} %`}
             </td>
           </tr>
         </tbody>

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.scss
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.scss
@@ -48,7 +48,7 @@ section.wires-list {
           min-width: 50px;
           padding: 5px 5px;
           vertical-align: middle;
-          width: 20%;
+          width: 25%;
           min-width: 100px;
           text-align: center;
         }
@@ -74,12 +74,12 @@ section.wires-list {
           min-width: 70px;
           text-align: center;
           color: red;
-          width: 20%;
+          width: 25%;
         }
         .earned {
           min-width: 70px;
           text-align: center;
-          width: 20%;
+          width: 25%;
           i {
             transform: rotate(-135deg);
             -webkit-transform: rotate(-135deg);

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.scss
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.scss
@@ -6,8 +6,8 @@ section.wires-list {
   table.wires-list-table {
     width: 100%;
     border-collapse: collapse;
-    text-align: left;
-    vertical-align: center;
+    text-align: center;
+    vertical-align: middle;
 
     tbody,
     thead {
@@ -48,21 +48,17 @@ section.wires-list {
           min-width: 50px;
           padding: 5px 5px;
           vertical-align: middle;
-          width: 25%;
+          width: 20%;
           min-width: 100px;
-          text-align: left;
-        }
-
-        .channel {
+          text-align: center;
         }
 
         .peer-id,
         .channel-id {
-          text-align: left;
+          text-align: center;
           font-style: italic;
           overflow: hidden;
           text-overflow: ellipsis;
-          max-width: 100px;
         }
 
         .channel-id {
@@ -76,13 +72,13 @@ section.wires-list {
         }
         .paid {
           min-width: 70px;
-          text-align: right;
+          text-align: center;
           color: red;
           width: 20%;
         }
         .earned {
           min-width: 70px;
-          text-align: right;
+          text-align: center;
           width: 20%;
           i {
             transform: rotate(-135deg);

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.scss
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.scss
@@ -7,6 +7,7 @@ section.wires-list {
     width: 100%;
     border-collapse: collapse;
     text-align: left;
+    vertical-align: center;
 
     tbody,
     thead {

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -72,20 +72,22 @@ function channelIdToTableRow(
         {/* temporal thing to show the true state instead of a parsed one */}
       </td>
       <td className="channel-id">
-        <Tooltip message={channelId}>
-          <Avatar>
-            <Blockie
-              opts={{
-                seed: channelId,
-                color: '#FC473D',
-                bgcolor: '#E4A663',
-                size: 15,
-                scale: 3,
-                spotcolor: '#000'
-              }}
-            />
-          </Avatar>
-        </Tooltip>
+        <span>
+          <Tooltip message={channelId}>
+            <Avatar>
+              <Blockie
+                opts={{
+                  seed: channelId,
+                  color: '#FC473D',
+                  bgcolor: '#E4A663',
+                  size: 15,
+                  scale: 3,
+                  spotcolor: '#000'
+                }}
+              />
+            </Avatar>
+          </Tooltip>
+        </span>
       </td>
       <td className="peer-id">
         <Tooltip message={peerSelectedAddress}>

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -71,26 +71,6 @@ function channelIdToTableRow(
         <button disabled>{channel.status}</button>
         {/* temporal thing to show the true state instead of a parsed one */}
       </td>
-      <td className="channel-id">
-        <span>
-          <Tooltip message={channelId}>
-            <Badge badgeContent={0} overlap={'circle'} showZero={false} max={999}>
-              <Avatar>
-                <Blockie
-                  opts={{
-                    seed: channelId,
-                    color: '#FC473D',
-                    bgcolor: '#E4A663',
-                    size: 15,
-                    scale: 3,
-                    spotcolor: '#000'
-                  }}
-                />
-              </Avatar>
-            </Badge>
-          </Tooltip>
-        </span>
-      </td>
       <td className="peer-id">
         <Tooltip message={peerSelectedAddress}>
           <Badge
@@ -98,11 +78,11 @@ function channelIdToTableRow(
               channel.turnNum.toNumber() > 3 ? Math.trunc(channel.turnNum.toNumber() / 2) : 0
             }
             color={isBeneficiary ? 'primary' : 'error'}
-            overlap={'circle'}
+            overlap={'rectangle'}
             showZero={false}
             max={999}
           >
-            <Avatar>
+            <Avatar variant="rounded">
               <Blockie
                 opts={{
                   seed: peerSelectedAddress,
@@ -143,7 +123,6 @@ export const ChannelsList: React.FC<UploadInfoProps> = ({torrent, channels, mySi
           <thead>
             <tr className="peerInfo">
               <td>Status</td>
-              <td>Channel</td>
               <td>Peer</td>
               <td>Data</td>
               <td>Funds</td>

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -5,8 +5,9 @@ import {ChannelState} from '../../../clients/payment-channel-client';
 import './ChannelsList.scss';
 import {prettyPrintWei, prettyPrintBytes} from '../../../utils/calculateWei';
 import {utils} from 'ethers';
-import {getPeerStatus} from '../../../utils/torrent-status-checker';
 import {TorrentUI} from '../../../types';
+import {Blockie, Tooltip, Avatar} from 'rimble-ui';
+import Badge from '@material-ui/core/Badge';
 
 type UploadInfoProps = {
   torrent: TorrentUI;
@@ -64,7 +65,28 @@ function channelIdToTableRow(
         {/* temporal thing to show the true state instead of a parsed one */}
       </td>
       <td className="channel-id">{channelId}</td>
-      <td className="peer-id">{peerAccount}</td>
+      <Badge
+        badgeContent={
+          channel.turnNum.toNumber() > 3 ? Math.trunc(channel.turnNum.toNumber() / 2) : 0
+        }
+        color={'primary'}
+        max={999}
+      >
+        <Tooltip message={peerAccount}>
+          <Avatar src="" ml="auto" mr="auto">
+            <Blockie
+              opts={{
+                seed: peerAccount,
+                color: '#2728e2',
+                bgcolor: '#46A5D0',
+                size: 15,
+                scale: 3,
+                spotcolor: '#000'
+              }}
+            />
+          </Avatar>
+        </Tooltip>
+      </Badge>
       <td className="transferred">
         {dataTransferred}
         <i className={isBeneficiary ? 'up' : 'down'}></i>

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -78,11 +78,11 @@ function channelIdToTableRow(
               channel.turnNum.toNumber() > 3 ? Math.trunc(channel.turnNum.toNumber() / 2) : 0
             }
             color={isBeneficiary ? 'primary' : 'error'}
-            overlap={'rectangle'}
+            overlap={'circle'}
             showZero={false}
             max={999}
           >
-            <Avatar variant="rounded">
+            <Avatar>
               <Blockie
                 opts={{
                   seed: peerSelectedAddress,

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -74,18 +74,20 @@ function channelIdToTableRow(
       <td className="channel-id">
         <span>
           <Tooltip message={channelId}>
-            <Avatar>
-              <Blockie
-                opts={{
-                  seed: channelId,
-                  color: '#FC473D',
-                  bgcolor: '#E4A663',
-                  size: 15,
-                  scale: 3,
-                  spotcolor: '#000'
-                }}
-              />
-            </Avatar>
+            <Badge badgeContent={0} overlap={'circle'} showZero={false} max={999}>
+              <Avatar>
+                <Blockie
+                  opts={{
+                    seed: channelId,
+                    color: '#FC473D',
+                    bgcolor: '#E4A663',
+                    size: 15,
+                    scale: 3,
+                    spotcolor: '#000'
+                  }}
+                />
+              </Avatar>
+            </Badge>
           </Tooltip>
         </span>
       </td>

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -6,8 +6,8 @@ import './ChannelsList.scss';
 import {prettyPrintWei, prettyPrintBytes} from '../../../utils/calculateWei';
 import {utils} from 'ethers';
 import {TorrentUI} from '../../../types';
-import {Blockie, Tooltip, Avatar} from 'rimble-ui';
-import Badge from '@material-ui/core/Badge';
+import {Blockie, Tooltip} from 'rimble-ui';
+import {Badge, Avatar} from '@material-ui/core';
 
 type UploadInfoProps = {
   torrent: TorrentUI;
@@ -48,7 +48,14 @@ function channelIdToTableRow(
   // }
 
   let dataTransferred: string;
-  const peerAccount = isBeneficiary ? channel['payer'] : channel['beneficiary']; // If I am the payer, my peer is the beneficiary and vice versa
+  // const peerAccount = isBeneficiary ? channel['payer'] : channel['beneficiary']; // If I am the payer, my peer is the beneficiary and vice versa
+  const peerOutcomeAddress = isBeneficiary
+    ? channel.payerOutcomeAddress
+    : channel.beneficiaryOutcomeAddress;
+
+  const peerSelectedAddress = '0x' + peerOutcomeAddress.slice(26).toLowerCase();
+  // For now, this ^ is the ethereum address in my peer's metamask
+
   if (wire) {
     dataTransferred = isBeneficiary ? prettier(wire.uploaded) : prettier(wire.downloaded);
   } else {
@@ -64,21 +71,14 @@ function channelIdToTableRow(
         <button disabled>{channel.status}</button>
         {/* temporal thing to show the true state instead of a parsed one */}
       </td>
-      <td className="channel-id">{channelId}</td>
-      <Badge
-        badgeContent={
-          channel.turnNum.toNumber() > 3 ? Math.trunc(channel.turnNum.toNumber() / 2) : 0
-        }
-        color={'primary'}
-        max={999}
-      >
-        <Tooltip message={peerAccount}>
-          <Avatar src="" ml="auto" mr="auto">
+      <td className="channel-id">
+        <Tooltip message={channelId}>
+          <Avatar>
             <Blockie
               opts={{
-                seed: peerAccount,
-                color: '#2728e2',
-                bgcolor: '#46A5D0',
+                seed: channelId,
+                color: '#FC473D',
+                bgcolor: '#E4A663',
                 size: 15,
                 scale: 3,
                 spotcolor: '#000'
@@ -86,9 +86,35 @@ function channelIdToTableRow(
             />
           </Avatar>
         </Tooltip>
-      </Badge>
+      </td>
+      <td className="peer-id">
+        <Tooltip message={peerSelectedAddress}>
+          <Badge
+            badgeContent={
+              channel.turnNum.toNumber() > 3 ? Math.trunc(channel.turnNum.toNumber() / 2) : 0
+            }
+            color={isBeneficiary ? 'primary' : 'error'}
+            overlap={'circle'}
+            showZero={false}
+            max={999}
+          >
+            <Avatar>
+              <Blockie
+                opts={{
+                  seed: peerSelectedAddress,
+                  color: '#2728e2',
+                  bgcolor: '#46A5D0',
+                  size: 15,
+                  scale: 3,
+                  spotcolor: '#000'
+                }}
+              />
+            </Avatar>
+          </Badge>
+        </Tooltip>
+      </td>
       <td className="transferred">
-        {dataTransferred}
+        {dataTransferred + ' '}
         <i className={isBeneficiary ? 'up' : 'down'}></i>
       </td>
       {isBeneficiary ? (

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -176,7 +176,10 @@ export {SINGLE_ASSET_PAYMENT_CONTRACT_ADDRESS};
 
 export const FUNDING_STRATEGY = process.env.FUNDING_STRATEGY === 'Direct' ? 'Direct' : 'Virtual';
 
-export const INITIAL_BUDGET_AMOUNT = utils.hexZeroPad(utils.parseEther('0.001').toHexString(), 32);
+export const INITIAL_BUDGET_AMOUNT = utils.hexZeroPad(
+  utils.parseEther('0.000000001').toHexString(),
+  32
+); // 1 Gwei (equivalant to 1GB at 1 wei per byte)
 
 export const LOG_DESTINATION = process.env.LOG_DESTINATION;
 export const ADD_LOGS = !!LOG_DESTINATION;

--- a/yarn.lock
+++ b/yarn.lock
@@ -27365,6 +27365,11 @@ react-burger-menu@2.6.13:
     prop-types "^15.7.2"
     snapsvg-cjs "0.0.6"
 
+react-circular-progressbar@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/react-circular-progressbar/-/react-circular-progressbar-2.0.3.tgz#fa8eb59f8db168d2904bae4590641792c80f5991"
+  integrity sha512-YKN+xAShXA3gYihevbQZbavfiJxo83Dt1cUxqg/cltj4VVsRQpDr7Fg1mvjDG3x1KHGtd9NmYKvJ2mMrPwbKyw==
+
 react-clientside-effect@^1.2.0, react-clientside-effect@^1.2.2:
   version "1.2.2"
   resolved "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1520,6 +1520,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7":
+  version "7.9.6"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz#a9102eb5cadedf3f31d08a9ecf294af7827ea29f"
+  integrity sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/standalone@^7.4.5":
   version "7.8.6"
   resolved "https://registry.npmjs.org/@babel/standalone/-/standalone-7.8.6.tgz#1364534775c83bf7b7988e4ca98823bef56a0a53"
@@ -1896,6 +1903,11 @@
   version "0.7.4"
   resolved "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.4.tgz#f14932887422c9056b15a8d222a9074a7dfa2831"
   integrity sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A==
+
+"@emotion/hash@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
+  integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
 "@emotion/is-prop-valid@0.8.7", "@emotion/is-prop-valid@^0.8.3":
   version "0.8.7"
@@ -4040,6 +4052,70 @@
   dependencies:
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
+
+"@material-ui/core@^4.9.14":
+  version "4.9.14"
+  resolved "https://registry.npmjs.org/@material-ui/core/-/core-4.9.14.tgz#4388f82cf94554cd3a935774fc12820f3c607a8a"
+  integrity sha512-71oYrOpInx5honJ9GzZlygPjmsFhn7Bui61/SWLJsPTkMnfvuZfU3qVqlEHjXyDsnZ+uKmLAIdsrOYnphJxxXw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/styles" "^4.9.14"
+    "@material-ui/system" "^4.9.14"
+    "@material-ui/types" "^5.1.0"
+    "@material-ui/utils" "^4.9.12"
+    "@types/react-transition-group" "^4.2.0"
+    clsx "^1.0.4"
+    hoist-non-react-statics "^3.3.2"
+    popper.js "^1.16.1-lts"
+    prop-types "^15.7.2"
+    react-is "^16.8.0"
+    react-transition-group "^4.4.0"
+
+"@material-ui/styles@^4.9.14":
+  version "4.9.14"
+  resolved "https://registry.npmjs.org/@material-ui/styles/-/styles-4.9.14.tgz#0a9e93a2bf24e8daa0811411a6f3dabdafbe9a07"
+  integrity sha512-zecwWKgRU2VzdmutNovPB4s5LKI0TWyZKc/AHfPu9iY8tg4UoLjpa4Rn9roYrRfuTbBZHI6b0BXcQ8zkis0nzQ==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@emotion/hash" "^0.8.0"
+    "@material-ui/types" "^5.1.0"
+    "@material-ui/utils" "^4.9.6"
+    clsx "^1.0.4"
+    csstype "^2.5.2"
+    hoist-non-react-statics "^3.3.2"
+    jss "^10.0.3"
+    jss-plugin-camel-case "^10.0.3"
+    jss-plugin-default-unit "^10.0.3"
+    jss-plugin-global "^10.0.3"
+    jss-plugin-nested "^10.0.3"
+    jss-plugin-props-sort "^10.0.3"
+    jss-plugin-rule-value-function "^10.0.3"
+    jss-plugin-vendor-prefixer "^10.0.3"
+    prop-types "^15.7.2"
+
+"@material-ui/system@^4.9.14":
+  version "4.9.14"
+  resolved "https://registry.npmjs.org/@material-ui/system/-/system-4.9.14.tgz#4b00c48b569340cefb2036d0596b93ac6c587a5f"
+  integrity sha512-oQbaqfSnNlEkXEziDcJDDIy8pbvwUmZXWNqlmIwDqr/ZdCK8FuV3f4nxikUh7hvClKV2gnQ9djh5CZFTHkZj3w==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.9.6"
+    csstype "^2.5.2"
+    prop-types "^15.7.2"
+
+"@material-ui/types@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz#efa1c7a0b0eaa4c7c87ac0390445f0f88b0d88f2"
+  integrity sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==
+
+"@material-ui/utils@^4.9.12", "@material-ui/utils@^4.9.6":
+  version "4.9.12"
+  resolved "https://registry.npmjs.org/@material-ui/utils/-/utils-4.9.12.tgz#0d639f1c1ed83fffb2ae10c21d15a938795d9e65"
+  integrity sha512-/0rgZPEOcZq5CFA4+4n6Q6zk7fi8skHhH2Bcra8R3epoJEYy5PL55LuMazPtPH1oKeRausDV/Omz4BbgFsn1HQ==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -6876,6 +6952,13 @@
   version "4.3.5"
   resolved "https://registry.npmjs.org/@types/react-textarea-autosize/-/react-textarea-autosize-4.3.5.tgz#6c4d2753fa1864c98c0b2b517f67bb1f6e4c46de"
   integrity sha512-PiDL83kPMTolyZAWW3lyzO6ktooTb9tFTntVy7CA83/qFLWKLJ5bLeRboy6J6j3b1e8h2Eec6gBTEOOJRjV14A==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-transition-group@^4.2.0":
+  version "4.2.4"
+  resolved "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.2.4.tgz#c7416225987ccdb719262766c1483da8f826838d"
+  integrity sha512-8DMUaDqh0S70TjkqU0DxOu80tFUiiaS9rxkWip/nb7gtvAsbqOXm02UCmR8zdcjWujgeYPiPNTVpVpKzUDotwA==
   dependencies:
     "@types/react" "*"
 
@@ -12073,6 +12156,11 @@ cloneable-readable@^1.0.0:
     process-nextick-args "^2.0.0"
     readable-stream "^2.3.5"
 
+clsx@^1.0.4:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/clsx/-/clsx-1.1.0.tgz#62937c6adfea771247c34b54d320fb99624f5702"
+  integrity sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -13130,6 +13218,14 @@ css-unit-converter@^1.1.1:
   resolved "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz#d9b9281adcfd8ced935bdbaba83786897f64e996"
   integrity sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=
 
+css-vendor@^2.0.7:
+  version "2.0.8"
+  resolved "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz#e47f91d3bd3117d49180a3c935e62e3d9f7f449d"
+  integrity sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==
+  dependencies:
+    "@babel/runtime" "^7.8.3"
+    is-in-browser "^1.0.2"
+
 css-what@2.1:
   version "2.1.3"
   resolved "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
@@ -13275,6 +13371,11 @@ csstype@^2.2.0, csstype@^2.5.7:
   version "2.6.9"
   resolved "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
   integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
+
+csstype@^2.5.2, csstype@^2.6.5, csstype@^2.6.7:
+  version "2.6.10"
+  resolved "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
+  integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -13979,6 +14080,14 @@ dom-helpers@^3.4.0:
   integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
   dependencies:
     "@babel/runtime" "^7.1.2"
+
+dom-helpers@^5.0.1:
+  version "5.1.4"
+  resolved "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.4.tgz#4609680ab5c79a45f2531441f1949b79d6587f4b"
+  integrity sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^2.6.7"
 
 dom-serializer@0:
   version "0.2.2"
@@ -18933,7 +19042,7 @@ hoist-non-react-statics@^2.3.1:
   resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -19267,7 +19376,7 @@ hyperlinker@^1.0.0:
   resolved "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
   integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
 
-hyphenate-style-name@^1.0.2:
+hyphenate-style-name@^1.0.2, hyphenate-style-name@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
   integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
@@ -19963,6 +20072,11 @@ is-hexadecimal@^1.0.0:
   version "1.0.4"
   resolved "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
   integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
+
+is-in-browser@^1.0.2, is-in-browser@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
+  integrity sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=
 
 is-installed-globally@^0.1.0:
   version "0.1.0"
@@ -21269,6 +21383,75 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jss-plugin-camel-case@^10.0.3:
+  version "10.1.1"
+  resolved "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.1.1.tgz#8e73ecc4f1d0f8dfe4dd31f6f9f2782588970e78"
+  integrity sha512-MDIaw8FeD5uFz1seQBKz4pnvDLnj5vIKV5hXSVdMaAVq13xR6SVTVWkIV/keyTs5txxTvzGJ9hXoxgd1WTUlBw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    hyphenate-style-name "^1.0.3"
+    jss "10.1.1"
+
+jss-plugin-default-unit@^10.0.3:
+  version "10.1.1"
+  resolved "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.1.1.tgz#2df86016dfe73085eead843f5794e3890e9c5c47"
+  integrity sha512-UkeVCA/b3QEA4k0nIKS4uWXDCNmV73WLHdh2oDGZZc3GsQtlOCuiH3EkB/qI60v2MiCq356/SYWsDXt21yjwdg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.1.1"
+
+jss-plugin-global@^10.0.3:
+  version "10.1.1"
+  resolved "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.1.1.tgz#36b0d6d9facb74dfd99590643708a89260747d14"
+  integrity sha512-VBG3wRyi3Z8S4kMhm8rZV6caYBegsk+QnQZSVmrWw6GVOT/Z4FA7eyMu5SdkorDlG/HVpHh91oFN56O4R9m2VA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.1.1"
+
+jss-plugin-nested@^10.0.3:
+  version "10.1.1"
+  resolved "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.1.1.tgz#5c3de2b8bda344de1ebcef3a4fd30870a29a8a8c"
+  integrity sha512-ozEu7ZBSVrMYxSDplPX3H82XHNQk2DQEJ9TEyo7OVTPJ1hEieqjDFiOQOxXEj9z3PMqkylnUbvWIZRDKCFYw5Q==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.1.1"
+    tiny-warning "^1.0.2"
+
+jss-plugin-props-sort@^10.0.3:
+  version "10.1.1"
+  resolved "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.1.1.tgz#34bddcbfaf9430ec8ccdf92729f03bb10caf1785"
+  integrity sha512-g/joK3eTDZB4pkqpZB38257yD4LXB0X15jxtZAGbUzcKAVUHPl9Jb47Y7lYmiGsShiV4YmQRqG1p2DHMYoK91g==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.1.1"
+
+jss-plugin-rule-value-function@^10.0.3:
+  version "10.1.1"
+  resolved "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.1.1.tgz#be00dac6fc394aaddbcef5860b9eca6224d96382"
+  integrity sha512-ClV1lvJ3laU9la1CUzaDugEcwnpjPTuJ0yGy2YtcU+gG/w9HMInD5vEv7xKAz53Bk4WiJm5uLOElSEshHyhKNw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.1.1"
+
+jss-plugin-vendor-prefixer@^10.0.3:
+  version "10.1.1"
+  resolved "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.1.1.tgz#8348b20749f790beebab3b6a8f7075b07c2cfcfd"
+  integrity sha512-09MZpQ6onQrhaVSF6GHC4iYifQ7+4YC/tAP6D4ZWeZotvCMq1mHLqNKRIaqQ2lkgANjlEot2JnVi1ktu4+L4pw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    css-vendor "^2.0.7"
+    jss "10.1.1"
+
+jss@10.1.1, jss@^10.0.3:
+  version "10.1.1"
+  resolved "https://registry.npmjs.org/jss/-/jss-10.1.1.tgz#450b27d53761af3e500b43130a54cdbe157ea332"
+  integrity sha512-Xz3qgRUFlxbWk1czCZibUJqhVPObrZHxY3FPsjCXhDld4NOj1BgM14Ir5hVm+Qr6OLqVljjGvoMcCdXNOAbdkQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    csstype "^2.6.5"
+    is-in-browser "^1.1.3"
+    tiny-warning "^1.0.2"
 
 jsx-ast-utils@^2.2.3:
   version "2.2.3"
@@ -25541,7 +25724,7 @@ popper.js@1.14.3:
   resolved "https://registry.npmjs.org/popper.js/-/popper.js-1.14.3.tgz#1438f98d046acf7b4d78cd502bf418ac64d4f095"
   integrity sha1-FDj5jQRqz3tNeM1QK/QYrGTU8JU=
 
-popper.js@^1.14.1, popper.js@^1.14.3, popper.js@^1.14.4, popper.js@^1.14.7:
+popper.js@^1.14.1, popper.js@^1.14.3, popper.js@^1.14.4, popper.js@^1.14.7, popper.js@^1.16.1-lts:
   version "1.16.1"
   resolved "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
@@ -27380,6 +27563,11 @@ react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-i
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
   integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
 
+react-is@^16.8.0:
+  version "16.13.1"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -27548,6 +27736,16 @@ react-transition-group@^2.2.1, react-transition-group@^2.3.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
+
+react-transition-group@^4.4.0:
+  version "4.4.1"
+  resolved "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
+  integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@16.12.0:
   version "16.12.0"
@@ -28520,6 +28718,24 @@ rimble-ui@0.13.1:
   version "0.13.1"
   resolved "https://registry.npmjs.org/rimble-ui/-/rimble-ui-0.13.1.tgz#82094cc780a85598012c978f31efd16a9ea9f5ac"
   integrity sha512-MtMQByWxv/CVcHP6o6SeXT1eNi7dr43dObGq7eHAUcG6dFhCyExV/3m8oqa/GG/xhTgGe9jGw39Q6XED91sFBA==
+  dependencies:
+    "@d8660091/react-popper" "^1.0.4"
+    "@rimble/icons" "^1.0.2"
+    "@styled-system/prop-types" "^5.1.2"
+    "@styled-system/theme-get" "^5.1.2"
+    "@svgr/rollup" "^4.2.0"
+    clipboard "^2.0.4"
+    ethereum-blockies "^0.1.1"
+    mixin-deep "^2.0.1"
+    polished "^3.2.0"
+    qrcode.react "^0.9.3"
+    set-value "^3.0.1"
+    styled-system "^5.1.5"
+
+rimble-ui@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.npmjs.org/rimble-ui/-/rimble-ui-0.14.0.tgz#86623865c62398da51326f8760b033b60a82f755"
+  integrity sha512-fwWCYuJCwOAcagt9PZT7cxLbAieF8XijglJCrYqReWKcbY64QES0CK9W/rlLlT/SXJIZw4eNO75b2QV43++ojA==
   dependencies:
     "@d8660091/react-popper" "^1.0.4"
     "@rimble/icons" "^1.0.2"


### PR DESCRIPTION
This is a demo app. When it works, it's pretty awesome to consider what is going on under the hood. 

OTH if users just come away with an impression of  "webtorrent clone", they will have largely missed the point. 

I think one way of showing off more of how awesome state channels are is to display the number of "L2 transactions" in real time.

This changeset also introduces a blockie for our peer, which has the full address in a tooltip. Personally I think this looks nicer, and it might help identify peers. 

![Screenshot 2020-05-20 at 19 21 29](https://user-images.githubusercontent.com/1833419/82482963-85af7e00-9acf-11ea-8d5f-025fedeb572d.png)
![Screenshot 2020-05-20 at 19 21 31](https://user-images.githubusercontent.com/1833419/82482970-87794180-9acf-11ea-8a14-31209d0be98f.png)


TODO (feedback welcomed)
---
- [x] potential changes to styling of blockie (we could make it match what's in MM by pulling the outcome address for our peer, and then trying to match the colours with MM)
- [x] display our blockie somewhere
- [x] extend blockies to channel ids
- [x] alignment of the table seems off (I don't think I caused this)
