### PR TITLE
Handle challenge detection

### DIFF
--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -11,7 +11,8 @@ import {Contract, Wallet, BigNumber, BigNumberish} from 'ethers';
 import {Observable, fromEvent, from, merge, combineLatest} from 'rxjs';
 import {filter, map, flatMap, defaultIfEmpty, last} from 'rxjs/operators';
 import {One, Zero} from '@ethersproject/constants';
-import {hexZeroPad, id} from '@ethersproject/bytes';
+import {hexZeroPad} from '@ethersproject/bytes';
+import {id} from '@ethersproject/hash';
 import {TransactionRequest} from '@ethersproject/providers';
 import EventEmitter from 'eventemitter3';
 
@@ -462,7 +463,7 @@ export class ChainWatcher implements Chain {
     const updates = fromEvent(this._adjudicator, 'ChallengeRegistered').pipe(
       filter((event: any) => event[0] === channelId), // index 0 of ChallengeRegistered event is channelId
       map(getChallengeRegisteredEvent),
-      map(({challengeStates, finalizesAt}: ChallengeRegisteredEvent) =>
+      map(({challengeStates}: ChallengeRegisteredEvent) =>
         fromNitroState(challengeStates[challengeStates.length - 1].state)
       )
     );

--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -438,19 +438,16 @@ export class ChainWatcher implements Chain {
 
   public chainUpdatedFeed(channelId: string): Observable<ChannelChainInfo> {
     return combineLatest(this.chainInfoFeed(channelId), this.challengeStateFeed(channelId)).pipe(
-      map(([chainInfo, challengeInfo]) => {
-        console.log(chainInfo, challengeInfo);
-        return {
-          ...chainInfo,
-          challengeState: chainInfo.finalizesAt.gt(Zero) ? challengeInfo.challengeState : undefined,
-          blockNum: chainInfo.blockNum.gt(challengeInfo.blockNum)
-            ? chainInfo.blockNum
-            : challengeInfo.blockNum,
-          finalizesAt: chainInfo.finalizesAt.gt(challengeInfo.finalizesAt)
-            ? chainInfo.finalizesAt
-            : challengeInfo.finalizesAt
-        };
-      })
+      map(([chainInfo, challengeInfo]) => ({
+        ...chainInfo,
+        challengeState: chainInfo.finalizesAt.gt(Zero) ? challengeInfo.challengeState : undefined,
+        blockNum: chainInfo.blockNum.gt(challengeInfo.blockNum)
+          ? chainInfo.blockNum
+          : challengeInfo.blockNum,
+        finalizesAt: chainInfo.finalizesAt.gt(challengeInfo.finalizesAt)
+          ? chainInfo.finalizesAt
+          : challengeInfo.finalizesAt
+      }))
     );
   }
   private chainInfoFeed(channelId: string): Observable<ChainQueryInfo> {

--- a/packages/xstate-wallet/src/integration-tests/close-withdraw.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/close-withdraw.test.ts
@@ -93,7 +93,7 @@ it('allows for a wallet to close the ledger channel with the hub and withdraw', 
 
   // Verify that the blockchain is correct
   const chainView = await playerA.store.chain.getChainInfo(ledgerChannel.channelId);
-  expect(chainView.channelStorage.finalizesAt.gt(0)).toBe(true);
+  expect(chainView.finalizesAt.gt(0)).toBe(true);
   expect(chainView.amount.eq(0)).toBe(true);
 
   // Check the channel is finalized

--- a/packages/xstate-wallet/src/integration-tests/helpers.ts
+++ b/packages/xstate-wallet/src/integration-tests/helpers.ts
@@ -11,7 +11,8 @@ import {
   UpdateChannelRequest,
   CloseChannelRequest,
   ApproveBudgetAndFundRequest,
-  CloseAndWithdrawRequest
+  CloseAndWithdrawRequest,
+  ChallengeChannelRequest
 } from '@statechannels/client-api-schema';
 import {interpret, Interpreter} from 'xstate';
 import {CreateAndFundLedger, Application as App} from '../workflows';
@@ -160,6 +161,17 @@ export function generateCloseRequest(channelId: string): CloseChannelRequest {
     jsonrpc: '2.0',
     method: 'CloseChannel',
     id: 777777777,
+    params: {
+      channelId
+    }
+  };
+}
+
+export function generateChallengeRequest(channelId: string): ChallengeChannelRequest {
+  return {
+    jsonrpc: '2.0',
+    method: 'ChallengeChannel',
+    id: 999999999,
     params: {
       channelId
     }

--- a/packages/xstate-wallet/src/store/channel-store-entry.ts
+++ b/packages/xstate-wallet/src/store/channel-store-entry.ts
@@ -16,6 +16,7 @@ import {BigNumber} from 'ethers';
 import {Funding} from './store';
 import {Errors} from '.';
 import {logger} from '../logger';
+import {Chain} from '../chain';
 export interface SignatureEntry {
   signature: string;
   signer: string;
@@ -32,7 +33,7 @@ export class ChannelStoreEntry {
   public readonly channelConstants: ChannelConstants;
   public readonly applicationDomain?: string;
 
-  constructor(channelData: ChannelStoredData) {
+  constructor(channelData: ChannelStoredData, private chain: Chain) {
     const {
       myIndex,
       stateVariables,
@@ -97,10 +98,6 @@ export class ChannelStoreEntry {
     return this.isSupported && this.support.every(s => s.isFinal);
   }
 
-  get isChallenging() {
-    // TODO: Check chain
-    return false;
-  }
 
   private get _supported() {
     const latestSupport = this._support;
@@ -321,7 +318,7 @@ export class ChannelStoreEntry {
     };
   }
 
-  static fromJson(data): ChannelStoreEntry {
+  static fromJson(data, chain): ChannelStoreEntry {
     if (!data) {
       logger.error("Data is undefined or null, Memory Channel Store Entry can't be created.");
       return data;
@@ -334,13 +331,16 @@ export class ChannelStoreEntry {
     channelConstants.challengeDuration = BigNumber.from(channelConstants.challengeDuration);
     channelConstants.channelNonce = BigNumber.from(channelConstants.channelNonce);
 
-    return new ChannelStoreEntry({
-      channelConstants,
-      myIndex,
-      stateVariables,
-      funding,
-      applicationDomain
-    });
+    return new ChannelStoreEntry(
+      {
+        channelConstants,
+        myIndex,
+        stateVariables,
+        funding,
+        applicationDomain
+      },
+      chain
+    );
   }
 
   private static prepareStateVariables(

--- a/packages/xstate-wallet/src/store/channel-store-entry.ts
+++ b/packages/xstate-wallet/src/store/channel-store-entry.ts
@@ -16,7 +16,7 @@ import {BigNumber} from 'ethers';
 import {Funding} from './store';
 import {Errors} from '.';
 import {logger} from '../logger';
-import {Chain} from '../chain';
+
 export interface SignatureEntry {
   signature: string;
   signer: string;
@@ -33,7 +33,7 @@ export class ChannelStoreEntry {
   public readonly channelConstants: ChannelConstants;
   public readonly applicationDomain?: string;
 
-  constructor(channelData: ChannelStoredData, private chain: Chain) {
+  constructor(channelData: ChannelStoredData) {
     const {
       myIndex,
       stateVariables,
@@ -97,7 +97,6 @@ export class ChannelStoreEntry {
   get hasConclusionProof() {
     return this.isSupported && this.support.every(s => s.isFinal);
   }
-
 
   private get _supported() {
     const latestSupport = this._support;
@@ -318,7 +317,7 @@ export class ChannelStoreEntry {
     };
   }
 
-  static fromJson(data, chain): ChannelStoreEntry {
+  static fromJson(data): ChannelStoreEntry {
     if (!data) {
       logger.error("Data is undefined or null, Memory Channel Store Entry can't be created.");
       return data;
@@ -331,16 +330,13 @@ export class ChannelStoreEntry {
     channelConstants.challengeDuration = BigNumber.from(channelConstants.challengeDuration);
     channelConstants.channelNonce = BigNumber.from(channelConstants.channelNonce);
 
-    return new ChannelStoreEntry(
-      {
-        channelConstants,
-        myIndex,
-        stateVariables,
-        funding,
-        applicationDomain
-      },
-      chain
-    );
+    return new ChannelStoreEntry({
+      channelConstants,
+      myIndex,
+      stateVariables,
+      funding,
+      applicationDomain
+    });
   }
 
   private static prepareStateVariables(

--- a/packages/xstate-wallet/src/store/state-utils.ts
+++ b/packages/xstate-wallet/src/store/state-utils.ts
@@ -25,7 +25,7 @@ import {Wallet, BigNumber} from 'ethers';
 import {SignatureEntry} from './channel-store-entry';
 import {logger} from '../logger';
 import {Zero} from '@ethersproject/constants';
-function toNitroState(state: State): NitroState {
+export function toNitroState(state: State): NitroState {
   const {challengeDuration, appDefinition, channelNonce, participants, chainId} = state;
   const channel = {
     channelNonce: channelNonce.toString(),

--- a/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
+++ b/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
@@ -177,6 +177,7 @@ it('the challenge state gets returned when there is an existing challenge', asyn
   const support = [allSignState];
 
   await chain.challenge(support, playerA.privateKey);
+
   const channelId = calculateChannelId(state);
 
   const chainEntry = await chain
@@ -231,9 +232,10 @@ it('the chainUpdated fires and returns a challenge state when a challenge occurs
   const channelId = calculateChannelId(state);
 
   await chain.challenge(support, playerA.privateKey);
+
   const chainEntry = await chain
     .chainUpdatedFeed(channelId)
-    .pipe(take(2))
+    .pipe(take(1))
     .toPromise();
 
   expect(chainEntry.challengeState).toBeDefined();

--- a/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
+++ b/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
@@ -17,7 +17,7 @@ import {Interpreter, Machine, interpret} from 'xstate';
 const chain = new ChainWatcher();
 
 const store = new Store(chain);
-
+jest.setTimeout(20_000);
 const mockContext = {
   channelId: randomChannelId(),
   fundedAt: BigNumber.from('0'),

--- a/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
+++ b/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
@@ -1,120 +1,91 @@
-import {ChainWatcher, FakeChain} from '../chain';
-import {Contract, BigNumber} from 'ethers';
+import {ChainWatcher, FakeChain, ChannelChainInfo} from '../chain';
+import {BigNumber} from 'ethers';
 import {randomChannelId} from '@statechannels/nitro-protocol';
 import {CHAIN_NETWORK_ID, CHALLENGE_DURATION, TRIVIAL_APP_ADDRESS} from '../config';
 
-import {first, take} from 'rxjs/operators';
-import {SignedState, State} from '../store';
-import {parseUnits} from '@ethersproject/units';
+import {first, take, map} from 'rxjs/operators';
+import {SignedState, State, Store} from '../store';
 
 import {simpleEthAllocation} from '../utils';
 import {Player} from '../integration-tests/helpers';
 import {createSignatureEntry, calculateChannelId, statesEqual} from '../store/state-utils';
 import {hexZeroPad} from '@ethersproject/bytes';
-import {Zero} from '@ethersproject/constants';
+import {Zero, One} from '@ethersproject/constants';
+
+import {Interpreter, Machine, interpret} from 'xstate';
 
 const chain = new ChainWatcher();
 
-// const store = new Store(chain);
+const store = new Store(chain);
 
 const mockContext = {
   channelId: randomChannelId(),
   fundedAt: BigNumber.from('0'),
   depositAt: BigNumber.from('0')
 };
-// type Init = {
-//   channelId: string;
-//   depositAt: BigNumber;
-//   totalAfterDeposit: BigNumber;
-//   fundedAt: BigNumber;
-// };
+type Init = {
+  channelId: string;
+  depositAt: BigNumber;
+  totalAfterDeposit: BigNumber;
+  fundedAt: BigNumber;
+};
 
-// const provider = new JsonRpcProvider(`http://localhost:${process.env.GANACHE_PORT}`);
-
-let ETHAssetHolder: Contract;
-// let service: Interpreter<any, any, any, any>;
+let service: Interpreter<any, any, any, any>;
 
 // this service to be invoked by a protocol xstate machine
-// const subscribeDepositEvent = (ctx: Init) =>
-//   store.chain.chainUpdatedFeed(ctx.channelId).pipe(
-//     map((chainInfo: ChannelChainInfo) => {
-//       if (chainInfo.amount.gte(ctx.fundedAt)) {
-//         return 'FUNDED';
-//       } else if (chainInfo.amount.gte(ctx.depositAt)) {
-//         return 'SAFE_TO_DEPOSIT';
-//       } else {
-//         return 'NOT_SAFE_TO_DEPOSIT';
-//       }
-//     })
-//   );
+const subscribeDepositEvent = (ctx: Init) =>
+  store.chain.chainUpdatedFeed(ctx.channelId).pipe(
+    map((chainInfo: ChannelChainInfo) => {
+      if (chainInfo.amount.gte(ctx.fundedAt)) {
+        return 'FUNDED';
+      } else if (chainInfo.amount.gte(ctx.depositAt)) {
+        return 'SAFE_TO_DEPOSIT';
+      } else {
+        return 'NOT_SAFE_TO_DEPOSIT';
+      }
+    })
+  );
 
 const fundedEventSent = jest.fn();
-// const safeToDepositEventSent = jest.fn();
-// const notSafeToDepositEventSent = jest.fn();
+const safeToDepositEventSent = jest.fn();
+const notSafeToDepositEventSent = jest.fn();
 
-// const mockMachine = Machine({
-//   initial: 'init',
-//   context: mockContext,
-//   states: {
-//     init: {
-//       invoke: {
-//         src: subscribeDepositEvent
-//       },
-//       on: {
-//         FUNDED: {actions: fundedEventSent},
-//         SAFE_TO_DEPOSIT: {actions: safeToDepositEventSent},
-//         NOT_SAFE_TO_DEPOSIT: {actions: notSafeToDepositEventSent}
-//       }
-//     }
-//   }
-// });
+const mockMachine = Machine({
+  initial: 'init',
+  context: mockContext,
+  states: {
+    init: {
+      invoke: {
+        src: subscribeDepositEvent
+      },
+      on: {
+        FUNDED: {actions: fundedEventSent},
+        SAFE_TO_DEPOSIT: {actions: safeToDepositEventSent},
+        NOT_SAFE_TO_DEPOSIT: {actions: notSafeToDepositEventSent}
+      }
+    }
+  }
+});
 
 beforeAll(async () => {
   (window as any).ethereum = {
     enable: () => ['0xfec44e15328B7d1d8885a8226b0858964358F1D6'],
     fake: true
   };
-  chain.ethereumEnable();
+  await chain.ethereumEnable();
   await chain.initialize();
-  // const signer = await provider.getSigner('0x28bF45680cA598708E5cDACc1414FCAc04a3F1ed');
-  // ETHAssetHolder = new Contract(
-  //   ETH_ASSET_HOLDER_ADDRESS,
-  //   ContractArtifacts.EthAssetHolderArtifact.abi,
-  //   signer
-  // );
-  // service = interpret(mockMachine).start(); // observable should be subscribed to on entering initial state
+  service = interpret(mockMachine).start(); // observable should be subscribed to on entering initial state
 });
 
-// afterEach(() => {
-//   service.stop();
-// });
-// TODO: figure out why this is failing
-// eslint-disable-next-line jest/no-disabled-tests
-it.skip('subscribes to chainUpdateFeed via a subscribeDepositEvent Observable, and sends correct event to xstate machine after a deposit', async () => {
+afterEach(() => {
+  service.stop();
+});
+
+it('subscribes to chainUpdateFeed via a subscribeDepositEvent Observable, and sends correct event to xstate machine after a deposit', async () => {
   // const ethDepositedFilter = ETHAssetHolder.filters.Deposited();
 
-  const depositEvent = new Promise((resolve, reject) => {
-    ETHAssetHolder.on('Deposited', (from, to, amount, event) => {
-      event.removeListener();
-      resolve();
-    });
+  await chain.deposit(mockContext.channelId, Zero.toHexString(), One.toHexString());
 
-    setTimeout(() => {
-      reject(new Error('timeout'));
-    }, 60000);
-  });
-
-  const tx = ETHAssetHolder.deposit(
-    mockContext.channelId, // destination
-    parseUnits('0', 'wei'), // expectedHeld
-    parseUnits('1', 'wei'), // amount
-    {
-      value: parseUnits('1', 'wei') // msgValue
-    }
-  );
-
-  await (await tx).wait(); // wait for tx to be mined
-  await depositEvent; // wait for this test to detect the event being fired
   expect(fundedEventSent).toHaveBeenCalled();
 });
 
@@ -158,6 +129,7 @@ it('correctly crafts a forceMove transaction (1x double-signed state)', async ()
     ...state,
     signatures: [playerA, playerB].map(({privateKey}) => createSignatureEntry(state, privateKey))
   };
+  4;
   const support = [allSignState];
   const result = await chain.challenge(support, playerA.privateKey);
   expect(result?.length).toBeGreaterThan(0);

--- a/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
+++ b/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
@@ -170,7 +170,6 @@ it('the challenge state gets returned when there is an existing challenge', asyn
     participants: [playerA.participant, playerB.participant]
   };
 
-  // const channelId = calculateChannelId(state);
   const allSignState: SignedState = {
     ...state,
     signatures: [playerA, playerB].map(({privateKey}) => createSignatureEntry(state, privateKey))

--- a/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
+++ b/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
@@ -1,97 +1,96 @@
-import {ChainWatcher, ChannelChainInfo, FakeChain} from '../chain';
+import {ChainWatcher, FakeChain} from '../chain';
 import {Contract, BigNumber} from 'ethers';
-import {ContractArtifacts, randomChannelId} from '@statechannels/nitro-protocol';
-import {
-  ETH_ASSET_HOLDER_ADDRESS,
-  CHAIN_NETWORK_ID,
-  CHALLENGE_DURATION,
-  TRIVIAL_APP_ADDRESS
-} from '../config';
-import {Machine, interpret, Interpreter} from 'xstate';
-import {map} from 'rxjs/operators';
-import {Store, SignedState, State} from '../store';
+import {randomChannelId} from '@statechannels/nitro-protocol';
+import {CHAIN_NETWORK_ID, CHALLENGE_DURATION, TRIVIAL_APP_ADDRESS} from '../config';
+
+import {first, take} from 'rxjs/operators';
+import {SignedState, State} from '../store';
 import {parseUnits} from '@ethersproject/units';
-import {JsonRpcProvider} from '@ethersproject/providers';
+
 import {simpleEthAllocation} from '../utils';
 import {Player} from '../integration-tests/helpers';
-import {createSignatureEntry} from '../store/state-utils';
+import {createSignatureEntry, calculateChannelId, statesEqual} from '../store/state-utils';
 import {hexZeroPad} from '@ethersproject/bytes';
 import {Zero} from '@ethersproject/constants';
 
 const chain = new ChainWatcher();
 
-const store = new Store(chain);
+// const store = new Store(chain);
 
 const mockContext = {
   channelId: randomChannelId(),
   fundedAt: BigNumber.from('0'),
   depositAt: BigNumber.from('0')
 };
-type Init = {
-  channelId: string;
-  depositAt: BigNumber;
-  totalAfterDeposit: BigNumber;
-  fundedAt: BigNumber;
-};
+// type Init = {
+//   channelId: string;
+//   depositAt: BigNumber;
+//   totalAfterDeposit: BigNumber;
+//   fundedAt: BigNumber;
+// };
 
-const provider = new JsonRpcProvider(`http://localhost:${process.env.GANACHE_PORT}`);
+// const provider = new JsonRpcProvider(`http://localhost:${process.env.GANACHE_PORT}`);
 
 let ETHAssetHolder: Contract;
-let service: Interpreter<any, any, any, any>;
+// let service: Interpreter<any, any, any, any>;
 
 // this service to be invoked by a protocol xstate machine
-const subscribeDepositEvent = (ctx: Init) =>
-  store.chain.chainUpdatedFeed(ctx.channelId).pipe(
-    map((chainInfo: ChannelChainInfo) => {
-      if (chainInfo.amount.gte(ctx.fundedAt)) {
-        return 'FUNDED';
-      } else if (chainInfo.amount.gte(ctx.depositAt)) {
-        return 'SAFE_TO_DEPOSIT';
-      } else {
-        return 'NOT_SAFE_TO_DEPOSIT';
-      }
-    })
-  );
+// const subscribeDepositEvent = (ctx: Init) =>
+//   store.chain.chainUpdatedFeed(ctx.channelId).pipe(
+//     map((chainInfo: ChannelChainInfo) => {
+//       if (chainInfo.amount.gte(ctx.fundedAt)) {
+//         return 'FUNDED';
+//       } else if (chainInfo.amount.gte(ctx.depositAt)) {
+//         return 'SAFE_TO_DEPOSIT';
+//       } else {
+//         return 'NOT_SAFE_TO_DEPOSIT';
+//       }
+//     })
+//   );
 
 const fundedEventSent = jest.fn();
-const safeToDepositEventSent = jest.fn();
-const notSafeToDepositEventSent = jest.fn();
+// const safeToDepositEventSent = jest.fn();
+// const notSafeToDepositEventSent = jest.fn();
 
-const mockMachine = Machine({
-  initial: 'init',
-  context: mockContext,
-  states: {
-    init: {
-      invoke: {
-        src: subscribeDepositEvent
-      },
-      on: {
-        FUNDED: {actions: fundedEventSent},
-        SAFE_TO_DEPOSIT: {actions: safeToDepositEventSent},
-        NOT_SAFE_TO_DEPOSIT: {actions: notSafeToDepositEventSent}
-      }
-    }
-  }
-});
+// const mockMachine = Machine({
+//   initial: 'init',
+//   context: mockContext,
+//   states: {
+//     init: {
+//       invoke: {
+//         src: subscribeDepositEvent
+//       },
+//       on: {
+//         FUNDED: {actions: fundedEventSent},
+//         SAFE_TO_DEPOSIT: {actions: safeToDepositEventSent},
+//         NOT_SAFE_TO_DEPOSIT: {actions: notSafeToDepositEventSent}
+//       }
+//     }
+//   }
+// });
 
 beforeAll(async () => {
-  (window as any).ethereum = {enable: () => ['0xfec44e15328B7d1d8885a8226b0858964358F1D6']};
+  (window as any).ethereum = {
+    enable: () => ['0xfec44e15328B7d1d8885a8226b0858964358F1D6'],
+    fake: true
+  };
   chain.ethereumEnable();
-
-  const signer = await provider.getSigner('0x28bF45680cA598708E5cDACc1414FCAc04a3F1ed');
-  ETHAssetHolder = new Contract(
-    ETH_ASSET_HOLDER_ADDRESS,
-    ContractArtifacts.EthAssetHolderArtifact.abi,
-    signer
-  );
-  service = interpret(mockMachine).start(); // observable should be subscribed to on entering initial state
+  await chain.initialize();
+  // const signer = await provider.getSigner('0x28bF45680cA598708E5cDACc1414FCAc04a3F1ed');
+  // ETHAssetHolder = new Contract(
+  //   ETH_ASSET_HOLDER_ADDRESS,
+  //   ContractArtifacts.EthAssetHolderArtifact.abi,
+  //   signer
+  // );
+  // service = interpret(mockMachine).start(); // observable should be subscribed to on entering initial state
 });
 
-afterEach(() => {
-  service.stop();
-});
-
-it('subscribes to chainUpdateFeed via a subscribeDepositEvent Observable, and sends correct event to xstate machine after a deposit', async () => {
+// afterEach(() => {
+//   service.stop();
+// });
+// TODO: figure out why this is failing
+// eslint-disable-next-line jest/no-disabled-tests
+it.skip('subscribes to chainUpdateFeed via a subscribeDepositEvent Observable, and sends correct event to xstate machine after a deposit', async () => {
   // const ethDepositedFilter = ETHAssetHolder.filters.Deposited();
 
   const depositEvent = new Promise((resolve, reject) => {
@@ -164,6 +163,110 @@ it('correctly crafts a forceMove transaction (1x double-signed state)', async ()
   expect(result?.length).toBeGreaterThan(0);
 });
 
+it('the challenge state gets returned when there is an existing challenge', async () => {
+  const playerA = await Player.createPlayer(
+    '0x275a2e2cd9314f53b42246694034a80119963097e3adf495fbf6d821dc8b6c8e',
+    'PlayerA',
+    chain
+  );
+  const playerB = await Player.createPlayer(
+    '0x3341c348ea8ade1ba7c3b6f071bfe9635c544b7fb5501797eaa2f673169a7d0d',
+    'PlayerB',
+    chain
+  );
+
+  const outcome = simpleEthAllocation([
+    {
+      destination: playerA.destination,
+      amount: BigNumber.from(hexZeroPad('0x06f05b59d3b20000', 32))
+    },
+    {
+      destination: playerA.destination,
+      amount: BigNumber.from(hexZeroPad('0x06f05b59d3b20000', 32))
+    }
+  ]);
+
+  const state: State = {
+    outcome,
+    turnNum: BigNumber.from(5),
+    appData: '0x0',
+    isFinal: false,
+    challengeDuration: CHALLENGE_DURATION,
+    chainId: CHAIN_NETWORK_ID,
+    channelNonce: BigNumber.from(4),
+    appDefinition: TRIVIAL_APP_ADDRESS, // TODO point at a deployed contract
+    participants: [playerA.participant, playerB.participant]
+  };
+
+  // const channelId = calculateChannelId(state);
+  const allSignState: SignedState = {
+    ...state,
+    signatures: [playerA, playerB].map(({privateKey}) => createSignatureEntry(state, privateKey))
+  };
+  const support = [allSignState];
+
+  await chain.challenge(support, playerA.privateKey);
+  const channelId = calculateChannelId(state);
+  const chainEntry = await chain
+    .chainUpdatedFeed(channelId)
+    .pipe(first())
+    .toPromise();
+  expect(chainEntry.challengeState).toBeDefined();
+  expect(statesEqual(state, chainEntry.challengeState as State)).toBe(true);
+});
+
+it('the chainUpdated fires and returns a challenge state when a challenge occurs', async () => {
+  const playerA = await Player.createPlayer(
+    '0x275a2e2cd9314f53b42246694034a80119963097e3adf495fbf6d821dc8b6c8e',
+    'PlayerA',
+    chain
+  );
+  const playerB = await Player.createPlayer(
+    '0x3341c348ea8ade1ba7c3b6f071bfe9635c544b7fb5501797eaa2f673169a7d0d',
+    'PlayerB',
+    chain
+  );
+
+  const outcome = simpleEthAllocation([
+    {
+      destination: playerA.destination,
+      amount: BigNumber.from(hexZeroPad('0x06f05b59d3b20000', 32))
+    },
+    {
+      destination: playerA.destination,
+      amount: BigNumber.from(hexZeroPad('0x06f05b59d3b20000', 32))
+    }
+  ]);
+
+  const state: State = {
+    outcome,
+    turnNum: BigNumber.from(5),
+    appData: '0x0',
+    isFinal: false,
+    challengeDuration: CHALLENGE_DURATION,
+    chainId: CHAIN_NETWORK_ID,
+    channelNonce: BigNumber.from(3),
+    appDefinition: TRIVIAL_APP_ADDRESS, // TODO point at a deployed contract
+    participants: [playerA.participant, playerB.participant]
+  };
+
+  // const channelId = calculateChannelId(state);
+  const allSignState: SignedState = {
+    ...state,
+    signatures: [playerA, playerB].map(({privateKey}) => createSignatureEntry(state, privateKey))
+  };
+  const support = [allSignState];
+  const channelId = calculateChannelId(state);
+  const chainEntryPromise = chain
+    .chainUpdatedFeed(channelId)
+    .pipe(take(1))
+    .toPromise();
+
+  await chain.challenge(support, playerA.privateKey);
+  const chainEntry = await chainEntryPromise;
+  expect(chainEntry.challengeState).toBeDefined();
+  expect(statesEqual(state, chainEntry.challengeState as State)).toBe(true);
+});
 it('correctly crafts a forceMove transaction (2x single-signed states)', async () => {
   const fakeChain = new FakeChain();
   const playerA = await Player.createPlayer(

--- a/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
+++ b/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
@@ -3,7 +3,7 @@ import {BigNumber} from 'ethers';
 import {randomChannelId} from '@statechannels/nitro-protocol';
 import {CHAIN_NETWORK_ID, CHALLENGE_DURATION, TRIVIAL_APP_ADDRESS} from '../config';
 
-import {first, take, map} from 'rxjs/operators';
+import {take, map} from 'rxjs/operators';
 import {SignedState, State, Store} from '../store';
 
 import {simpleEthAllocation} from '../utils';
@@ -178,9 +178,10 @@ it('the challenge state gets returned when there is an existing challenge', asyn
 
   await chain.challenge(support, playerA.privateKey);
   const channelId = calculateChannelId(state);
+
   const chainEntry = await chain
     .chainUpdatedFeed(channelId)
-    .pipe(first())
+    .pipe(take(1))
     .toPromise();
   expect(chainEntry.challengeState).toBeDefined();
   expect(statesEqual(state, chainEntry.challengeState as State)).toBe(true);
@@ -228,13 +229,13 @@ it('the chainUpdated fires and returns a challenge state when a challenge occurs
   };
   const support = [allSignState];
   const channelId = calculateChannelId(state);
-  const chainEntryPromise = chain
-    .chainUpdatedFeed(channelId)
-    .pipe(take(1))
-    .toPromise();
 
   await chain.challenge(support, playerA.privateKey);
-  const chainEntry = await chainEntryPromise;
+  const chainEntry = await chain
+    .chainUpdatedFeed(channelId)
+    .pipe(take(2))
+    .toPromise();
+
   expect(chainEntry.challengeState).toBeDefined();
   expect(statesEqual(state, chainEntry.challengeState as State)).toBe(true);
 });

--- a/packages/xstate-wallet/src/utils/contract-utils.ts
+++ b/packages/xstate-wallet/src/utils/contract-utils.ts
@@ -22,7 +22,7 @@ export function tokenAddress(assetHolderAddress: string): string | undefined {
 }
 
 export function getProvider(): Web3Provider | JsonRpcProvider {
-  if (window.ethereum) {
+  if (window.ethereum && !window.ethereum.fake) {
     return new Web3Provider(window.ethereum);
   } else {
     return new JsonRpcProvider(`http://localhost:${process.env.GANACHE_PORT}`);

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -370,8 +370,8 @@ export const workflow = (
     channelClosing: (_: ChannelIdExists, event: ChannelUpdated): boolean =>
       !!event.storeEntry.latest?.isFinal, // TODO: Should use supported
 
-    channelChallenging: (context: ChannelIdExists, event: ChannelUpdated): boolean =>
-      !!event.storeEntry.isChallenging,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    channelChallenging: (_context: ChannelIdExists, _event: ChannelUpdated): boolean => false,
 
     channelClosed: (_, event: any): boolean => !!event.storeEntry.supported?.isFinal,
     isDirectFunding: (ctx: Init) => ctx.fundingStrategy === 'Direct',

--- a/packages/xstate-wallet/src/workflows/challenge-channel.ts
+++ b/packages/xstate-wallet/src/workflows/challenge-channel.ts
@@ -91,10 +91,9 @@ const submitChallengeTransaction = (store: Store) => async ({channelId}: Initial
 
 const observeOnChainChannelStorage = (store: Store, channelId: string) =>
   store.chain.chainUpdatedFeed(channelId).pipe(
-    map<ChannelChainInfo, ChainEvent>(({finalized, channelStorage}) => ({
+    map<ChannelChainInfo, ChainEvent>(event => ({
       type: 'CHAIN_EVENT',
-      finalized,
-      ...channelStorage
+      ...event
     }))
   );
 

--- a/packages/xstate-wallet/src/workflows/tests/challenge.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/challenge.test.ts
@@ -79,9 +79,7 @@ it('initializes and starts challenge thing', async () => {
 
   await waitForExpect(async () => {
     expect(service.state.value).toEqual('waitForResponseOrTimeout');
-    const {
-      channelStorage: {finalizesAt, turnNumRecord}
-    } = await fakeChain.getChainInfo(channelId);
+    const {finalizesAt, turnNumRecord} = await fakeChain.getChainInfo(channelId);
     expect(finalizesAt).toStrictEqual(state.challengeDuration.add(1));
     expect(turnNumRecord).toStrictEqual(state.turnNum);
   }, 10000);


### PR DESCRIPTION
Fixes #1915

This implements / refactors some plumbing around challenges.

The biggest change is that everything is now accessed via the `ChainUpdatedFeed`. 
Also the feed will now query for existing challenges/cleared challenges on start up.

There is now [work](https://github.com/statechannels/monorepo/issues/1960) to do to properly implement challenging/responding in the application workflow. 

TODO
- [x] Handle challenge cleared
- [x] Clean up interface and types
- [x] Handle challenge expiry