### PR TITLE
[ nitro protocol ] Remove all GAS_LIMIT instances

### DIFF
--- a/packages/nitro-protocol/src/contract/transaction-creators/asset-holder.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/asset-holder.ts
@@ -9,11 +9,6 @@ import {
   Outcome,
 } from '../outcome';
 
-// TODO: Currently we are setting some arbitrary gas limit
-// To avoid issues with Ganache sendTransaction and parsing BN.js
-// If we don't set a gas limit some transactions will fail
-const GAS_LIMIT = 100_000;
-
 export function createTransferAllTransaction(
   assetHolderContractInterface: Interface,
   channelId: string,
@@ -23,7 +18,7 @@ export function createTransferAllTransaction(
     channelId,
     encodeAllocation(allocation),
   ]);
-  return {data, gasLimit: GAS_LIMIT};
+  return {data};
 }
 
 export function claimAllArgs(
@@ -43,7 +38,7 @@ export function createClaimAllTransaction(
   const data = assetHolderContractInterface.functions.claimAll.encode(
     claimAllArgs(channelId, guarantee, allocation)
   );
-  return {data, gasLimit: GAS_LIMIT};
+  return {data};
 }
 
 export function createSetOutcomeTransaction(
@@ -55,5 +50,5 @@ export function createSetOutcomeTransaction(
     channelId,
     hashOutcome(outcome),
   ]);
-  return {data, gasLimit: GAS_LIMIT};
+  return {data};
 }

--- a/packages/nitro-protocol/src/contract/transaction-creators/asset-holder.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/asset-holder.ts
@@ -12,7 +12,7 @@ import {
 // TODO: Currently we are setting some arbitrary gas limit
 // To avoid issues with Ganache sendTransaction and parsing BN.js
 // If we don't set a gas limit some transactions will fail
-const GAS_LIMIT = 3000000;
+const GAS_LIMIT = 100_000;
 
 export function createTransferAllTransaction(
   assetHolderContractInterface: Interface,

--- a/packages/nitro-protocol/src/contract/transaction-creators/consensus-app.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/consensus-app.ts
@@ -8,7 +8,7 @@ import {Outcome} from '../outcome';
 // TODO: Currently we are setting some arbitrary gas limit
 // To avoid issues with Ganache sendTransaction and parsing BN.js
 // If we don't set a gas limit some transactions will fail
-const GAS_LIMIT = 3000000;
+const GAS_LIMIT = 100_000;
 
 // Ethers mis-interprets the artifact's abi paramter so we cast to any
 const ConsensusAppContractInterface = new Interface(ConsensusAppArtifact.abi as any);

--- a/packages/nitro-protocol/src/contract/transaction-creators/consensus-app.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/consensus-app.ts
@@ -5,11 +5,6 @@ import {getVariablePart} from '../consensus-app';
 import {ConsensusData} from '../consensus-data';
 import {Outcome} from '../outcome';
 
-// TODO: Currently we are setting some arbitrary gas limit
-// To avoid issues with Ganache sendTransaction and parsing BN.js
-// If we don't set a gas limit some transactions will fail
-const GAS_LIMIT = 100_000;
-
 // Ethers mis-interprets the artifact's abi paramter so we cast to any
 const ConsensusAppContractInterface = new Interface(ConsensusAppArtifact.abi as any);
 
@@ -30,5 +25,5 @@ export function createValidTransitionTransaction(
     numberOfParticipants,
   ]);
 
-  return {data, gasLimit: GAS_LIMIT};
+  return {data};
 }

--- a/packages/nitro-protocol/src/contract/transaction-creators/erc20-asset-holder.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/erc20-asset-holder.ts
@@ -8,11 +8,6 @@ import * as assetHolderTransactionCreator from './asset-holder';
 // @ts-ignore
 const Erc20AssetHolderContractInterface = new Interface(Erc20AssetHolderArtifact.abi);
 
