### PR TITLE
W3t close channel

### DIFF
--- a/packages/e2e-tests/puppeteer/__tests__/stress.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/stress.test.ts
@@ -51,7 +51,7 @@ describe('One file, three leechers, one seeder', () => {
     async () => CLOSE_BROWSERS && (await forEachActor(async ({browser}) => browser.close()))
   );
 
-  it('allows peers to start torrenting', async () => {
+  it('Allows peers to share a torrent completely', async () => {
     let i = 1;
     console.log('Opening browsers');
     await assignEachLabel(async () => {
@@ -83,8 +83,8 @@ describe('One file, three leechers, one seeder', () => {
     console.log('Downloading');
     await forEachActor(({tab}) => waitForNthState(tab, 10));
 
-    console.log('C cancels download');
-    await cancelDownload(actors.C.tab);
+    // console.log('C cancels download'); // disabled to test the correct multiple channel closing
+    // await cancelDownload(actors.C.tab);
 
     console.log('Waiting for channels to close');
     await forEachActor(({tab}) => waitForClosedState(tab));

--- a/packages/e2e-tests/puppeteer/__tests__/stress.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/stress.test.ts
@@ -13,7 +13,7 @@ import {
   waitForClosedState
 } from '../helpers';
 
-import {uploadFile, startDownload, cancelDownload} from '../scripts/web3torrent';
+import {uploadFile, startDownload} from '../scripts/web3torrent';
 import {Dappeteer} from 'dappeteer';
 import {CLOSE_BROWSERS} from '../constants';
 const USE_DAPPETEER = false;

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -204,7 +204,7 @@ export class PaymentChannelClient {
     this.insertIntoChannelCache(convertToChannelState(channelResult));
   }
 
-  async closeChannel(channelId: string, waitForMyTurn = false): Promise<ChannelState> {
+  async closeChannel(channelId: string): Promise<ChannelState> {
     const isClosed = (channelState: ChannelState) =>
       channelState.channelId === channelId && channelState.status === 'closed';
 

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -210,7 +210,6 @@ export class PaymentChannelClient {
 
     if (!['closing', 'closed'].includes(this.channelCache[channelId].status)) {
       await this.getLatestPaymentReceipt(channelId);
-      log.info('My turn, about to close channel');
       this.channelClient.closeChannel(channelId);
     }
     return this.channelClient.channelState

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -210,8 +210,8 @@ export class PaymentChannelClient {
 
     if (!['closing', 'closed'].includes(this.channelCache[channelId].status)) {
       await this.getLatestPaymentReceipt(channelId);
+      log.info('My turn, about to close channel');
       this.channelClient.closeChannel(channelId);
-      log.info('closeChannel() - channelClient.closeChannel() called!');
     }
     return this.channelClient.channelState
       .pipe(map(convertToChannelState), filter(isClosed), first())

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -209,11 +209,7 @@ export class PaymentChannelClient {
       channelState.channelId === channelId && channelState.status === 'closed';
 
     if (!['closing', 'closed'].includes(this.channelCache[channelId].status)) {
-      if (waitForMyTurn) {
-        log.info('closeChannel() - Waiting in line');
-        await this.getLatestPaymentReceipt(channelId);
-        log.info('closeChannel() - Ready to Close!');
-      }
+      await this.getLatestPaymentReceipt(channelId);
       this.channelClient.closeChannel(channelId);
       log.info('closeChannel() - channelClient.closeChannel() called!');
     }

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -518,18 +518,18 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
       torrent.wires.map(async wire => {
         const {seedingChannelId, leechingChannelId} = wire.paidStreamingExtension;
         if (leechingChannelId) {
-          log.info(`SP-> About to close payment channel ${leechingChannelId}`);
-          return this.paymentChannelClient.closeChannel(leechingChannelId, true).then(() => {
+          log.info(`About to close payment channel ${leechingChannelId}`);
+          return this.paymentChannelClient.closeChannel(leechingChannelId).then(() => {
             wire.paidStreamingExtension.leechingChannelId = null;
-            log.info(`SP-> Channel closed: ${leechingChannelId}`);
+            log.info(`Channel closed: ${leechingChannelId}`);
           });
         }
 
         if (includeSeedChannels && seedingChannelId) {
-          log.info(`SP-> About to close paying channel ${seedingChannelId}`);
-          return this.paymentChannelClient.closeChannel(seedingChannelId, true).then(() => {
+          log.info(`About to close paying channel ${seedingChannelId}`);
+          return this.paymentChannelClient.closeChannel(seedingChannelId).then(() => {
             wire.paidStreamingExtension.seedingChannelId = null;
-            log.info(`SP-> Channel closed: ${seedingChannelId}`);
+            log.info(`Channel closed: ${seedingChannelId}`);
           });
         }
       })

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -518,19 +518,19 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
       torrent.wires.map(async wire => {
         const {seedingChannelId, leechingChannelId} = wire.paidStreamingExtension;
         if (leechingChannelId) {
-          log.info(`About to close payment channel ${leechingChannelId}`);
-          await this.paymentChannelClient.getLatestPaymentReceipt(leechingChannelId);
-          await this.paymentChannelClient.closeChannel(leechingChannelId);
-          wire.paidStreamingExtension.leechingChannelId = null;
-          log.info(`Channel ${leechingChannelId} closed`);
+          log.info(`SP-> About to close payment channel ${leechingChannelId}`);
+          return this.paymentChannelClient.closeChannel(leechingChannelId, true).then(() => {
+            wire.paidStreamingExtension.leechingChannelId = null;
+            log.info(`SP-> Channel closed: ${leechingChannelId}`);
+          });
         }
 
         if (includeSeedChannels && seedingChannelId) {
-          // TODO: do we need to make something like getLatestPaymentReceipt for this case?
-          log.info(`About to close paying channel ${seedingChannelId}`);
-          await this.paymentChannelClient.closeChannel(seedingChannelId);
-          wire.paidStreamingExtension.seedingChannelId = null;
-          log.info(`Channel ${seedingChannelId} closed`);
+          log.info(`SP-> About to close paying channel ${seedingChannelId}`);
+          return this.paymentChannelClient.closeChannel(seedingChannelId, true).then(() => {
+            wire.paidStreamingExtension.seedingChannelId = null;
+            log.info(`SP-> Channel closed: ${seedingChannelId}`);
+          });
         }
       })
     );


### PR DESCRIPTION
This PR:
- Prevents the web3torrentClient to trigger payments while a torrent is being cancelled (by pausing the torrent):
https://github.com/statechannels/monorepo/compare/w3t-close-channel?expand=1#diff-a84153ed9f3ab2bd13c41bca43b584c7R134
https://github.com/statechannels/monorepo/compare/w3t-close-channel?expand=1#diff-a84153ed9f3ab2bd13c41bca43b584c7L401
- moves the logic of waiting for the user's turn before closing to the PaymentChannelClient:
https://github.com/statechannels/monorepo/compare/w3t-close-channel?expand=1#diff-9b0f77e1a02c15a73ad86b3e5d0b6620R212
- Makes channelClose calls independent of each other:
https://github.com/statechannels/monorepo/compare/w3t-close-channel?expand=1#diff-a84153ed9f3ab2bd13c41bca43b584c7R522-R525

related to #1961 and #1918 and #1811