### PR TITLE
Get Challenge Transaction Working

### DIFF
--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -48,7 +48,7 @@ contract ForceMove is IForceMove {
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat,
         Signature memory challengerSig
-    ) public {
+    ) public override {
         bytes32 channelId = _getChannelId(fixedPart);
 
         if (_mode(channelId) == ChannelMode.Open) {
@@ -116,7 +116,7 @@ contract ForceMove is IForceMove {
         // variablePartAB[0] = challengeVariablePart
         // variablePartAB[1] = responseVariablePart
         Signature memory sig
-    ) public {
+    ) public override{
         bytes32 channelId = _getChannelId(fixedPart);
         (uint48 turnNumRecord, uint48 finalizesAt, ) = _getData(channelId);
 
@@ -188,7 +188,7 @@ contract ForceMove is IForceMove {
         uint8 isFinalCount, // how many of the states are final
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat
-    ) public {
+    ) public override{
         bytes32 channelId = _getChannelId(fixedPart);
 
         // checks
@@ -227,7 +227,7 @@ contract ForceMove is IForceMove {
         uint8 numStates,
         uint8[] memory whoSignedWhat,
         Signature[] memory sigs
-    ) public {
+    ) public override {
         bytes32 channelId = _getChannelId(fixedPart);
         _requireChannelNotFinalized(channelId);
 

--- a/packages/nitro-protocol/contracts/ForceMove.sol
+++ b/packages/nitro-protocol/contracts/ForceMove.sol
@@ -4,22 +4,23 @@ pragma experimental ABIEncoderV2;
 import './interfaces/IForceMove.sol';
 import './interfaces/ForceMoveApp.sol';
 
+
 /**
-  * @dev An implementation of ForceMove protocol, which allows state channels to be adjudicated and finalized.
-*/
+ * @dev An implementation of ForceMove protocol, which allows state channels to be adjudicated and finalized.
+ */
 contract ForceMove is IForceMove {
     mapping(bytes32 => bytes32) public channelStorageHashes;
 
     // Public methods:
 
     /**
-    * @notice Unpacks turnNumRecord, finalizesAt and fingerprint from the channelStorageHash of a particular channel.
-    * @dev Unpacks turnNumRecord, finalizesAt and fingerprint from the channelStorageHash of a particular channel.
-    * @param channelId Unique identifier for a state channel.
-    * @return turnNumRecord A turnNum that (the adjudicator knows) is supported by a signature from each participant.
-    * @return finalizesAt The unix timestamp when `channelId` will finalize.
-    * @return fingerprint Unique identifier for the channel's current state, up to hash collisions.
-    */
+     * @notice Unpacks turnNumRecord, finalizesAt and fingerprint from the channelStorageHash of a particular channel.
+     * @dev Unpacks turnNumRecord, finalizesAt and fingerprint from the channelStorageHash of a particular channel.
+     * @param channelId Unique identifier for a state channel.
+     * @return turnNumRecord A turnNum that (the adjudicator knows) is supported by a signature from each participant.
+     * @return finalizesAt The unix timestamp when `channelId` will finalize.
+     * @return fingerprint Unique identifier for the channel's current state, up to hash collisions.
+     */
     function getData(bytes32 channelId)
         public
         view
@@ -29,16 +30,16 @@ contract ForceMove is IForceMove {
     }
 
     /**
-    * @notice Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
-    * @dev Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
-    * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-    * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
-    * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
-    * @param isFinalCount Describes how many of the submitted states have the `isFinal` property set to `true`. It is implied that the rightmost `isFinalCount` states are final, and the rest are not final.
-    * @param sigs An array of signatures that support the state with the `largestTurnNum`.
-    * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
-    * @param challengerSig The signature of a participant on the keccak256 of the abi.encode of (supportedStateHash, 'forceMove').
-    */
+     * @notice Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
+     * @dev Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
+     * @param fixedPart Data describing properties of the state channel that do not change with state updates.
+     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
+     * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
+     * @param isFinalCount Describes how many of the submitted states have the `isFinal` property set to `true`. It is implied that the rightmost `isFinalCount` states are final, and the rest are not final.
+     * @param sigs An array of signatures that support the state with the `largestTurnNum`. There must be one for each participant, e.g.: [sig-from-p0, sig-from-p1, ...]
+     * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
+     * @param challengerSig The signature of a participant on the keccak256 of the abi.encode of (supportedStateHash, 'forceMove').
+     */
     function forceMove(
         FixedPart memory fixedPart,
         uint48 largestTurnNum,
@@ -47,7 +48,7 @@ contract ForceMove is IForceMove {
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat,
         Signature memory challengerSig
-    ) public override {
+    ) public {
         bytes32 channelId = _getChannelId(fixedPart);
 
         if (_mode(channelId) == ChannelMode.Open) {
@@ -96,18 +97,17 @@ contract ForceMove is IForceMove {
                 keccak256(abi.encode(variableParts[variableParts.length - 1].outcome))
             )
         );
-
     }
 
     /**
-    * @notice Repsonds to an ongoing challenge registered against a state channel.
-    * @dev Repsonds to an ongoing challenge registered against a state channel.
-    * @param challenger The address of the participant whom registered the challenge.
-    * @param isFinalAB An pair of booleans describing if the challenge state and/or the response state have the `isFinal` property set to `true`.
-    * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-    * @param variablePartAB An pair of structs, each decribing the properties of the state channel that may change with each state update (for the challenge state and for the response state).
-    * @param sig The responder's signature on the `responseStateHash`.
-    */
+     * @notice Repsonds to an ongoing challenge registered against a state channel.
+     * @dev Repsonds to an ongoing challenge registered against a state channel.
+     * @param challenger The address of the participant whom registered the challenge.
+     * @param isFinalAB An pair of booleans describing if the challenge state and/or the response state have the `isFinal` property set to `true`.
+     * @param fixedPart Data describing properties of the state channel that do not change with state updates.
+     * @param variablePartAB An pair of structs, each decribing the properties of the state channel that may change with each state update (for the challenge state and for the response state).
+     * @param sig The responder's signature on the `responseStateHash`.
+     */
     function respond(
         address challenger,
         bool[2] memory isFinalAB,
@@ -116,7 +116,7 @@ contract ForceMove is IForceMove {
         // variablePartAB[0] = challengeVariablePart
         // variablePartAB[1] = responseVariablePart
         Signature memory sig
-    ) public override {
+    ) public {
         bytes32 channelId = _getChannelId(fixedPart);
         (uint48 turnNumRecord, uint48 finalizesAt, ) = _getData(channelId);
 
@@ -172,15 +172,15 @@ contract ForceMove is IForceMove {
     }
 
     /**
-    * @notice Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
-    * @dev Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
-    * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-    * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
-    * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
-    * @param isFinalCount Describes how many of the submitted states have the `isFinal` property set to `true`. It is implied that the rightmost `isFinalCount` states are final, and the rest are not final.
-    * @param sigs An array of signatures that support the state with the `largestTurnNum`.
-    * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
-    */
+     * @notice Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
+     * @dev Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
+     * @param fixedPart Data describing properties of the state channel that do not change with state updates.
+     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
+     * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
+     * @param isFinalCount Describes how many of the submitted states have the `isFinal` property set to `true`. It is implied that the rightmost `isFinalCount` states are final, and the rest are not final.
+     * @param sigs An array of signatures that support the state with the `largestTurnNum`.
+     * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
+     */
     function checkpoint(
         FixedPart memory fixedPart,
         uint48 largestTurnNum,
@@ -188,7 +188,7 @@ contract ForceMove is IForceMove {
         uint8 isFinalCount, // how many of the states are final
         Signature[] memory sigs,
         uint8[] memory whoSignedWhat
-    ) public override {
+    ) public {
         bytes32 channelId = _getChannelId(fixedPart);
 
         // checks
@@ -206,20 +206,19 @@ contract ForceMove is IForceMove {
 
         // effects
         _clearChallenge(channelId, largestTurnNum);
-
     }
 
     /**
-    * @notice Finalizes a channel by providing a finalization proof.
-    * @dev Finalizes a channel by providing a finalization proof.
-    * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
-    * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-    * @param appPartHash The keccak256 of the abi.encode of `(challengeDuration, appDefinition, appData)`. Applies to all states in the finalization proof.
-    * @param outcomeHash The keccak256 of the abi.encode of the `outcome`. Applies to all stats in the finalization proof.
-    * @param numStates The number of states in the finalization proof.
-    * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
-    * @param sigs An array of signatures that support the state with the `largestTurnNum`.
-    */
+     * @notice Finalizes a channel by providing a finalization proof.
+     * @dev Finalizes a channel by providing a finalization proof.
+     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
+     * @param fixedPart Data describing properties of the state channel that do not change with state updates.
+     * @param appPartHash The keccak256 of the abi.encode of `(challengeDuration, appDefinition, appData)`. Applies to all states in the finalization proof.
+     * @param outcomeHash The keccak256 of the abi.encode of the `outcome`. Applies to all stats in the finalization proof.
+     * @param numStates The number of states in the finalization proof.
+     * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
+     * @param sigs An array of signatures that support the state with the `largestTurnNum`.
+     */
     function conclude(
         uint48 largestTurnNum,
         FixedPart memory fixedPart,
@@ -228,7 +227,7 @@ contract ForceMove is IForceMove {
         uint8 numStates,
         uint8[] memory whoSignedWhat,
         Signature[] memory sigs
-    ) public override {
+    ) public {
         bytes32 channelId = _getChannelId(fixedPart);
         _requireChannelNotFinalized(channelId);
 
@@ -270,12 +269,12 @@ contract ForceMove is IForceMove {
     // Internal methods:
 
     /**
-    * @notice Checks that the challengerSignature was created by one of the supplied participants.
-    * @dev Checks that the challengerSignature was created by one of the supplied participants.
-    * @param supportedStateHash Forms part of the digest to be signed, along with the string 'forceMove'.
-    * @param participants A list of addresses representing the participants of a channel.
-    * @param challengerSignature The signature of a participant on the keccak256 of the abi.encode of (supportedStateHash, 'forceMove').
-    */
+     * @notice Checks that the challengerSignature was created by one of the supplied participants.
+     * @dev Checks that the challengerSignature was created by one of the supplied participants.
+     * @param supportedStateHash Forms part of the digest to be signed, along with the string 'forceMove'.
+     * @param participants A list of addresses representing the participants of a channel.
+     * @param challengerSignature The signature of a participant on the keccak256 of the abi.encode of (supportedStateHash, 'forceMove').
+     */
     function _requireChallengerIsParticipant(
         bytes32 supportedStateHash,
         address[] memory participants,
@@ -289,12 +288,12 @@ contract ForceMove is IForceMove {
     }
 
     /**
-    * @notice Tests whether a given address is in a given array of addresses.
-    * @dev Tests whether a given address is in a given array of addresses.
-    * @param suspect A single address of interest.
-    * @param addresses A line-up of possible perpetrators.
-    * @return true if the address is in the array, false otherwise
-    */
+     * @notice Tests whether a given address is in a given array of addresses.
+     * @dev Tests whether a given address is in a given array of addresses.
+     * @param suspect A single address of interest.
+     * @param addresses A line-up of possible perpetrators.
+     * @return true if the address is in the array, false otherwise
+     */
     function _isAddressInArray(address suspect, address[] memory addresses)
         internal
         pure
@@ -309,15 +308,15 @@ contract ForceMove is IForceMove {
     }
 
     /**
-    * @notice Given an array of state hashes, checks the validity of the supplied signatures. Valid means there is a signature for each participant, either on the hash of the state for which they are a mover, or on the hash of a state that appears after that state in the array.
-    * @dev Given an array of state hashes, checks the validity of the supplied signatures. Valid means there is a signature for each participant, either on the hash of the state for which they are a mover, or on the hash of a state that appears after that state in the array.
-    * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
-    * @param participants A list of addresses representing the participants of a channel.
-    * @param stateHashes Array of keccak256(State) submitted in support of a state,
-    * @param sigs Array of Signatures, one for each participant
-    * @param whoSignedWhat participant[i] signed stateHashes[whoSignedWhat[i]]
-    * @return true if the signatures are valid, false otherwise
-    */
+     * @notice Given an array of state hashes, checks the validity of the supplied signatures. Valid means there is a signature for each participant, either on the hash of the state for which they are a mover, or on the hash of a state that appears after that state in the array.
+     * @dev Given an array of state hashes, checks the validity of the supplied signatures. Valid means there is a signature for each participant, either on the hash of the state for which they are a mover, or on the hash of a state that appears after that state in the array.
+     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
+     * @param participants A list of addresses representing the participants of a channel.
+     * @param stateHashes Array of keccak256(State) submitted in support of a state,
+     * @param sigs Array of Signatures, one for each participant
+     * @param whoSignedWhat participant[i] signed stateHashes[whoSignedWhat[i]]
+     * @return true if the signatures are valid, false otherwise
+     */
     function _validSignatures(
         uint256 largestTurnNum,
         address[] memory participants,
@@ -342,14 +341,14 @@ contract ForceMove is IForceMove {
     }
 
     /**
-    * @notice Given a declaration of which state in the support proof was signed by which participant, check if this declaration is acceptable. Acceptable means there is a signature for each participant, either on the hash of the state for which they are a mover, or on the hash of a state that appears after that state in the array.
-    * @dev Given a declaration of which state in the support proof was signed by which participant, check if this declaration is acceptable. Acceptable means there is a signature for each participant, either on the hash of the state for which they are a mover, or on the hash of a state that appears after that state in the array.
-    * @param whoSignedWhat participant[i] signed stateHashes[whoSignedWhat[i]]
-    * @param largestTurnNum Largest turnNum of the support proof
-    * @param nParticipants Number of participants in the channel
-    * @param nStates Number of states in the support proof
-    * @return true if whoSignedWhat is acceptable, false otherwise
-    */
+     * @notice Given a declaration of which state in the support proof was signed by which participant, check if this declaration is acceptable. Acceptable means there is a signature for each participant, either on the hash of the state for which they are a mover, or on the hash of a state that appears after that state in the array.
+     * @dev Given a declaration of which state in the support proof was signed by which participant, check if this declaration is acceptable. Acceptable means there is a signature for each participant, either on the hash of the state for which they are a mover, or on the hash of a state that appears after that state in the array.
+     * @param whoSignedWhat participant[i] signed stateHashes[whoSignedWhat[i]]
+     * @param largestTurnNum Largest turnNum of the support proof
+     * @param nParticipants Number of participants in the channel
+     * @param nStates Number of states in the support proof
+     * @return true if whoSignedWhat is acceptable, false otherwise
+     */
     function _acceptableWhoSignedWhat(
         uint8[] memory whoSignedWhat,
         uint256 largestTurnNum,
@@ -372,32 +371,32 @@ contract ForceMove is IForceMove {
     }
 
     bytes constant prefix = '\x19Ethereum Signed Message:\n32';
+
     /**
-    * @notice Given a digest and ethereum digital signature, recover the signer
-    * @dev Given a digest and digital signature, recover the signer
-    * @param _d message digest
-    * @param sig ethereum digital signature
-    * @return signer
-    */
+     * @notice Given a digest and ethereum digital signature, recover the signer
+     * @dev Given a digest and digital signature, recover the signer
+     * @param _d message digest
+     * @param sig ethereum digital signature
+     * @return signer
+     */
     function _recoverSigner(bytes32 _d, Signature memory sig) internal pure returns (address) {
         bytes32 prefixedHash = keccak256(abi.encodePacked(prefix, _d));
         address a = ecrecover(prefixedHash, sig.v, sig.r, sig.s);
         return (a);
     }
 
-
     /**
-    * @notice Check that the submitted data constitute a support proof.
-    * @dev Check that the submitted data constitute a support proof.
-    * @param largestTurnNum Largest turnNum of the support proof
-    * @param variableParts Variable parts of the states in the support proof
-    * @param isFinalCount How many of the states are final? The final isFinalCount states are implied final, the remainder are implied not final.
-    * @param channelId Unique identifier for a channel.
-    * @param fixedPart Fixed Part of the states in the support proof
-    * @param sigs A signature from each participant.
-    * @param whoSignedWhat participant[i] signed stateHashes[whoSignedWhat[i]]
-    * @return The hash of the latest state in the proof, if supported, else reverts.
-    */
+     * @notice Check that the submitted data constitute a support proof.
+     * @dev Check that the submitted data constitute a support proof.
+     * @param largestTurnNum Largest turnNum of the support proof
+     * @param variableParts Variable parts of the states in the support proof
+     * @param isFinalCount How many of the states are final? The final isFinalCount states are implied final, the remainder are implied not final.
+     * @param channelId Unique identifier for a channel.
+     * @param fixedPart Fixed Part of the states in the support proof
+     * @param sigs A signature from each participant.
+     * @param whoSignedWhat participant[i] signed stateHashes[whoSignedWhat[i]]
+     * @return The hash of the latest state in the proof, if supported, else reverts.
+     */
     function _requireStateSupportedBy(
         uint256 largestTurnNum,
         ForceMoveApp.VariablePart[] memory variableParts,
@@ -430,15 +429,15 @@ contract ForceMove is IForceMove {
     }
 
     /**
-    * @notice Check that the submitted states form a chain of valid transitions
-    * @dev Check that the submitted states form a chain of valid transitions
-    * @param largestTurnNum Largest turnNum of the support proof
-    * @param variableParts Variable parts of the states in the support proof
-    * @param isFinalCount How many of the states are final? The final isFinalCount states are implied final, the remainder are implied not final.
-    * @param channelId Unique identifier for a channel.
-    * @param fixedPart Fixed Part of the states in the support proof
-    * @return true if every state is a validTransition from its predecessor, false otherwise.
-    */
+     * @notice Check that the submitted states form a chain of valid transitions
+     * @dev Check that the submitted states form a chain of valid transitions
+     * @param largestTurnNum Largest turnNum of the support proof
+     * @param variableParts Variable parts of the states in the support proof
+     * @param isFinalCount How many of the states are final? The final isFinalCount states are implied final, the remainder are implied not final.
+     * @param channelId Unique identifier for a channel.
+     * @param fixedPart Fixed Part of the states in the support proof
+     * @return true if every state is a validTransition from its predecessor, false otherwise.
+     */
     function _requireValidTransitionChain(
         // returns stateHashes array if valid
         // else, reverts
@@ -474,7 +473,6 @@ contract ForceMove is IForceMove {
         }
         return stateHashes;
     }
-
 
     /**
     * @notice Check that the submitted pair of states form a valid transition
@@ -532,22 +530,22 @@ contract ForceMove is IForceMove {
     }
 
     /**
-    * @notice Check for equality of two byte strings
-    * @dev Check for equality of two byte strings
-    * @param left One bytes string
-    * @param right The other bytes string
-    * @return true if the bytes are identical, false otherwise.
-    */
+     * @notice Check for equality of two byte strings
+     * @dev Check for equality of two byte strings
+     * @param left One bytes string
+     * @param right The other bytes string
+     * @return true if the bytes are identical, false otherwise.
+     */
     function _bytesEqual(bytes memory left, bytes memory right) internal pure returns (bool) {
         return keccak256(left) == keccak256(right);
     }
 
     /**
-    * @notice Clears a challenge by updating the turnNumRecord and resetting the remaining channel storage fields, and emits a ChallengeCleared event.
-    * @dev Clears a challenge by updating the turnNumRecord and resetting the remaining channel storage fields, and emits a ChallengeCleared event.
-    * @param channelId Unique identifier for a channel.
-    * @param newTurnNumRecord New turnNumRecord to overwrite existing value
-    */
+     * @notice Clears a challenge by updating the turnNumRecord and resetting the remaining channel storage fields, and emits a ChallengeCleared event.
+     * @dev Clears a challenge by updating the turnNumRecord and resetting the remaining channel storage fields, and emits a ChallengeCleared event.
+     * @param channelId Unique identifier for a channel.
+     * @param newTurnNumRecord New turnNumRecord to overwrite existing value
+     */
     function _clearChallenge(bytes32 channelId, uint256 newTurnNumRecord) internal {
         channelStorageHashes[channelId] = _hashChannelStorage(
             ChannelStorage(newTurnNumRecord, 0, bytes32(0), address(0), bytes32(0))
@@ -556,22 +554,22 @@ contract ForceMove is IForceMove {
     }
 
     /**
-    * @notice Checks that the submitted turnNumRecord is strictly greater than the turnNumRecord stored on chain.
-    * @dev Checks that the submitted turnNumRecord is strictly greater than the turnNumRecord stored on chain.
-    * @param channelId Unique identifier for a channel.
-    * @param newTurnNumRecord New turnNumRecord intended to overwrite existing value
-    */
+     * @notice Checks that the submitted turnNumRecord is strictly greater than the turnNumRecord stored on chain.
+     * @dev Checks that the submitted turnNumRecord is strictly greater than the turnNumRecord stored on chain.
+     * @param channelId Unique identifier for a channel.
+     * @param newTurnNumRecord New turnNumRecord intended to overwrite existing value
+     */
     function _requireIncreasedTurnNumber(bytes32 channelId, uint48 newTurnNumRecord) internal view {
         (uint48 turnNumRecord, , ) = _getData(channelId);
         require(newTurnNumRecord > turnNumRecord, 'turnNumRecord not increased.');
     }
 
     /**
-    * @notice Checks that the submitted turnNumRecord is greater than or equal to the turnNumRecord stored on chain.
-    * @dev Checks that the submitted turnNumRecord is greater than or equal to the turnNumRecord stored on chain.
-    * @param channelId Unique identifier for a channel.
-    * @param newTurnNumRecord New turnNumRecord intended to overwrite existing value
-    */
+     * @notice Checks that the submitted turnNumRecord is greater than or equal to the turnNumRecord stored on chain.
+     * @dev Checks that the submitted turnNumRecord is greater than or equal to the turnNumRecord stored on chain.
+     * @param channelId Unique identifier for a channel.
+     * @param newTurnNumRecord New turnNumRecord intended to overwrite existing value
+     */
     function _requireNonDecreasedTurnNumber(bytes32 channelId, uint48 newTurnNumRecord)
         internal
         view
@@ -581,59 +579,58 @@ contract ForceMove is IForceMove {
     }
 
     /**
-    * @notice Checks that a given ChannelStorage struct matches the challenge stored on chain, and that the channel is in Challenge mode.
-    * @dev Checks that a given ChannelStorage struct matches the challenge stored on chain, and that the channel is in Challenge mode.
-    * @param cs A given ChannelStorage data structure.
-    * @param channelId Unique identifier for a channel.
-    */
+     * @notice Checks that a given ChannelStorage struct matches the challenge stored on chain, and that the channel is in Challenge mode.
+     * @dev Checks that a given ChannelStorage struct matches the challenge stored on chain, and that the channel is in Challenge mode.
+     * @param cs A given ChannelStorage data structure.
+     * @param channelId Unique identifier for a channel.
+     */
     function _requireSpecificChallenge(ChannelStorage memory cs, bytes32 channelId) internal view {
         _requireMatchingStorage(cs, channelId);
         _requireOngoingChallenge(channelId);
     }
 
-
     /**
-    * @notice Checks that a given channel is in the Challenge mode.
-    * @dev Checks that a given channel is in the Challenge mode.
-    * @param channelId Unique identifier for a channel.
-    */
+     * @notice Checks that a given channel is in the Challenge mode.
+     * @dev Checks that a given channel is in the Challenge mode.
+     * @param channelId Unique identifier for a channel.
+     */
     function _requireOngoingChallenge(bytes32 channelId) internal view {
         require(_mode(channelId) == ChannelMode.Challenge, 'No ongoing challenge.');
     }
 
     /**
-    * @notice Checks that a given channel is NOT in the Finalized mode.
-    * @dev Checks that a given channel is in the Challenge mode.
-    * @param channelId Unique identifier for a channel.
-    */
+     * @notice Checks that a given channel is NOT in the Finalized mode.
+     * @dev Checks that a given channel is in the Challenge mode.
+     * @param channelId Unique identifier for a channel.
+     */
     function _requireChannelNotFinalized(bytes32 channelId) internal view {
         require(_mode(channelId) != ChannelMode.Finalized, 'Channel finalized.');
     }
 
     /**
-    * @notice Checks that a given channel is in the Finalized mode.
-    * @dev Checks that a given channel is in the Challenge mode.
-    * @param channelId Unique identifier for a channel.
-    */
+     * @notice Checks that a given channel is in the Finalized mode.
+     * @dev Checks that a given channel is in the Challenge mode.
+     * @param channelId Unique identifier for a channel.
+     */
     function _requireChannelFinalized(bytes32 channelId) internal view {
         require(_mode(channelId) == ChannelMode.Finalized, 'Channel not finalized.');
     }
 
     /**
-    * @notice Checks that a given channel is in the Open mode.
-    * @dev Checks that a given channel is in the Challenge mode.
-    * @param channelId Unique identifier for a channel.
-    */
+     * @notice Checks that a given channel is in the Open mode.
+     * @dev Checks that a given channel is in the Challenge mode.
+     * @param channelId Unique identifier for a channel.
+     */
     function _requireChannelOpen(bytes32 channelId) internal view {
         require(_mode(channelId) == ChannelMode.Open, 'Channel not open.');
     }
 
     /**
-    * @notice Checks that a given ChannelStorage struct matches the challenge stored on chain.
-    * @dev Checks that a given ChannelStorage struct matches the challenge stored on chain.
-    * @param cs A given ChannelStorage data structure.
-    * @param channelId Unique identifier for a channel.
-    */
+     * @notice Checks that a given ChannelStorage struct matches the challenge stored on chain.
+     * @dev Checks that a given ChannelStorage struct matches the challenge stored on chain.
+     * @param cs A given ChannelStorage data structure.
+     * @param channelId Unique identifier for a channel.
+     */
     function _requireMatchingStorage(ChannelStorage memory cs, bytes32 channelId) internal view {
         require(
             _matchesHash(cs, channelStorageHashes[channelId]),
@@ -642,10 +639,10 @@ contract ForceMove is IForceMove {
     }
 
     /**
-    * @notice Computes the ChannelMode for a given channelId.
-    * @dev Computes the ChannelMode for a given channelId.
-    * @param channelId Unique identifier for a channel.
-    */
+     * @notice Computes the ChannelMode for a given channelId.
+     * @dev Computes the ChannelMode for a given channelId.
+     * @param channelId Unique identifier for a channel.
+     */
     function _mode(bytes32 channelId) internal view returns (ChannelMode) {
         // Note that _getData(someRandomChannelId) returns (0,0,0), which is
         // correct when nobody has written to storage yet.
@@ -661,10 +658,10 @@ contract ForceMove is IForceMove {
     }
 
     /**
-    * @notice Hashes the input data and formats it for on chain storage.
-    * @dev Hashes the input data and formats it for on chain storage.
-    * @param channelStorage ChannelStorage data.
-    */
+     * @notice Hashes the input data and formats it for on chain storage.
+     * @dev Hashes the input data and formats it for on chain storage.
+     * @param channelStorage ChannelStorage data.
+     */
     function _hashChannelStorage(ChannelStorage memory channelStorage)
         internal
         pure
@@ -687,13 +684,13 @@ contract ForceMove is IForceMove {
     }
 
     /**
-    * @notice Unpacks turnNumRecord, finalizesAt and fingerprint from the channelStorageHash of a particular channel.
-    * @dev Unpacks turnNumRecord, finalizesAt and fingerprint from the channelStorageHash of a particular channel.
-    * @param channelId Unique identifier for a state channel.
-    * @return turnNumRecord A turnNum that (the adjudicator knows) is supported by a signature from each participant.
-    * @return finalizesAt The unix timestamp when `channelId` will finalize.
-    * @return fingerprint Unique identifier for the channel's current state, up to hash collisions.
-    */
+     * @notice Unpacks turnNumRecord, finalizesAt and fingerprint from the channelStorageHash of a particular channel.
+     * @dev Unpacks turnNumRecord, finalizesAt and fingerprint from the channelStorageHash of a particular channel.
+     * @param channelId Unique identifier for a state channel.
+     * @return turnNumRecord A turnNum that (the adjudicator knows) is supported by a signature from each participant.
+     * @return finalizesAt The unix timestamp when `channelId` will finalize.
+     * @return fingerprint Unique identifier for the channel's current state, up to hash collisions.
+     */
     function _getData(bytes32 channelId)
         internal
         view
@@ -707,26 +704,26 @@ contract ForceMove is IForceMove {
     }
 
     /**
-    * @notice Checks that a given ChannelStorage struct matches a supplied bytes32 when formatted for storage.
-    * @dev Checks that a given ChannelStorage struct matches a supplied bytes32 when formatted for storage.
-    * @param cs A given ChannelStorage data structure.
-    * @param h Some data in on-chain storage format.
-    */
+     * @notice Checks that a given ChannelStorage struct matches a supplied bytes32 when formatted for storage.
+     * @dev Checks that a given ChannelStorage struct matches a supplied bytes32 when formatted for storage.
+     * @param cs A given ChannelStorage data structure.
+     * @param h Some data in on-chain storage format.
+     */
     function _matchesHash(ChannelStorage memory cs, bytes32 h) internal pure returns (bool) {
         return _hashChannelStorage(cs) == h;
     }
 
     /**
-    * @notice Computes the hash of the state corresponding to the input data.
-    * @dev Computes the hash of the state corresponding to the input data.
-    * @param turnNum Turn number
-    * @param isFinal Is the state final?
-    * @param channelId Unique identifier for the channel
-    * @param fixedPart Part of the state that does not change
-    * @param appData Application specific date
-    * @param outcomeHash Hash of the outcome.
-    * @return The stateHash
-    */
+     * @notice Computes the hash of the state corresponding to the input data.
+     * @dev Computes the hash of the state corresponding to the input data.
+     * @param turnNum Turn number
+     * @param isFinal Is the state final?
+     * @param channelId Unique identifier for the channel
+     * @param fixedPart Part of the state that does not change
+     * @param appData Application specific date
+     * @param outcomeHash Hash of the outcome.
+     * @return The stateHash
+     */
     function _hashState(
         uint256 turnNum,
         bool isFinal,
@@ -756,21 +753,21 @@ contract ForceMove is IForceMove {
     }
 
     /**
-    * @notice Computes the hash of a given outcome.
-    * @dev Computes the hash of a given outcome.
-    * @param outcome An outcome
-    * @return The outcomeHash
-    */
+     * @notice Computes the hash of a given outcome.
+     * @dev Computes the hash of a given outcome.
+     * @param outcome An outcome
+     * @return The outcomeHash
+     */
     function _hashOutcome(bytes memory outcome) internal pure returns (bytes32) {
         return keccak256(abi.encode(outcome));
     }
 
     /**
-    * @notice Computes the unique id of a channel.
-    * @dev Computes the unique id of a channel.
-    * @param fixedPart Part of the state that does not change
-    * @return channelId
-    */
+     * @notice Computes the unique id of a channel.
+     * @dev Computes the unique id of a channel.
+     * @param fixedPart Part of the state that does not change
+     * @return channelId
+     */
     function _getChannelId(FixedPart memory fixedPart) internal pure returns (bytes32 channelId) {
         channelId = keccak256(
             abi.encode(fixedPart.chainId, fixedPart.participants, fixedPart.channelNonce)

--- a/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
+++ b/packages/nitro-protocol/contracts/interfaces/IForceMove.sol
@@ -3,9 +3,10 @@ pragma experimental ABIEncoderV2;
 
 import './ForceMoveApp.sol';
 
+
 /**
-  * @dev The IForceMove contract abstraction defines the interface that an implementation of ForceMove should implement. ForceMove protocol allows state channels to be adjudicated and finalized.
-*/
+ * @dev The IForceMove contract abstraction defines the interface that an implementation of ForceMove should implement. ForceMove protocol allows state channels to be adjudicated and finalized.
+ */
 abstract contract IForceMove {
     struct Signature {
         uint8 v;
@@ -47,16 +48,16 @@ abstract contract IForceMove {
     enum ChannelMode {Open, Challenge, Finalized}
 
     /**
-    * @notice Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
-    * @dev Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
-    * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-    * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
-    * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
-    * @param isFinalCount Describes how many of the submitted states have the `isFinal` property set to `true`. It is implied that the rightmost `isFinalCount` states are final, and the rest are not final.
-    * @param sigs An array of signatures that support the state with the `largestTurnNum`.
-    * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
-    * @param challengerSig The signature of a participant on the keccak256 of the abi.encode of (supportedStateHash, 'forceMove').
-    */
+     * @notice Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
+     * @dev Registers a challenge against a state channel. A challenge will either prompt another participant into clearing the challenge (via one of the other methods), or cause the channel to finalize at a specific time.
+     * @param fixedPart Data describing properties of the state channel that do not change with state updates.
+     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
+     * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
+     * @param isFinalCount Describes how many of the submitted states have the `isFinal` property set to `true`. It is implied that the rightmost `isFinalCount` states are final, and the rest are not final.
+     * @param sigs An array of signatures that support the state with the `largestTurnNum`.
+     * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
+     * @param challengerSig The signature of a participant on the keccak256 of the abi.encode of (supportedStateHash, 'forceMove').
+     */
     function forceMove(
         FixedPart memory fixedPart,
         uint48 largestTurnNum,
@@ -68,14 +69,14 @@ abstract contract IForceMove {
     ) public virtual;
 
     /**
-    * @notice Repsonds to an ongoing challenge registered against a state channel.
-    * @dev Repsonds to an ongoing challenge registered against a state channel.
-    * @param challenger The address of the participant whom registered the challenge.
-    * @param isFinalAB An pair of booleans describing if the challenge state and/or the response state have the `isFinal` property set to `true`.
-    * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-    * @param variablePartAB An pair of structs, each decribing the properties of the state channel that may change with each state update (for the challenge state and for the response state).
-    * @param sig The responder's signature on the `responseStateHash`.
-    */
+     * @notice Repsonds to an ongoing challenge registered against a state channel.
+     * @dev Repsonds to an ongoing challenge registered against a state channel.
+     * @param challenger The address of the participant whom registered the challenge.
+     * @param isFinalAB An pair of booleans describing if the challenge state and/or the response state have the `isFinal` property set to `true`.
+     * @param fixedPart Data describing properties of the state channel that do not change with state updates.
+     * @param variablePartAB An pair of structs, each decribing the properties of the state channel that may change with each state update (for the challenge state and for the response state).
+     * @param sig The responder's signature on the `responseStateHash`.
+     */
     function respond(
         address challenger,
         bool[2] memory isFinalAB,
@@ -87,15 +88,15 @@ abstract contract IForceMove {
     ) public virtual;
 
     /**
-    * @notice Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
-    * @dev Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
-    * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-    * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
-    * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
-    * @param isFinalCount Describes how many of the submitted states have the `isFinal` property set to `true`. It is implied that the rightmost `isFinalCount` states are final, and the rest are not final.
-    * @param sigs An array of signatures that support the state with the `largestTurnNum`.
-    * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
-    */
+     * @notice Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
+     * @dev Overwrites the `turnNumRecord` stored against a channel by providing a state with higher turn number, supported by a signature from each participant.
+     * @param fixedPart Data describing properties of the state channel that do not change with state updates.
+     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
+     * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
+     * @param isFinalCount Describes how many of the submitted states have the `isFinal` property set to `true`. It is implied that the rightmost `isFinalCount` states are final, and the rest are not final.
+     * @param sigs An array of signatures that support the state with the `largestTurnNum`.
+     * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
+     */
     function checkpoint(
         FixedPart memory fixedPart,
         uint48 largestTurnNum,
@@ -106,16 +107,16 @@ abstract contract IForceMove {
     ) public virtual;
 
     /**
-    * @notice Finalizes a channel by providing a finalization proof.
-    * @dev Finalizes a channel by providing a finalization proof.
-    * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
-    * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-    * @param appPartHash The keccak256 of the abi.encode of `(challengeDuration, appDefinition, appData)`. Applies to all states in the finalization proof.
-    * @param outcomeHash The keccak256 of the abi.encode of the `outcome`. Applies to all stats in the finalization proof.
-    * @param numStates The number of states in the finalization proof.
-    * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
-    * @param sigs An array of signatures that support the state with the `largestTurnNum`.
-    */
+     * @notice Finalizes a channel by providing a finalization proof.
+     * @dev Finalizes a channel by providing a finalization proof.
+     * @param largestTurnNum The largest turn number of the submitted states; will overwrite the stored value of `turnNumRecord`.
+     * @param fixedPart Data describing properties of the state channel that do not change with state updates.
+     * @param appPartHash The keccak256 of the abi.encode of `(challengeDuration, appDefinition, appData)`. Applies to all states in the finalization proof.
+     * @param outcomeHash The keccak256 of the abi.encode of the `outcome`. Applies to all stats in the finalization proof.
+     * @param numStates The number of states in the finalization proof.
+     * @param whoSignedWhat An array denoting which participant has signed which state: `participant[i]` signed the state with index `whoSignedWhat[i]`.
+     * @param sigs An array of signatures that support the state with the `largestTurnNum`.
+     */
     function conclude(
         uint48 largestTurnNum,
         FixedPart memory fixedPart,
@@ -129,17 +130,17 @@ abstract contract IForceMove {
     // events
 
     /**
-    * @dev Indicates that a challenge has been registered against `channelId`.
-    * @param channelId Unique identifier for a state channel.
-    * @param turnNumRecord A turnNum that (the adjudicator knows) is supported by a signature from each participant.
-    * @param finalizesAt The unix timestamp when `channelId` will finalize.
-    * @param challenger The address of the participant whom registered the challenge.
-    * @param isFinal Boolean denoting whether the challenge state is final.
-    * @param fixedPart Data describing properties of the state channel that do not change with state updates.
-    * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
-    * @param sigs A list of Signatures that supported the challenge
-    * @param whoSignedWhat Indexing information to identify which signature was by which participant
-    */
+     * @dev Indicates that a challenge has been registered against `channelId`.
+     * @param channelId Unique identifier for a state channel.
+     * @param turnNumRecord A turnNum that (the adjudicator knows) is supported by a signature from each participant.
+     * @param finalizesAt The unix timestamp when `channelId` will finalize.
+     * @param challenger The address of the participant whom registered the challenge.
+     * @param isFinal Boolean denoting whether the challenge state is final.
+     * @param fixedPart Data describing properties of the state channel that do not change with state updates.
+     * @param variableParts An ordered array of structs, each decribing the properties of the state channel that may change with each state update.
+     * @param sigs A list of Signatures that supported the challenge
+     * @param whoSignedWhat Indexing information to identify which signature was by which participant
+     */
     event ChallengeRegistered(
         bytes32 indexed channelId,
         // everything needed to respond or checkpoint
@@ -154,15 +155,15 @@ abstract contract IForceMove {
     );
 
     /**
-    * @dev Indicates that a challenge, previously registered against `channelId`, has been cleared.
-    * @param channelId Unique identifier for a state channel.
-    * @param newTurnNumRecord A turnNum that (the adjudicator knows) is supported by a signature from each participant.
-    */
+     * @dev Indicates that a challenge, previously registered against `channelId`, has been cleared.
+     * @param channelId Unique identifier for a state channel.
+     * @param newTurnNumRecord A turnNum that (the adjudicator knows) is supported by a signature from each participant.
+     */
     event ChallengeCleared(bytes32 indexed channelId, uint256 newTurnNumRecord);
 
     /**
-    * @dev Indicates that a challenge has been registered against `channelId`.
-    * @param channelId Unique identifier for a state channel.
-    */
+     * @dev Indicates that a challenge has been registered against `channelId`.
+     * @param channelId Unique identifier for a state channel.
+     */
     event Concluded(bytes32 indexed channelId);
 }

--- a/packages/nitro-protocol/src/transactions.ts
+++ b/packages/nitro-protocol/src/transactions.ts
@@ -85,9 +85,9 @@ export function createSignatureArguments(
 
   // Get a list of all unique signed states.
   const uniqueSignedStates = signedStates.filter((s, i, a) => a.indexOf(s) === i);
-  // Get a list of unique states ignoring their signatures
-  // This allows us to create a single state with multiple signatures
-  // which is required by the contracts
+  // We may receive multiple Signed States which have the same state and different signatures
+  // so we get a list of unique states ignoring their signatures
+  // which allows us to create a single state with multiple signatures
   const uniqueStates = uniqueSignedStates.map(s => s.state).filter((s, i, a) => a.indexOf(s) === i);
   const signatures = new Array<Signature>(uniqueStates.length);
   for (let i = 0; i < uniqueStates.length; i++) {
@@ -103,5 +103,9 @@ export function createSignatureArguments(
     }
   }
 
-  return {states, signatures, whoSignedWhat};
+  return {
+    states,
+    signatures,
+    whoSignedWhat,
+  };
 }

--- a/packages/nitro-protocol/test/contracts/ForceMove/forceMove.test.ts
+++ b/packages/nitro-protocol/test/contracts/ForceMove/forceMove.test.ts
@@ -82,15 +82,15 @@ beforeAll(async () => {
 // Scenarios are synonymous with channelNonce:
 
 const acceptsWhenOpen = 'It accepts for an open channel, and updates storage correctly, ';
-const accepts1 = acceptsWhenOpen + 'when the slot is empty, n states submitted';
-const accepts2 = acceptsWhenOpen + 'when the slot is empty, 1 state submitted';
-const accepts3 = acceptsWhenOpen + 'when the slot is not empty, n states submitted';
+const accepts1 = acceptsWhenOpen + 'when the slot is empty, 1 state submitted';
+const accepts2 = acceptsWhenOpen + 'when the slot is empty, 3 states submitted';
+const accepts3 = acceptsWhenOpen + 'when the slot is not empty, 3 states submitted';
 const accepts4 = acceptsWhenOpen + 'when the slot is not empty, 1 state submitted';
 
 const acceptsWhenChallengePresent =
   'It accepts when a challenge is present, and updates storage correctly, ';
 const accepts5 = acceptsWhenChallengePresent + 'when the turnNumRecord increases, 1 state';
-const accepts6 = acceptsWhenChallengePresent + 'when the turnNumRecord increases, n states';
+const accepts6 = acceptsWhenChallengePresent + 'when the turnNumRecord increases, 3 states';
 
 const revertsWhenOpenIf = 'It reverts for an open channel if ';
 const reverts1 = revertsWhenOpenIf + 'the turnNumRecord does not increase';

--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -332,11 +332,13 @@ export class ChainWatcher implements Chain {
   }
 
   public async challenge(support: SignedState[], privateKey: string): Promise<string | undefined> {
-    const convertedSignedStates = support.reduce(
-      (previous, current) => previous.concat(toNitroSignedState(current)),
-      new Array<NitroSignedState>()
-    );
-    console.log(convertedSignedStates);
+    const convertedSignedStates = support
+      .reduce(
+        (previous, current) => previous.concat(toNitroSignedState(current)),
+        new Array<NitroSignedState>()
+      )
+      .sort((s1, s2) => s1.state.turnNum - s2.state.turnNum);
+
     const response = await this.signer.sendTransaction({
       ...Transactions.createForceMoveTransaction(
         convertedSignedStates,

--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -3,7 +3,8 @@ import {
   createETHDepositTransaction,
   Transactions,
   getChallengeRegisteredEvent,
-  ChallengeRegisteredEvent
+  ChallengeRegisteredEvent,
+  SignedState as NitroSignedState
 } from '@statechannels/nitro-protocol';
 import {Contract, Wallet} from 'ethers';
 import {Zero, One} from 'ethers/constants';
@@ -14,6 +15,7 @@ import {filter, map, flatMap} from 'rxjs/operators';
 import EventEmitter from 'eventemitter3';
 
 import {fromNitroState, toNitroSignedState, calculateChannelId} from './store/state-utils';
+
 import {getProvider} from './utils/contract-utils';
 import {State, SignedState} from './store/types';
 import {ETH_ASSET_HOLDER_ADDRESS, NITRO_ADJUDICATOR_ADDRESS} from './config';
@@ -330,10 +332,14 @@ export class ChainWatcher implements Chain {
   }
 
   public async challenge(support: SignedState[], privateKey: string): Promise<string | undefined> {
+    const convertedSignedStates = support.reduce(
+      (previous, current) => previous.concat(toNitroSignedState(current)),
+      new Array<NitroSignedState>()
+    );
+    console.log(convertedSignedStates);
     const response = await this.signer.sendTransaction({
       ...Transactions.createForceMoveTransaction(
-        // TODO: Code is assuming a doubly-signed state at the moment.
-        toNitroSignedState(support[0]),
+        convertedSignedStates,
         // createForceMoveTransaction requires this to sign a "challenge message"
         privateKey
       ),

--- a/packages/xstate-wallet/src/config.ts
+++ b/packages/xstate-wallet/src/config.ts
@@ -40,6 +40,8 @@ export const LOG_DESTINATION: string | undefined = process.env.LOG_DESTINATION;
 export const NITRO_ADJUDICATOR_ADDRESS: string =
   process.env.NITRO_ADJUDICATOR_ADDRESS || AddressZero;
 
+export const TRIVIAL_APP_ADDRESS: string = process.env.TRIVIAL_APP_ADDRESS || AddressZero;
+
 export const USE_INDEXED_DB = getBool(process.env.USE_INDEXED_DB);
 
 export const CHALLENGE_DURATION = bigNumberify(process.env.CHALLENGE_DURATION || '0x12c');

--- a/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
+++ b/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
@@ -187,7 +187,7 @@ it('correctly crafts a forceMove transaction (2x single-signed states)', async (
 
   const state5: State = {
     outcome,
-    turnNum: bigNumberify(5),
+    turnNum: bigNumberify(4),
     appData: '0x0',
     isFinal: false,
     challengeDuration: CHALLENGE_DURATION,
@@ -200,13 +200,13 @@ it('correctly crafts a forceMove transaction (2x single-signed states)', async (
 
   const state6: State = {
     outcome,
-    turnNum: bigNumberify(6),
+    turnNum: bigNumberify(5),
     appData: '0x0',
     isFinal: false,
     challengeDuration: CHALLENGE_DURATION,
     chainId: CHAIN_NETWORK_ID,
     channelNonce: bigNumberify(0),
-    appDefinition: TRIVIAL_APP_ADDRESS, // TODO point at a deployed contract
+    appDefinition: TRIVIAL_APP_ADDRESS,
     participants: [playerA.participant, playerB.participant]
   };
 

--- a/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
+++ b/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
@@ -1,11 +1,19 @@
-import {ChainWatcher, ChannelChainInfo} from '../chain';
-import {bigNumberify, parseUnits, BigNumber} from 'ethers/utils';
+import {ChainWatcher, ChannelChainInfo, FakeChain} from '../chain';
+import {bigNumberify, parseUnits, BigNumber, hexZeroPad} from 'ethers/utils';
 import {Contract, providers} from 'ethers';
 import {ContractArtifacts, randomChannelId} from '@statechannels/nitro-protocol';
-import {ETH_ASSET_HOLDER_ADDRESS} from '../config';
+import {
+  ETH_ASSET_HOLDER_ADDRESS,
+  CHAIN_NETWORK_ID,
+  CHALLENGE_DURATION,
+  TRIVIAL_APP_ADDRESS
+} from '../config';
 import {Machine, interpret, Interpreter} from 'xstate';
 import {map} from 'rxjs/operators';
-import {Store} from '../store';
+import {Store, SignedState, State} from '../store';
+import {simpleEthAllocation} from '../utils';
+import {Player} from '../integration-tests/helpers';
+import {createSignatureEntry} from '../store/state-utils';
 
 const chain = new ChainWatcher();
 
@@ -106,4 +114,108 @@ it('subscribes to chainUpdateFeed via a subscribeDepositEvent Observable, and se
   await (await tx).wait(); // wait for tx to be mined
   await depositEvent; // wait for this test to detect the event being fired
   expect(fundedEventSent).toHaveBeenCalled();
+});
+
+it('correctly crafts a forceMove transaction (1x double-signed state)', async () => {
+  const fakeChain = new FakeChain();
+  const playerA = await Player.createPlayer(
+    '0x275a2e2cd9314f53b42246694034a80119963097e3adf495fbf6d821dc8b6c8e',
+    'PlayerA',
+    fakeChain
+  );
+  const playerB = await Player.createPlayer(
+    '0x3341c348ea8ade1ba7c3b6f071bfe9635c544b7fb5501797eaa2f673169a7d0d',
+    'PlayerB',
+    fakeChain
+  );
+
+  const outcome = simpleEthAllocation([
+    {
+      destination: playerA.destination,
+      amount: bigNumberify(hexZeroPad('0x06f05b59d3b20000', 32))
+    },
+    {
+      destination: playerA.destination,
+      amount: bigNumberify(hexZeroPad('0x06f05b59d3b20000', 32))
+    }
+  ]);
+
+  const state: State = {
+    outcome,
+    turnNum: bigNumberify(5),
+    appData: '0x0',
+    isFinal: false,
+    challengeDuration: CHALLENGE_DURATION,
+    chainId: CHAIN_NETWORK_ID,
+    channelNonce: bigNumberify(0),
+    appDefinition: TRIVIAL_APP_ADDRESS, // TODO point at a deployed contract
+    participants: [playerA.participant, playerB.participant]
+  };
+
+  const allSignState: SignedState = {
+    ...state,
+    signatures: [playerA, playerB].map(({privateKey}) => createSignatureEntry(state, privateKey))
+  };
+  const support = [allSignState];
+  const result = await chain.challenge(support, playerA.privateKey);
+  expect(result?.length).toBeGreaterThan(0);
+});
+
+it('correctly crafts a forceMove transaction (2x single-signed states)', async () => {
+  const fakeChain = new FakeChain();
+  const playerA = await Player.createPlayer(
+    '0x275a2e2cd9314f53b42246694034a80119963097e3adf495fbf6d821dc8b6c8e',
+    'PlayerA',
+    fakeChain
+  );
+  const playerB = await Player.createPlayer(
+    '0x3341c348ea8ade1ba7c3b6f071bfe9635c544b7fb5501797eaa2f673169a7d0d',
+    'PlayerB',
+    fakeChain
+  );
+
+  const outcome = simpleEthAllocation([
+    {
+      destination: playerA.destination,
+      amount: bigNumberify(hexZeroPad('0x06f05b59d3b20000', 32))
+    },
+    {
+      destination: playerA.destination,
+      amount: bigNumberify(hexZeroPad('0x06f05b59d3b20000', 32))
+    }
+  ]);
+
+  const state5: State = {
+    outcome,
+    turnNum: bigNumberify(5),
+    appData: '0x0',
+    isFinal: false,
+    challengeDuration: CHALLENGE_DURATION,
+    chainId: CHAIN_NETWORK_ID,
+    channelNonce: bigNumberify(0),
+    appDefinition: TRIVIAL_APP_ADDRESS, // TODO point at a deployed contract
+    participants: [playerA.participant, playerB.participant]
+  };
+  const state5signature = createSignatureEntry(state5, playerA.privateKey);
+
+  const state6: State = {
+    outcome,
+    turnNum: bigNumberify(6),
+    appData: '0x0',
+    isFinal: false,
+    challengeDuration: CHALLENGE_DURATION,
+    chainId: CHAIN_NETWORK_ID,
+    channelNonce: bigNumberify(0),
+    appDefinition: TRIVIAL_APP_ADDRESS, // TODO point at a deployed contract
+    participants: [playerA.participant, playerB.participant]
+  };
+
+  const state6signature = createSignatureEntry(state6, playerB.privateKey);
+
+  const support = [
+    {...state5, signatures: [state5signature]},
+    {...state6, signatures: [state6signature]}
+  ];
+  const result = await chain.challenge(support, playerA.privateKey);
+  expect(result?.length).toBeGreaterThan(0);
 });

--- a/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
+++ b/packages/xstate-wallet/src/tests-with-chain/chain.test.ts
@@ -192,7 +192,7 @@ it('correctly crafts a forceMove transaction (2x single-signed states)', async (
     isFinal: false,
     challengeDuration: CHALLENGE_DURATION,
     chainId: CHAIN_NETWORK_ID,
-    channelNonce: bigNumberify(0),
+    channelNonce: bigNumberify(1),
     appDefinition: TRIVIAL_APP_ADDRESS, // TODO point at a deployed contract
     participants: [playerA.participant, playerB.participant]
   };
@@ -205,7 +205,7 @@ it('correctly crafts a forceMove transaction (2x single-signed states)', async (
     isFinal: false,
     challengeDuration: CHALLENGE_DURATION,
     chainId: CHAIN_NETWORK_ID,
-    channelNonce: bigNumberify(0),
+    channelNonce: bigNumberify(1),
     appDefinition: TRIVIAL_APP_ADDRESS,
     participants: [playerA.participant, playerB.participant]
   };

--- a/packages/xstate-wallet/src/workflows/challenge-channel.ts
+++ b/packages/xstate-wallet/src/workflows/challenge-channel.ts
@@ -6,7 +6,8 @@ import {
   StateMachine,
   StateSchema,
   Guard,
-  spawn
+  spawn,
+  actions
 } from 'xstate';
 import {map} from 'rxjs/operators';
 import {Zero} from 'ethers/constants';
@@ -15,6 +16,7 @@ import {BigNumber} from 'ethers/utils';
 import {Store} from '../store';
 import {ChannelChainInfo} from '../chain';
 
+const {log} = actions;
 export interface Initial {
   channelId: string;
 }
@@ -112,6 +114,7 @@ export const machine = (
     initial: 'init',
 
     on: {
+      CHANNEL_UPDATED: {actions: log('CHANNEL_UPDATED sent to challenge channel machine')},
       CHAIN_EVENT: [
         {
           target: 'waitForResponseOrTimeout',


### PR DESCRIPTION
Based on @geoknee's work in #1907.

This gets the challenge transaction properly working for `rps`.

The integration tests haven't been updated to include challenging yet as I'd like to finish my work in #1935 and then update the integration tests to tests both challenging and responding to the challenge.