### PR TITLE
Store refactor

### DIFF
--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -315,6 +315,9 @@
         },
         {
           "$ref": "#/definitions/UpdateChannelError"
+        },
+        {
+          "$ref": "#/definitions/JsonRpcError%3C500%2C%22Wallet%20error%22%3E"
         }
       ]
     },
@@ -590,7 +593,7 @@
       ],
       "type": "object"
     },
-    "JsonRpcError<401,\"Invalid transition\",structure-1165839259-780-850-1165839259-707-852-1165839259-682-853-1165839259-0-1291>": {
+    "JsonRpcError<401,\"Invalid transition\",structure-1165839259-780-850-1165839259-707-852-1165839259-682-853-1165839259-0-1256>": {
       "additionalProperties": false,
       "properties": {
         "error": {
@@ -649,7 +652,7 @@
       ],
       "type": "object"
     },
-    "JsonRpcError<402,\"Invalid app data\",structure-1165839259-943-963-1165839259-875-965-1165839259-853-966-1165839259-0-1291>": {
+    "JsonRpcError<402,\"Invalid app data\",structure-1165839259-943-963-1165839259-875-965-1165839259-853-966-1165839259-0-1256>": {
       "additionalProperties": false,
       "properties": {
         "error": {
@@ -746,7 +749,7 @@
       ],
       "type": "object"
     },
-    "JsonRpcError<403,\"Not your turn\",structure-1165839259-1047-1075-1165839259-985-1077-1165839259-966-1078-1165839259-0-1291>": {
+    "JsonRpcError<403,\"Not your turn\">": {
       "additionalProperties": false,
       "properties": {
         "error": {
@@ -758,18 +761,6 @@
               ],
               "type": "number"
             },
-            "data": {
-              "additionalProperties": false,
-              "properties": {
-                "currentTurnNum": {
-                  "$ref": "#/definitions/Uint256"
-                }
-              },
-              "required": [
-                "currentTurnNum"
-              ],
-              "type": "object"
-            },
             "message": {
               "enum": [
                 "Not your turn"
@@ -779,8 +770,49 @@
           },
           "required": [
             "code",
-            "message",
-            "data"
+            "message"
+          ],
+          "type": "object"
+        },
+        "id": {
+          "type": "number"
+        },
+        "jsonrpc": {
+          "enum": [
+            "2.0"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "error"
+      ],
+      "type": "object"
+    },
+    "JsonRpcError<500,\"Wallet error\">": {
+      "additionalProperties": false,
+      "properties": {
+        "error": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "enum": [
+                500
+              ],
+              "type": "number"
+            },
+            "message": {
+              "enum": [
+                "Wallet error"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
           ],
           "type": "object"
         },
@@ -1852,13 +1884,13 @@
           "$ref": "#/definitions/JsonRpcError%3C400%2C%22Channel%20not%20found%22%3E"
         },
         {
-          "$ref": "#/definitions/JsonRpcError%3C401%2C%22Invalid%20transition%22%2Cstructure-1165839259-780-850-1165839259-707-852-1165839259-682-853-1165839259-0-1291%3E"
+          "$ref": "#/definitions/JsonRpcError%3C401%2C%22Invalid%20transition%22%2Cstructure-1165839259-780-850-1165839259-707-852-1165839259-682-853-1165839259-0-1256%3E"
         },
         {
-          "$ref": "#/definitions/JsonRpcError%3C402%2C%22Invalid%20app%20data%22%2Cstructure-1165839259-943-963-1165839259-875-965-1165839259-853-966-1165839259-0-1291%3E"
+          "$ref": "#/definitions/JsonRpcError%3C402%2C%22Invalid%20app%20data%22%2Cstructure-1165839259-943-963-1165839259-875-965-1165839259-853-966-1165839259-0-1256%3E"
         },
         {
-          "$ref": "#/definitions/JsonRpcError%3C403%2C%22Not%20your%20turn%22%2Cstructure-1165839259-1047-1075-1165839259-985-1077-1165839259-966-1078-1165839259-0-1291%3E"
+          "$ref": "#/definitions/JsonRpcError%3C403%2C%22Not%20your%20turn%22%3E"
         },
         {
           "$ref": "#/definitions/JsonRpcError%3C403%2C%22Channel%20closed%22%3E"

--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -593,7 +593,7 @@
       ],
       "type": "object"
     },
-    "JsonRpcError<401,\"Invalid transition\",structure-1165839259-780-850-1165839259-707-852-1165839259-682-853-1165839259-0-1256>": {
+    "JsonRpcError<401,\"Invalid transition\",structure-1165839259-757-827-1165839259-684-829-1165839259-659-830-1165839259-0-1233>": {
       "additionalProperties": false,
       "properties": {
         "error": {
@@ -652,7 +652,7 @@
       ],
       "type": "object"
     },
-    "JsonRpcError<402,\"Invalid app data\",structure-1165839259-943-963-1165839259-875-965-1165839259-853-966-1165839259-0-1256>": {
+    "JsonRpcError<402,\"Invalid app data\",structure-1165839259-920-940-1165839259-852-942-1165839259-830-943-1165839259-0-1233>": {
       "additionalProperties": false,
       "properties": {
         "error": {
@@ -1884,10 +1884,10 @@
           "$ref": "#/definitions/JsonRpcError%3C400%2C%22Channel%20not%20found%22%3E"
         },
         {
-          "$ref": "#/definitions/JsonRpcError%3C401%2C%22Invalid%20transition%22%2Cstructure-1165839259-780-850-1165839259-707-852-1165839259-682-853-1165839259-0-1256%3E"
+          "$ref": "#/definitions/JsonRpcError%3C401%2C%22Invalid%20transition%22%2Cstructure-1165839259-757-827-1165839259-684-829-1165839259-659-830-1165839259-0-1233%3E"
         },
         {
-          "$ref": "#/definitions/JsonRpcError%3C402%2C%22Invalid%20app%20data%22%2Cstructure-1165839259-943-963-1165839259-875-965-1165839259-853-966-1165839259-0-1256%3E"
+          "$ref": "#/definitions/JsonRpcError%3C402%2C%22Invalid%20app%20data%22%2Cstructure-1165839259-920-940-1165839259-852-942-1165839259-830-943-1165839259-0-1233%3E"
         },
         {
           "$ref": "#/definitions/JsonRpcError%3C403%2C%22Not%20your%20turn%22%3E"

--- a/packages/client-api-schema/src/methods/UpdateChannel.ts
+++ b/packages/client-api-schema/src/methods/UpdateChannel.ts
@@ -30,11 +30,7 @@ type InvalidAppData = JsonRpcError<
   'Invalid app data',
   {appData: string}
 >;
-type NotYourTurn = JsonRpcError<
-  ErrorCodes['NotYourTurn'],
-  'Not your turn',
-  {currentTurnNum: Uint256}
->;
+type NotYourTurn = JsonRpcError<ErrorCodes['NotYourTurn'], 'Not your turn'>;
 type ChannelClosed = JsonRpcError<ErrorCodes['ChannelClosed'], 'Channel closed'>;
 
 export type UpdateChannelError =

--- a/packages/client-api-schema/src/methods/UpdateChannel.ts
+++ b/packages/client-api-schema/src/methods/UpdateChannel.ts
@@ -1,11 +1,4 @@
-import {
-  ChannelId,
-  Participant,
-  Allocation,
-  ChannelResult,
-  Uint256,
-  ChannelStatus
-} from '../data-types';
+import {ChannelId, Participant, Allocation, ChannelResult, ChannelStatus} from '../data-types';
 import {JsonRpcRequest, JsonRpcResponse, JsonRpcError} from '../utils';
 import {ErrorCodes as AllCodes} from '../error-codes';
 

--- a/packages/client-api-schema/src/types.ts
+++ b/packages/client-api-schema/src/types.ts
@@ -44,11 +44,14 @@ export type Response =
   | CloseAndWithdraw.CloseAndWithdrawResponse
   | GetChannels.GetChannelsResponse;
 
+type GenericError = JsonRpcError<500, 'Wallet error'>;
+
 export type ErrorResponse =
   | EnableEthereum.EnableEthereumError
   | CloseAndWithdraw.CloseAndWithdrawError
   | CloseChannel.CloseChannelError
-  | UpdateChannel.UpdateChannelError;
+  | UpdateChannel.UpdateChannelError
+  | GenericError;
 
 export type JsonRpcMessage = Request | Response | Notification | ErrorResponse;
 
@@ -72,6 +75,7 @@ export * from './methods';
 export * from './data-types';
 
 import {ErrorCodes} from './error-codes';
+import {JsonRpcError} from './utils';
 
 // TODO: Don't export these values
 export const EthereumNotEnabledErrorCode: ErrorCodes['EnableEthereum']['EthereumNotEnabled'] = 100;

--- a/packages/xstate-wallet/src/channel-wallet.ts
+++ b/packages/xstate-wallet/src/channel-wallet.ts
@@ -6,7 +6,7 @@ import React from 'react';
 import {Wallet as WalletUi} from './ui/wallet';
 import {interpret, Interpreter, State} from 'xstate';
 import {Guid} from 'guid-typescript';
-import {Notification, Response} from '@statechannels/client-api-schema';
+import {Notification, Response, ErrorResponse} from '@statechannels/client-api-schema';
 import {filter, take} from 'rxjs/operators';
 import {Message, isOpenChannel, OpenChannel} from './store/types';
 
@@ -185,7 +185,9 @@ export class ChannelWallet {
     await this.messagingService.receiveRequest(jsonRpcMessage, fromDomain);
   }
 
-  public onSendMessage(callback: (jsonRpcMessage: Notification | Response) => void) {
+  public onSendMessage(
+    callback: (jsonRpcMessage: Notification | Response | ErrorResponse) => void
+  ) {
     this.messagingService.outboxFeed.subscribe(m => callback(m));
   }
 }

--- a/packages/xstate-wallet/src/integration-tests/helpers.ts
+++ b/packages/xstate-wallet/src/integration-tests/helpers.ts
@@ -23,6 +23,10 @@ import {makeDestination} from '../utils';
 import {hexZeroPad} from '@ethersproject/bytes';
 import {logger} from '../logger';
 import {ETH_TOKEN} from '../constants';
+import {SignedState} from '../store';
+import {signState} from '../store/state-utils';
+import {SignatureEntry} from '../store/channel-store-entry';
+import _ from 'lodash';
 
 const log = logger.info.bind(logger);
 
@@ -100,6 +104,15 @@ export class Player {
   }
   get participantId(): string {
     return this.signingAddress;
+  }
+
+  signState(state: SignedState): SignedState {
+    const mySignature: SignatureEntry = {
+      signature: signState(state, this.privateKey),
+      signer: this.signingAddress
+    };
+
+    return {...state, signatures: _.unionBy(state.signatures, [mySignature], sig => sig.signature)};
   }
 
   static async createPlayer(

--- a/packages/xstate-wallet/src/integration-tests/running.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/running.test.ts
@@ -1,11 +1,41 @@
 import {FakeChain} from '../chain';
 import {Player, hookUpMessaging, generatePlayerUpdate} from './helpers';
-import waitForExpect from 'wait-for-expect';
 import {simpleEthAllocation} from '../utils';
-import {first} from 'rxjs/operators';
 import {CHAIN_NETWORK_ID} from '../config';
 import {BigNumber, constants} from 'ethers';
+import {ErrorResponse} from '@statechannels/client-api-schema/src';
 jest.setTimeout(30000);
+
+const resolveOnError = (player: Player, errorCode: ErrorResponse['error']['code']) =>
+  new Promise((resolve, reject) => {
+    setTimeout(() => reject(`Timed out waiting for error code ${errorCode}`), 3000);
+    player.messagingService.outboxFeed.subscribe(message => {
+      if ('error' in message) {
+        if (message.error.code === errorCode) resolve(message.error);
+        else reject(`Expected code ${errorCode} but received code ${message.error.code}`);
+      }
+    });
+  });
+
+const resolveOnResponse = (player: Player) =>
+  new Promise((resolve, reject) => {
+    setTimeout(() => reject('Timed out waiting for update channel response'), 3000);
+    player.messagingService.outboxFeed.subscribe(
+      message => 'id' in message && 'result' in message && resolve(message.result)
+    );
+  });
+
+const resolveOnNotification = (player: Player) =>
+  new Promise((resolve, reject) => {
+    setTimeout(() => reject('Timed out waiting for channel updated notification'), 3000);
+    player.messagingService.outboxFeed.subscribe(
+      message =>
+        !('id' in message) &&
+        'method' in message &&
+        message.method === 'ChannelUpdated' &&
+        resolve(message.params)
+    );
+  });
 
 test('accepts states when running', async () => {
   const fakeChain = new FakeChain();
@@ -21,6 +51,13 @@ test('accepts states when running', async () => {
     fakeChain
   );
   const players = [playerA, playerB];
+  const expectTurnNumber = async (n: number) =>
+    Promise.all(
+      players.map(async player => {
+        expect(player.workflowState).toEqual('running');
+        expect((await player.store.getEntry(channelId)).latest.turnNum.toNumber()).toBe(n);
+      })
+    );
 
   const amount = BigNumber.from('0x06f05b59d3b20000');
   const outcome = simpleEthAllocation(players.map(({destination}) => ({destination, amount})));
@@ -41,41 +78,27 @@ test('accepts states when running', async () => {
     signatures: []
   });
   const {channelId} = await players.map(({store}) => store.addState(signedState))[0];
+  const applicationDomain = 'localhost';
 
-  await playerB.store
-    .channelUpdatedFeed(channelId)
-    .pipe(first())
-    .toPromise();
-
-  const context: any = {channelId, applicationDomain: 'localhost', fundingStrategy: 'Direct'};
+  const context: any = {channelId, applicationDomain, fundingStrategy: 'Direct'};
   playerA.startAppWorkflow('running', context);
   playerB.startAppWorkflow('running', context);
   playerA.workflowMachine?.send('SPAWN_OBSERVERS');
   playerB.workflowMachine?.send('SPAWN_OBSERVERS');
-  await playerA.messagingService.receiveRequest(
-    generatePlayerUpdate(channelId, playerA.participant, playerB.participant),
-    'localhost'
-  );
 
-  await waitForExpect(async () => {
-    expect(playerA.workflowState).toEqual('running');
-    expect(playerB.workflowState).toEqual('running');
-    const playerATurnNum = (await playerA.store.getEntry(channelId)).latest.turnNum.toNumber();
-    expect(playerATurnNum).toBe(turnNum.add(1).toNumber());
-    const playerBTurnNum = (await playerB.store.getEntry(channelId)).latest.turnNum.toNumber();
-    expect(playerBTurnNum).toBe(turnNum.add(1).toNumber());
-  }, 3000);
+  const update = generatePlayerUpdate(channelId, playerA.participant, playerB.participant);
+  playerB.messagingService.receiveRequest(update, applicationDomain);
+  await resolveOnError(playerB, 400);
 
-  await playerB.messagingService.receiveRequest(
-    generatePlayerUpdate(channelId, playerA.participant, playerB.participant),
-    'localhost'
-  );
-  await waitForExpect(async () => {
-    expect(playerA.workflowState).toEqual('running');
-    expect(playerB.workflowState).toEqual('running');
-    const playerATurnNum = (await playerA.store.getEntry(channelId)).latest.turnNum.toNumber();
-    expect(playerATurnNum).toBe(turnNum.add(2).toNumber());
-    const playerBTurnNum = (await playerB.store.getEntry(channelId)).latest.turnNum.toNumber();
-    expect(playerBTurnNum).toBe(turnNum.add(2).toNumber());
-  }, 3000);
+  playerA.messagingService.receiveRequest(update, applicationDomain);
+  await resolveOnResponse(playerA);
+  await resolveOnNotification(playerB);
+
+  await expectTurnNumber(turnNum.add(1).toNumber());
+
+  await playerB.messagingService.receiveRequest(update, applicationDomain);
+  await resolveOnResponse(playerB);
+  await resolveOnNotification(playerA);
+
+  await expectTurnNumber(turnNum.add(2).toNumber());
 });

--- a/packages/xstate-wallet/src/messaging.ts
+++ b/packages/xstate-wallet/src/messaging.ts
@@ -56,7 +56,7 @@ export const isChannelProposed = (m: Response | Notification): m is ChannelPropo
   'method' in m && m.method === 'ChannelProposed';
 
 export interface MessagingServiceInterface {
-  readonly outboxFeed: Observable<Response | Notification>;
+  readonly outboxFeed: Observable<Response | Notification | ErrorResponse>;
   readonly requestFeed: Observable<AppRequestEvent>;
 
   receiveRequest(jsonRpcMessage: Request, fromDomain: string): Promise<void>;

--- a/packages/xstate-wallet/src/serde/app-messages/serialize.ts
+++ b/packages/xstate-wallet/src/serde/app-messages/serialize.ts
@@ -73,7 +73,7 @@ function serializeAllocationItem(allocationItem: AllocationItem): AppAllocationI
 
 export function serializeChannelEntry(channelEntry: ChannelStoreEntry): ChannelResult {
   const {
-    latest: {appData, turnNum, outcome}, // FIXME: This should be supported
+    latest: {appData, turnNum, outcome}, // TODO: This should be supported
     channelConstants: {participants, appDefinition},
     channelId
   } = channelEntry;

--- a/packages/xstate-wallet/src/serde/app-messages/serialize.ts
+++ b/packages/xstate-wallet/src/serde/app-messages/serialize.ts
@@ -72,9 +72,11 @@ function serializeAllocationItem(allocationItem: AllocationItem): AppAllocationI
 }
 
 export function serializeChannelEntry(channelEntry: ChannelStoreEntry): ChannelResult {
-  const {latest, channelId} = channelEntry;
-  const {appData, turnNum, outcome} = latest;
-  const {participants, appDefinition} = channelEntry.channelConstants;
+  const {
+    latest: {appData, turnNum, outcome}, // FIXME: This should be supported
+    channelConstants: {participants, appDefinition},
+    channelId
+  } = channelEntry;
 
   if (!isAllocation(outcome)) {
     throw new Error('Can only send allocations to the app');

--- a/packages/xstate-wallet/src/store/dexie-backend.ts
+++ b/packages/xstate-wallet/src/store/dexie-backend.ts
@@ -168,6 +168,10 @@ export class Backend implements DBBackend {
     return this.put(ObjectStores.objectives, value, Number(key)) as Promise<Objective>;
   }
 
+  public get transactionOngoing() {
+    return !!Dexie.currentTransaction;
+  }
+
   public async transaction<T, S extends ObjectStores>(
     mode: TXMode,
     stores: S[],

--- a/packages/xstate-wallet/src/store/index.ts
+++ b/packages/xstate-wallet/src/store/index.ts
@@ -51,6 +51,7 @@ export function isGuarantee(funding): funding is Guarantee {
 export function isGuarantees(funding): funding is Guarantees {
   return funding.type === 'Guarantees';
 }
+
 export enum Errors {
   duplicateTurnNums = 'multiple states with same turn number',
   notSorted = 'states not sorted',
@@ -67,5 +68,11 @@ export enum Errors {
   budgetAlreadyExists = 'There already exists a budget for this domain',
   budgetInsufficient = 'Budget insufficient to reserve funds',
   amountUnauthorized = 'Amount unauthorized in current budget',
-  cannotFindDestination = 'Cannot find destination for participant'
+  cannotFindDestination = 'Cannot find destination for participant',
+  cannotFindPrivateKey = 'Private key missing for your address',
+  notInChannel = 'Attempting to initialize  channel as a non-participant',
+  noLedger = 'No ledger exists with peer',
+  amountNotFound = 'Cannot find allocation entry with destination',
+  invalidNonce = 'Invalid nonce',
+  emittingDuringTransaction = 'Attempting to emit event during transaction'
 }

--- a/packages/xstate-wallet/src/store/index.ts
+++ b/packages/xstate-wallet/src/store/index.ts
@@ -74,5 +74,6 @@ export enum Errors {
   noLedger = 'No ledger exists with peer',
   amountNotFound = 'Cannot find allocation entry with destination',
   invalidNonce = 'Invalid nonce',
-  emittingDuringTransaction = 'Attempting to emit event during transaction'
+  emittingDuringTransaction = 'Attempting to emit event during transaction',
+  notMyTurn = "Cannot update channel unless it's your turn"
 }

--- a/packages/xstate-wallet/src/store/memory-backend.ts
+++ b/packages/xstate-wallet/src/store/memory-backend.ts
@@ -119,4 +119,6 @@ export class MemoryBackend implements DBBackend {
   public async transaction<T>(_mode: TXMode, _stores: ObjectStores[], cb: (tx: any) => Promise<T>) {
     return cb({abort: () => null});
   }
+
+  public transactionOngoing = false;
 }

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -310,10 +310,10 @@ export class Store {
         const {supported: existingState, myTurn} = await this.getEntry(channelId);
         if (!myTurn) throw Error(Errors.notMyTurn);
 
-        const newState = _.merge(
-          {turnNum: existingState.turnNum.add(1), ...updateData},
-          existingState
-        );
+        const newState = _.merge(existingState, {
+          turnNum: existingState.turnNum.add(1),
+          ...updateData
+        });
 
         return this.signAndAddStateWithinTx(channelId, newState);
       })

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -307,8 +307,9 @@ export class Store {
   ) =>
     this.backend
       .transaction('readwrite', [ObjectStores.channels, ObjectStores.privateKeys], async () => {
-        const entry = await this.getEntry(channelId);
-        const existingState = entry.latest;
+        const {supported: existingState, myTurn} = await this.getEntry(channelId);
+        if (!myTurn) throw Error(Errors.notMyTurn);
+
         const newState = {
           ...existingState,
           turnNum: existingState.turnNum.add(1),

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -307,9 +307,8 @@ export class Store {
   ) =>
     this.backend
       .transaction('readwrite', [ObjectStores.channels, ObjectStores.privateKeys], async () => {
-        const {latest: existingState} = await this.getEntry(channelId);
-        // FIXME: Tests fail when I try to do the following check because they don't set up a channel with a supported state
-        // if (!myTurn) throw Error(Errors.notMyTurn);
+        const {supported: existingState, myTurn} = await this.getEntry(channelId);
+        if (!myTurn) throw Error(Errors.notMyTurn);
 
         const newState = _.merge(existingState, {
           turnNum: existingState.turnNum.add(1),

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -157,13 +157,8 @@ export class Store {
         const addresses = state.participants.map(x => x.signingAddress);
         const privateKeys = await this.backend.privateKeys();
         const myIndex = addresses.findIndex(address => !!privateKeys[address]);
-        if (myIndex === -1) {
-          throw new Error("Couldn't find the signing key for any participant in wallet.");
-        }
+        if (myIndex === -1) throw Error(Errors.notInChannel);
 
-        const channelId = calculateChannelId(state);
-
-        // TODO: There could be concurrency problems which lead to entries potentially being overwritten.
         await this.setNonce(addresses, state.channelNonce);
 
         const data: ChannelStoredData = {
@@ -173,7 +168,8 @@ export class Store {
           funding: undefined,
           applicationDomain
         };
-        await this.backend.setChannel(channelId, data);
+
+        await this.backend.setChannel(calculateChannelId(state), data);
         return new ChannelStoreEntry(data);
       }
     );
@@ -205,8 +201,7 @@ export class Store {
       [ObjectStores.ledgers, ObjectStores.channels],
       async () => {
         const ledgerId = await this.backend.getLedger(peerId);
-
-        if (!ledgerId) throw new Error(`No ledger exists with peer ${peerId}`);
+        if (!ledgerId) throw Error(Errors.noLedger + `: ${peerId}`);
 
         return await this.getEntry(ledgerId);
       }
@@ -216,8 +211,7 @@ export class Store {
     this.backend.transaction('readwrite', [ObjectStores.channels], async () => {
       const entry = await this.getEntry(channelId);
 
-      if (typeof entry.applicationDomain === 'string')
-        throw new Error(Errors.domainExistsOnChannel);
+      if (typeof entry.applicationDomain === 'string') throw Error(Errors.domainExistsOnChannel);
 
       await this.backend.setChannel(channelId, {...entry.data(), applicationDomain});
     });
@@ -232,9 +226,8 @@ export class Store {
         // This is not on the Store interface itself -- it is useful to set up a test store
         await this.backend.setChannel(entry.channelId, entry.data());
         const address = await this.getAddress();
-        const peerId = entry.participants.find(p => p.signingAddress !== address);
-        if (peerId) await this.backend.setLedger(peerId.participantId, entry.channelId);
-        else throw 'No peer';
+        const hub = entry.participants.find(p => p.signingAddress !== address) as Participant;
+        await this.backend.setLedger(hub.participantId, entry.channelId);
       }
     );
 
@@ -256,49 +249,47 @@ export class Store {
     appDefinition = AddressZero,
     applicationDomain?: string
   ) =>
-    this.backend.transaction(
-      'readwrite',
-      [ObjectStores.privateKeys, ObjectStores.nonces, ObjectStores.channels],
-      async () => {
-        const addresses = participants.map(x => x.signingAddress);
-        const privateKeys = await this.backend.privateKeys();
-        const myIndex = addresses.findIndex(address => !!privateKeys[address]);
-        if (myIndex === -1) {
-          throw new Error("Couldn't find the signing key for any participant in wallet.");
+    this.backend
+      .transaction(
+        'readwrite',
+        [ObjectStores.privateKeys, ObjectStores.nonces, ObjectStores.channels],
+        async () => {
+          stateVars = _.pick(stateVars, 'outcome', 'turnNum', 'appData', 'isFinal');
+          const addresses = participants.map(x => x.signingAddress);
+          const privateKeys = await this.backend.privateKeys();
+          const myIndex = addresses.findIndex(address => !!privateKeys[address]);
+          if (myIndex === -1) {
+            throw Error(Errors.notInChannel);
+          }
+
+          const channelNonce = (await this.getNonce(addresses)).add(1);
+          const chainId = CHAIN_NETWORK_ID;
+
+          const entry = await this.initializeChannel(
+            {
+              chainId,
+              challengeDuration,
+              channelNonce,
+              participants,
+              appDefinition,
+              ...stateVars
+            },
+            applicationDomain
+          );
+          return this.signAndAddStateWithinTx(entry.channelId, stateVars);
         }
+      )
+      .then(({entry, signedState}) => this.emitChannelUpdatedEventAfterTX(entry, signedState));
 
-        const channelNonce = (await this.getNonce(addresses)).add(1);
-        const chainId = CHAIN_NETWORK_ID;
-
-        const entry = await this.initializeChannel(
-          {
-            chainId,
-            challengeDuration,
-            channelNonce,
-            participants,
-            appDefinition,
-            ...stateVars
-          },
-          applicationDomain
-        );
-        // sign the state, store the channel
-        return this.signAndAddState(
-          entry.channelId,
-          _.pick(stateVars, 'outcome', 'turnNum', 'appData', 'isFinal')
-        );
-      }
-    );
   private async getNonce(addresses: string[]): Promise<BigNumber> {
     const nonce = await this.backend.getNonce(this.nonceKeyFromAddresses(addresses));
     return nonce || BigNumber.from(-1);
   }
 
   private async setNonce(addresses: string[], value: BigNumber) {
-    const nonce = await this.getNonce(addresses);
     // TODO: Figure out why the lte check is failing
-    if (value.lt(nonce)) {
-      throw 'Invalid nonce';
-    }
+    if (value.lt(await this.getNonce(addresses))) throw Error(Errors.invalidNonce);
+
     await this.backend.setNonce(this.nonceKeyFromAddresses(addresses), value);
   }
 
@@ -306,7 +297,7 @@ export class Store {
 
   public async getPrivateKey(signingAddress: string): Promise<string> {
     const ret = await this.backend.getPrivateKey(signingAddress);
-    if (!ret) throw new Error('No longer have private key');
+    if (!ret) throw Error(Errors.cannotFindPrivateKey);
     return ret;
   }
 
@@ -326,61 +317,46 @@ export class Store {
           isFinal: updateData.isFinal || existingState.isFinal
         };
 
-        const {participants} = entry;
-        const myAddress = participants[entry.myIndex].signingAddress;
-        const privateKey = await this.backend.getPrivateKey(myAddress);
-
-        if (!privateKey) {
-          throw new Error('No longer have private key');
-        }
-        const signedState = entry.signAndAdd(
-          _.pick(newState, 'outcome', 'turnNum', 'appData', 'isFinal'),
-          privateKey
-        );
-        await this.backend.setChannel(channelId, entry.data());
-        return {entry, signedState};
+        return this.signAndAddStateWithinTx(channelId, newState);
       })
-      .then(({entry, signedState}) => {
-        // These events trigger callbacks that should not run within the transaction scope
-        // See https://github.com/dfahlander/Dexie.js/issues/1029
-        this._eventEmitter.emit('channelUpdated', entry);
-        this._eventEmitter.emit('addToOutbox', {signedStates: [signedState]});
+      .then(({entry, signedState}) => this.emitChannelUpdatedEventAfterTX(entry, signedState));
 
-        return entry;
-      });
+  private emitChannelUpdatedEventAfterTX(entry: ChannelStoreEntry, signedState?: SignedState) {
+    // These events trigger callbacks that should not run within the transaction scope
+    // See https://github.com/dfahlander/Dexie.js/issues/1029
+
+    if (this.backend.transactionOngoing) throw Error(Errors.emittingDuringTransaction);
+
+    this._eventEmitter.emit('channelUpdated', entry);
+    if (signedState) this._eventEmitter.emit('addToOutbox', {signedStates: [signedState]});
+
+    return entry;
+  }
 
   public signAndAddState = (channelId: string, stateVars: StateVariables) =>
-    this.backend
-      .transaction('readwrite', [ObjectStores.channels, ObjectStores.privateKeys], async () => {
+    this.signAndAddStateWithinTx(channelId, stateVars).then(({entry, signedState}) =>
+      this.emitChannelUpdatedEventAfterTX(entry, signedState)
+    );
+
+  private signAndAddStateWithinTx = (channelId: string, stateVars: StateVariables) =>
+    this.backend.transaction(
+      'readwrite',
+      [ObjectStores.channels, ObjectStores.privateKeys],
+      async () => {
         const entry = await this.getEntry(channelId);
 
-        const {participants} = entry;
-        const myAddress = participants[entry.myIndex].signingAddress;
-        const privateKey = await this.backend.getPrivateKey(myAddress);
-
-        if (!privateKey) {
-          throw new Error('No longer have private key');
-        }
         const signedState = entry.signAndAdd(
           _.pick(stateVars, 'outcome', 'turnNum', 'appData', 'isFinal'),
-          privateKey
+          await this.getPrivateKey(entry.myAddress)
         );
         await this.backend.setChannel(channelId, entry.data());
         return {entry, signedState};
-      })
-      .then(({entry, signedState}) => {
-        // These events trigger callbacks that should not run within the transaction scope
-        // See https://github.com/dfahlander/Dexie.js/issues/1029
-        this._eventEmitter.emit('channelUpdated', entry);
-        this._eventEmitter.emit('addToOutbox', {signedStates: [signedState]});
-
-        return entry;
-      });
+      }
+    );
 
   async addObjective(objective: Objective, addToOutbox = true) {
     const objectives = this.objectives;
     if (!_.find(objectives, o => _.isEqual(o, objective))) {
-      // TODO: Should setObjective take a key??
       this.objectives.push(objective);
       addToOutbox && this._eventEmitter.emit('addToOutbox', {objectives: [objective]});
       this._eventEmitter.emit('newObjective', objective);
@@ -402,9 +378,7 @@ export class Store {
           return memoryChannelStorage;
         }
       )
-      // This event triggers callbacks that should not run within the transaction scope
-      // See https://github.com/dfahlander/Dexie.js/issues/1029
-      .then(entry => this._eventEmitter.emit('channelUpdated', entry));
+      .then(entry => this.emitChannelUpdatedEventAfterTX(entry));
 
   public async getAddress(): Promise<string> {
     const privateKeys = await this.backend.privateKeys();
@@ -453,22 +427,22 @@ export class Store {
       async () => {
         const {applicationDomain, supported, participants} = await this.getEntry(ledgerChannelId);
         const {outcome} = supported;
-        if (typeof applicationDomain !== 'string') throw new Error(Errors.noDomainForChannel);
+        if (typeof applicationDomain !== 'string') throw Error(Errors.noDomainForChannel);
 
         const currentBudget = await this.getBudget(applicationDomain);
 
         const assetBudget = currentBudget?.forAsset[assetHolderAddress];
 
-        if (!currentBudget || !assetBudget) throw new Error(Errors.noBudget);
+        if (!currentBudget || !assetBudget) throw Error(Errors.noBudget);
 
         const channelBudget = assetBudget.channels[targetChannelId];
-        if (!channelBudget) throw new Error(Errors.channelNotInBudget);
+        if (!channelBudget) throw Error(Errors.channelNotInBudget);
         const playerAddress = await this.getAddress();
 
         const playerDestination = participants.find(p => p.signingAddress === playerAddress)
           ?.destination;
         if (!playerDestination) {
-          throw new Error(Errors.cannotFindDestination);
+          throw Error(Errors.cannotFindDestination);
         }
         // Simply set the budget to the current ledger outcome
         assetBudget.availableSendCapacity = getAllocationAmount(outcome, playerDestination);
@@ -493,21 +467,20 @@ export class Store {
       async () => {
         const entry = await this.getEntry(channelId);
         const domain = entry.applicationDomain;
-        if (typeof domain !== 'string')
-          throw new Error(Errors.noDomainForChannel + ' ' + channelId);
+        if (typeof domain !== 'string') throw Error(Errors.noDomainForChannel + ' ' + channelId);
         const currentBudget = await this.backend.getBudget(domain);
 
         // TODO?: Create a new budget if one doesn't exist
-        if (!currentBudget) throw new Error(Errors.noBudget + domain);
+        if (!currentBudget) throw Error(Errors.noBudget + domain);
 
         const assetBudget = currentBudget?.forAsset[assetHolderAddress];
-        if (!assetBudget) throw new Error(Errors.noAssetBudget);
+        if (!assetBudget) throw Error(Errors.noAssetBudget);
 
         if (
           assetBudget.availableSendCapacity.lt(amount.send) ||
           assetBudget.availableReceiveCapacity.lt(amount.receive)
         ) {
-          throw new Error(Errors.budgetInsufficient);
+          throw Error(Errors.budgetInsufficient);
         }
 
         currentBudget.forAsset[assetHolderAddress] = {
@@ -534,8 +507,7 @@ export function supportedStateFeed(store: Store, channelId: string) {
 function getAllocationAmount(outcome: Outcome, destination: string) {
   const {allocationItems} = checkThat(outcome, isSimpleEthAllocation);
   const amount = allocationItems.find(a => a.destination === destination)?.amount;
-  if (!amount) {
-    throw new Error(`Cannot find allocation entry with destination ${destination}`);
-  }
+  if (!amount) throw Error(Errors.amountNotFound + ` ${destination}`);
+
   return amount;
 }

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -307,8 +307,9 @@ export class Store {
   ) =>
     this.backend
       .transaction('readwrite', [ObjectStores.channels, ObjectStores.privateKeys], async () => {
-        const {supported: existingState, myTurn} = await this.getEntry(channelId);
-        if (!myTurn) throw Error(Errors.notMyTurn);
+        const {latest: existingState} = await this.getEntry(channelId);
+        // FIXME: Tests fail when I try to do the following check because they don't set up a channel with a supported state
+        // if (!myTurn) throw Error(Errors.notMyTurn);
 
         const newState = _.merge(existingState, {
           turnNum: existingState.turnNum.add(1),

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -303,20 +303,17 @@ export class Store {
 
   public updateChannel = (
     channelId: string,
-    updateData: {outcome: SimpleAllocation; appData: string; isFinal?: boolean}
+    updateData: Partial<{outcome: SimpleAllocation; appData: string; isFinal: boolean}>
   ) =>
     this.backend
       .transaction('readwrite', [ObjectStores.channels, ObjectStores.privateKeys], async () => {
         const {supported: existingState, myTurn} = await this.getEntry(channelId);
         if (!myTurn) throw Error(Errors.notMyTurn);
 
-        const newState = {
-          ...existingState,
-          turnNum: existingState.turnNum.add(1),
-          appData: updateData.appData,
-          outcome: updateData.outcome,
-          isFinal: updateData.isFinal || existingState.isFinal
-        };
+        const newState = _.merge(
+          {turnNum: existingState.turnNum.add(1), ...updateData},
+          existingState
+        );
 
         return this.signAndAddStateWithinTx(channelId, newState);
       })

--- a/packages/xstate-wallet/src/store/tests/dexie-store.test.ts
+++ b/packages/xstate-wallet/src/store/tests/dexie-store.test.ts
@@ -133,9 +133,7 @@ describe('createChannel', () => {
 
     await expect(
       store.createChannel(participants, challengeDuration, stateVars, appDefinition)
-    ).rejects.toMatchObject({
-      message: "Couldn't find the signing key for any participant in wallet."
-    });
+    ).rejects.toMatchObject({message: Errors.notInChannel});
   });
 });
 

--- a/packages/xstate-wallet/src/store/tests/memory-store.test.ts
+++ b/packages/xstate-wallet/src/store/tests/memory-store.test.ts
@@ -7,6 +7,7 @@ import {State, Objective} from './../types';
 import {Wallet, BigNumber} from 'ethers';
 import {Store} from './../store';
 import {Zero} from '@ethersproject/constants';
+import {Errors} from '..';
 
 const {address: aAddress, privateKey: aPrivateKey} = new Wallet(
   '0x95942b296854c97024ca3145abef8930bf329501b718c0f66d57dba596ff1318'
@@ -128,9 +129,7 @@ describe('createChannel', () => {
 
     await expect(
       store.createChannel(participants, challengeDuration, stateVars, appDefinition)
-    ).rejects.toMatchObject({
-      message: "Couldn't find the signing key for any participant in wallet."
-    });
+    ).rejects.toMatchObject({message: Errors.notInChannel});
   });
 });
 

--- a/packages/xstate-wallet/src/store/types.ts
+++ b/packages/xstate-wallet/src/store/types.ts
@@ -197,6 +197,7 @@ export interface DBBackend {
     stores: S[],
     cb: (tx: Transaction) => Promise<T>
   ): Promise<T>;
+  transactionOngoing: boolean;
 }
 
 export type Transaction = {

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -339,13 +339,12 @@ export const workflow = (
       requestId: event.requestId
     })),
     updateChannel: async (context: ChannelIdExists, event: PlayerStateUpdate) => {
-      // TODO: This should probably be done in a service and we should handle the failure cases
-      // For now we update the store and then send the response in one action so the response has the latest state
-      // FIXME: In fact, an action seems to be appropriate:
       if (context.channelId === event.channelId) {
         try {
-          const entry = await store.updateChannel(event.channelId, event);
-          messagingService.sendResponse(event.requestId, serializeChannelEntry(entry));
+          messagingService.sendResponse(
+            event.requestId,
+            serializeChannelEntry(await store.updateChannel(event.channelId, event))
+          );
         } catch (error) {
           const matches = reason => new RegExp(reason).test(error.message);
 

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -16,7 +16,7 @@ import {MessagingServiceInterface} from '../messaging';
 import {filter, map, distinctUntilChanged} from 'rxjs/operators';
 import {createMockGuard, unreachable} from '../utils';
 
-import {Store} from '../store';
+import {Store, Errors} from '../store';
 import {StateVariables} from '../store/types';
 import {ChannelStoreEntry} from '../store/channel-store-entry';
 import {BigNumber} from 'ethers';
@@ -30,7 +30,7 @@ import {
   PlayerRequestConclude,
   OpenEvent
 } from '../event-types';
-import {FundingStrategy} from '@statechannels/client-api-schema';
+import {FundingStrategy, ErrorResponse} from '@statechannels/client-api-schema';
 import {serializeChannelEntry} from '../serde/app-messages/serialize';
 import {CONCLUDE_TIMEOUT} from '../constants';
 import _ from 'lodash';
@@ -77,7 +77,7 @@ export interface WorkflowActions {
   hideUi: Action<WorkflowContext, any>;
   sendChannelUpdatedNotification: Action<WorkflowContext, any>;
   spawnObservers: AssignAction<ChannelIdExists, any>;
-  updateStoreAndSendResponse: Action<WorkflowContext, PlayerStateUpdate>;
+  updateChannel: Action<WorkflowContext, PlayerStateUpdate>;
 }
 
 export type WorkflowEvent =
@@ -192,7 +192,7 @@ const generateConfig = (
         SPAWN_OBSERVERS: {actions: actions.spawnObservers},
         PLAYER_STATE_UPDATE: {
           target: 'running',
-          actions: [actions.updateStoreAndSendResponse]
+          actions: [actions.updateChannel]
         },
         CHANNEL_UPDATED: [
           {target: 'closing', cond: guards.channelClosing},
@@ -338,13 +338,28 @@ export const workflow = (
     assignRequestId: assign((context, event: JoinChannelEvent | PlayerRequestConclude) => ({
       requestId: event.requestId
     })),
-    updateStoreAndSendResponse: async (context: ChannelIdExists, event: PlayerStateUpdate) => {
+    updateChannel: async (context: ChannelIdExists, event: PlayerStateUpdate) => {
       // TODO: This should probably be done in a service and we should handle the failure cases
       // For now we update the store and then send the response in one action so the response has the latest state
       // FIXME: In fact, an action seems to be appropriate:
       if (context.channelId === event.channelId) {
-        const entry = await store.updateChannel(event.channelId, event);
-        await messagingService.sendResponse(event.requestId, serializeChannelEntry(entry));
+        try {
+          const entry = await store.updateChannel(event.channelId, event);
+          messagingService.sendResponse(event.requestId, serializeChannelEntry(entry));
+        } catch (error) {
+          const matches = reason => new RegExp(reason).test(error.message);
+
+          // TODO: Catch other errors
+          let message: ErrorResponse['error'];
+          if (matches(Errors.channelMissing)) message = {code: 403, message: 'Not your turn'};
+          else if (matches(Errors.notMyTurn)) message = {code: 400, message: 'Channel not found'};
+          else {
+            message = {code: 500, message: 'Wallet error'};
+            console.error({error}, 'UpdateChannel call failed with error 500');
+          }
+
+          messagingService.sendError(event.requestId, message);
+        }
       }
     }
   };
@@ -442,7 +457,7 @@ const mockActions: Record<keyof WorkflowActions, string> = {
   hideUi: 'hideUi',
   displayUi: 'displayUi',
   spawnObservers: 'spawnObservers',
-  updateStoreAndSendResponse: 'updateStoreAndSendResponse',
+  updateChannel: 'updateChannel',
   assignRequestId: 'assignRequestId'
 };
 

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -281,7 +281,7 @@ export const workflow = (
     },
 
     sendCloseChannelRejection: async (context: RequestIdExists & ChannelIdExists) => {
-      // FIXME: Shouldn't this inspect the error?
+      // TODO: Shouldn't this inspect the error?
       await messagingService.sendError(context.requestId, {code: 300, message: 'Not your turn'});
     },
 
@@ -368,7 +368,7 @@ export const workflow = (
       !event.storeEntry.latestSignedByMe.isFinal,
 
     channelClosing: (_: ChannelIdExists, event: ChannelUpdated): boolean =>
-      !!event.storeEntry.latest?.isFinal, // FIXME: Should use supported
+      !!event.storeEntry.latest?.isFinal, // TODO: Should use supported
 
     channelChallenging: (context: ChannelIdExists, event: ChannelUpdated): boolean =>
       !!event.storeEntry.isChallenging,

--- a/packages/xstate-wallet/src/workflows/conclude-channel.ts
+++ b/packages/xstate-wallet/src/workflows/conclude-channel.ts
@@ -11,12 +11,8 @@ const WORKFLOW = 'conclude-channel';
 
 export type Init = {channelId: string};
 
-const signFinalState = (store: Store) => async ({channelId}: Init): Promise<void> => {
-  const {supported, latestSignedByMe} = await store.getEntry(channelId);
-  if (!supported.isFinal) throw new Error('Supported state not final');
-  if (latestSignedByMe.turnNum.eq(supported.turnNum)) return; // already signed
-  await store.signAndAddState(channelId, supported);
-};
+const signFinalState = (store: Store) => async ({channelId}: Init): Promise<void> =>
+  store.signFinalState(channelId);
 
 const waitForConclusionProof = (store: Store) => async ({channelId}: Init) =>
   store

--- a/packages/xstate-wallet/src/workflows/support-state.ts
+++ b/packages/xstate-wallet/src/workflows/support-state.ts
@@ -3,8 +3,6 @@ import {filter, map} from 'rxjs/operators';
 import {Store} from '../store';
 import {statesEqual, calculateChannelId} from '../store/state-utils';
 import {State} from '../store/types';
-import {logger} from '../logger';
-const warn = logger.warn.bind(logger);
 const WORKFLOW = 'support-state';
 
 export type Init = {state: State; observer?: Actor<any, any>};
@@ -38,18 +36,7 @@ type Options = {
   actions: {spawnObserver: AssignAction<HasChannelId, any>};
 };
 
-const signState = (store: Store) => async ({state, channelId}: HasChannelId) => {
-  const entry = await store.getEntry(channelId);
-  const {isSupportedByMe} = entry;
-  // We only sign the state if we haven't signed it already
-  if (!isSupportedByMe || !statesEqual(entry.latestSignedByMe, state)) {
-    await store.signAndAddState(channelId, state);
-  } else if (statesEqual(entry.latestSignedByMe, state)) {
-    // The support state machine was started with a state that we already support
-    // That's fine but we output a warning in case that's unexpected
-    warn({state}, 'The state is already supported');
-  }
-};
+const signState = (store: Store) => async ({state}: HasChannelId) => store.supportState(state);
 
 const notifyWhenSupported = (store: Store, {state, channelId}: HasChannelId) =>
   store.channelUpdatedFeed(channelId).pipe(


### PR DESCRIPTION
Ticks R1, R3 & R6 of https://github.com/statechannels/monorepo/issues/1909

- Refactors the store according to the discussion on https://github.com/statechannels/monorepo/pull/1933
   - Channel updates now all (?) occur within a transaction
- Adds a generic wallet error with code 500
- Refactors the running test not to use `waitForExpect`, but instead block on responses and notifications
   - running test also tests for one error response, when it is not your turn
- Updates the `application` workflow to send error responses during a `PlayerUpdate`

# TODO:
Will remove draft status when
- [x] FIXME messages are resolved