### PR TITLE
Set default value for onNext and onComplete for simple-hub

### DIFF
--- a/packages/simple-hub/src/message/on-message.ts
+++ b/packages/simple-hub/src/message/on-message.ts
@@ -16,7 +16,7 @@ export function onIncomingMessage(
     message: Either<Error, Message>;
   }>,
   onNext: () => void = noop,
-  onComplete: () => void = noop
+  onComplete?: () => void
 ) {
   return observable
     .pipe(

--- a/packages/simple-hub/src/message/on-message.ts
+++ b/packages/simple-hub/src/message/on-message.ts
@@ -14,8 +14,8 @@ export function onIncomingMessage(
     snapshotKey: string;
     message: Either<Error, Message>;
   }>,
-  onNext?: () => void,
-  onComplete?: () => void
+  onNext: () => void = noop,
+  onComplete: () => void = noop
 ) {
   return observable
     .pipe(

--- a/packages/simple-hub/src/message/on-message.ts
+++ b/packages/simple-hub/src/message/on-message.ts
@@ -1,3 +1,4 @@
+import {noop} from "lodash";
 import {deleteIncomingMessage, sendReplies} from '../message/firebase-relay';
 import {respondToMessage} from '../wallet/respond-to-message';
 import {map} from 'rxjs/operators';

--- a/packages/simple-hub/src/message/on-message.ts
+++ b/packages/simple-hub/src/message/on-message.ts
@@ -1,4 +1,4 @@
-import {noop} from "lodash";
+import {noop} from 'lodash';
 import {deleteIncomingMessage, sendReplies} from '../message/firebase-relay';
 import {respondToMessage} from '../wallet/respond-to-message';
 import {map} from 'rxjs/operators';


### PR DESCRIPTION
Fixes harmless (I think?) error on console:

```
20-05-22 12:56:36.665 +0000] INFO  (simple-hub/86966 on mhz.local): makeDeposit: attempting to make 0 deposits
[2020-05-22 12:56:36.665 +0000] INFO  (simple-hub/86966 on mhz.local): makeDepost: making 0 deposits
[2020-05-22 12:56:36.665 +0000] ERROR (simple-hub/86966 on mhz.local): onNext is not a function
    TypeError: onNext is not a function
        at SafeSubscriber.observable.pipe.subscribe [as _next] (/Users/liam/Documents/Projects/statechannels/monorepo/packages/simple-hub/src/message/on-message.ts:38:11)
        at process._tickCallback (internal/process/next_tick.js:68:7)
```