-// TODO: Currently we are setting some arbitrary gas limit
-// To avoid issues with Ganache sendTransaction and parsing BN.js
-// If we don't set a gas limit some transactions will fail
-const GAS_LIMIT = 100_000;
-
 export function createTransferAllTransaction(
   channelId: string,
   allocation: Allocation
@@ -56,5 +51,5 @@ export function createDepositTransaction(
     expectedHeld,
     amount,
   ]);
-  return {data, gasLimit: GAS_LIMIT};
+  return {data};
 }

--- a/packages/nitro-protocol/src/contract/transaction-creators/erc20-asset-holder.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/erc20-asset-holder.ts
@@ -11,7 +11,7 @@ const Erc20AssetHolderContractInterface = new Interface(Erc20AssetHolderArtifact
 // TODO: Currently we are setting some arbitrary gas limit
 // To avoid issues with Ganache sendTransaction and parsing BN.js
 // If we don't set a gas limit some transactions will fail
-const GAS_LIMIT = 3000000;
+const GAS_LIMIT = 100_000;
 
 export function createTransferAllTransaction(
   channelId: string,

--- a/packages/nitro-protocol/src/contract/transaction-creators/eth-asset-holder.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/eth-asset-holder.ts
@@ -8,7 +8,7 @@ import * as assetHolderTransactionCreator from './asset-holder';
 // TODO: Currently we are setting some arbitrary gas limit
 // To avoid issues with Ganache sendTransaction and parsing BN.js
 // If we don't set a gas limit some transactions will fail
-const GAS_LIMIT = 3000000;
+const GAS_LIMIT = 100_000;
 
 // @ts-ignore
 const EthAssetHolderContractInterface = new Interface(EthAssetHolderArtifact.abi);

--- a/packages/nitro-protocol/src/contract/transaction-creators/eth-asset-holder.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/eth-asset-holder.ts
@@ -5,11 +5,6 @@ import EthAssetHolderArtifact from '../../../build/contracts/ETHAssetHolder.json
 import {Allocation, Guarantee, Outcome} from '../outcome';
 import * as assetHolderTransactionCreator from './asset-holder';
 
-// TODO: Currently we are setting some arbitrary gas limit
-// To avoid issues with Ganache sendTransaction and parsing BN.js
-// If we don't set a gas limit some transactions will fail
-const GAS_LIMIT = 100_000;
-
 // @ts-ignore
 const EthAssetHolderContractInterface = new Interface(EthAssetHolderArtifact.abi);
 
@@ -57,5 +52,5 @@ export function createDepositTransaction(
     expectedHeld,
     amount,
   ]);
-  return {data, gasLimit: GAS_LIMIT};
+  return {data};
 }

--- a/packages/nitro-protocol/src/contract/transaction-creators/force-move.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/force-move.ts
@@ -7,11 +7,6 @@ import {signChallengeMessage} from '../../signatures';
 import {hashOutcome} from '../outcome';
 import {getFixedPart, getVariablePart, hashAppPart, State} from '../state';
 
-// TODO: Currently we are setting some arbitrary gas limit
-// To avoid issues with Ganache sendTransaction and parsing BN.js
-// If we don't set a gas limit some transactions will fail
-const GAS_LIMIT = 100_000;
-
 // @ts-ignore https://github.com/ethers-io/ethers.js/issues/602#issuecomment-574671078
 export const ForceMoveContractInterface = new ethers.utils.Interface(ForceMoveArtifact.abi);
 
@@ -20,12 +15,6 @@ interface CheckpointData {
   states: State[];
   signatures: Signature[];
   whoSignedWhat: number[];
-}
-
-export function createGetDataTransaction(channelId: string): TransactionRequest {
-  return {
-    gasLimit: GAS_LIMIT,
-  };
 }
 
 export function createForceMoveTransaction(
@@ -67,7 +56,7 @@ export function createForceMoveTransaction(
     whoSignedWhat,
     challengerSignature,
   ]);
