### PR TITLE
[simple-hub] Do not log to an empty destination

### DIFF
--- a/packages/simple-hub/src/logger.ts
+++ b/packages/simple-hub/src/logger.ts
@@ -1,7 +1,7 @@
 import pino from 'pino';
 import {LOG_DESTINATION, IS_PRODUCTION} from './constants';
 const LOG_TO_CONSOLE = LOG_DESTINATION === 'console';
-const LOG_TO_FILE = !LOG_TO_CONSOLE;
+const LOG_TO_FILE = LOG_DESTINATION && !LOG_TO_CONSOLE;
 
 const name = 'simple-hub';
 


### PR DESCRIPTION
Seeing the following log on the production hub: `Error: ENOENT: no such file or directory, open ''`