### PR TITLE
Update UpdateChannel API

### DIFF
--- a/packages/client-api-schema/src/types.ts
+++ b/packages/client-api-schema/src/types.ts
@@ -70,6 +70,7 @@ export function isError(message: JsonRpcMessage): message is ErrorResponse {
 export * from './notifications';
 export * from './methods';
 export * from './data-types';
+export * from './error-codes';
 
 import {ErrorCodes} from './error-codes';
 

--- a/packages/xstate-wallet/src/store/dexie-backend.ts
+++ b/packages/xstate-wallet/src/store/dexie-backend.ts
@@ -181,6 +181,10 @@ export class Backend implements DBBackend {
       case 'readonly':
         dexieMode = 'r';
         break;
+      case 'external':
+        dexieMode = 'rw!';
+        break;
+
       default:
         return unreachable(mode);
     }

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -25,8 +25,7 @@ import {
   DomainBudget,
   State,
   StateVariables,
-  ObjectStores,
-  SimpleAllocation
+  ObjectStores
 } from './types';
 import {logger} from '../logger';
 
@@ -312,38 +311,11 @@ export class Store {
   }
 
   public updateChannel = (
-    channelId: string,
-    updateData: {outcome: SimpleAllocation; appData: string; isFinal?: boolean}
+    updateData: () => Promise<{entry: ChannelStoreEntry; signedState: SignedState}>
   ) =>
     this.backend
-      .transaction('readwrite', [ObjectStores.channels, ObjectStores.privateKeys], async () => {
-        const entry = await this.getEntry(channelId);
-        const existingState = entry.latest;
-        const newState = {
-          ...existingState,
-          turnNum: existingState.turnNum.add(1),
-          appData: updateData.appData,
-          outcome: updateData.outcome,
-          isFinal: updateData.isFinal || existingState.isFinal
-        };
-
-        const {participants} = entry;
-        const myAddress = participants[entry.myIndex].signingAddress;
-        const privateKey = await this.backend.getPrivateKey(myAddress);
-
-        if (!privateKey) {
-          throw new Error('No longer have private key');
-        }
-        const signedState = entry.signAndAdd(
-          _.pick(newState, 'outcome', 'turnNum', 'appData', 'isFinal'),
-          privateKey
-        );
-        await this.backend.setChannel(channelId, entry.data());
-        return {entry, signedState};
-      })
+      .transaction('external', [ObjectStores.channels, ObjectStores.privateKeys], updateData)
       .then(({entry, signedState}) => {
-        // These events trigger callbacks that should not run within the transaction scope
-        // See https://github.com/dfahlander/Dexie.js/issues/1029
         this._eventEmitter.emit('channelUpdated', entry);
         this._eventEmitter.emit('addToOutbox', {signedStates: [signedState]});
 

--- a/packages/xstate-wallet/src/store/types.ts
+++ b/packages/xstate-wallet/src/store/types.ts
@@ -209,7 +209,8 @@ export type Transaction = {
   // channels(): Table<ChannelRecord>
 };
 
-export type TXMode = 'readonly' | 'readwrite';
+// External facing transactions should be top-level as an extra precaution
+export type TXMode = 'readonly' | 'readwrite' | 'external';
 
 export const enum ObjectStores {
   channels = 'channels',


### PR DESCRIPTION
- store.updateChannel accepts a callback, which executes within a tx scope. This allows us to push logic away from the store, and into the relevant workflows
- application workflow responds with "Not your turn" and "No channel found" error responses

(Based on https://github.com/statechannels/monorepo/pull/1931)


## TODO
Before removing draft status, I'd like to address some of these issues:
- [ ] Refactor away the term "Player"
   - web3torrent is not a game!
- [ ] Refactor running test to more easily test the error responses
   - Currently, there is a lot of setup that could be simplified by the ability to [reload a store](https://github.com/statechannels/monorepo/issues/1711)
- [ ] Handle the `PLAYER_UPDATE` event when not in the `running` state
- [ ] Handle the other [possible errors](https://github.com/statechannels/monorepo/blob/59ade2faf295c555cef9ea3d544a92731f5b5648/packages/client-api-schema/src/error-codes.ts#L12-L18)
- [ ] Define more [UpdateChannel errors](https://github.com/statechannels/monorepo/blob/59ade2faf295c555cef9ea3d544a92731f5b5648/packages/client-api-schema/src/error-codes.ts#L12-L18)
   - What should happen if the workflow is not in the `running` state? (more or less equivalent to: the channel cannot accept an update)