-  return {data, gasLimit: GAS_LIMIT};
+  return {data};
 }
 
 interface RespondArgs {
@@ -90,7 +79,7 @@ export function respondArgs({
 
 export function createRespondTransaction(args: RespondArgs): TransactionRequest {
   const data = ForceMoveContractInterface.functions.respond.encode(respondArgs(args));
-  return {data, gasLimit: GAS_LIMIT};
+  return {data};
 }
 
 export function createCheckpointTransaction({
@@ -102,7 +91,7 @@ export function createCheckpointTransaction({
     checkpointArgs({states, signatures, whoSignedWhat})
   );
 
-  return {data, gasLimit: GAS_LIMIT};
+  return {data};
 }
 
 export function checkpointArgs({states, signatures, whoSignedWhat}: CheckpointData): any[] {
@@ -122,7 +111,7 @@ export function createConcludeTransaction(
   const data = ForceMoveContractInterface.functions.conclude.encode(
     concludeArgs(states, signatures, whoSignedWhat)
   );
-  return {data, gasLimit: GAS_LIMIT};
+  return {data};
 }
 
 export function concludeArgs(

--- a/packages/nitro-protocol/src/contract/transaction-creators/force-move.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/force-move.ts
@@ -10,7 +10,7 @@ import {getFixedPart, getVariablePart, hashAppPart, State} from '../state';
 // TODO: Currently we are setting some arbitrary gas limit
 // To avoid issues with Ganache sendTransaction and parsing BN.js
 // If we don't set a gas limit some transactions will fail
-const GAS_LIMIT = 3000000;
+const GAS_LIMIT = 100_000;
 
 // @ts-ignore https://github.com/ethers-io/ethers.js/issues/602#issuecomment-574671078
 export const ForceMoveContractInterface = new ethers.utils.Interface(ForceMoveArtifact.abi);

--- a/packages/nitro-protocol/src/contract/transaction-creators/nitro-adjudicator.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/nitro-adjudicator.ts
@@ -6,11 +6,6 @@ import {encodeOutcome, Outcome} from '../outcome';
 import {getFixedPart, hashAppPart, hashState, State} from '../state';
 import {Signature, Interface} from 'ethers/utils';
 
-// TODO: Currently we are setting some arbitrary gas limit
-// To avoid issues with Ganache sendTransaction and parsing BN.js
-// If we don't set a gas limit some transactions will fail
-const GAS_LIMIT = 100_000;
-
 // @ts-ignore https://github.com/ethers-io/ethers.js/issues/602#issuecomment-574671078
 const NitroAdjudicatorContractInterface = new Interface(NitroAdjudicatorArtifact.abi);
 
@@ -35,7 +30,7 @@ export function createPushOutcomeTransaction(
     encodedOutcome,
   ]);
 
-  return {data, gasLimit: GAS_LIMIT};
+  return {data};
 }
 
 export function concludePushOutcomeAndTransferAllArgs(
@@ -83,6 +78,5 @@ export function createConcludePushOutcomeAndTransferAllTransaction(
     data: NitroAdjudicatorContractInterface.functions.concludePushOutcomeAndTransferAll.encode(
       concludePushOutcomeAndTransferAllArgs(states, signatures, whoSignedWhat)
     ),
-    gasLimit: GAS_LIMIT,
   };
 }

--- a/packages/nitro-protocol/src/contract/transaction-creators/nitro-adjudicator.ts
+++ b/packages/nitro-protocol/src/contract/transaction-creators/nitro-adjudicator.ts
@@ -9,7 +9,7 @@ import {Signature, Interface} from 'ethers/utils';
 // TODO: Currently we are setting some arbitrary gas limit
 // To avoid issues with Ganache sendTransaction and parsing BN.js
 // If we don't set a gas limit some transactions will fail
-const GAS_LIMIT = 3000000;
+const GAS_LIMIT = 100_000;
 
 // @ts-ignore https://github.com/ethers-io/ethers.js/issues/602#issuecomment-574671078
 const NitroAdjudicatorContractInterface = new Interface(NitroAdjudicatorArtifact.abi);


### PR DESCRIPTION
Making this change didn't break anything. And it seems to allow ethers to automatically provide an accurate estimate for the gas limit. 

![Screenshot 2020-05-22 at 11 45 26](https://user-images.githubusercontent.com/1833419/82660194-d0d9a600-9c21-11ea-9494-1c1c4a50541a.png)
