### PR TITLE
Add LogLevel to Channel Provider and Xstate Wallet

### DIFF
--- a/packages/channel-provider/src/logger.ts
+++ b/packages/channel-provider/src/logger.ts
@@ -36,6 +36,12 @@ const browser: any = IS_BROWSER_CONTEXT
   : undefined;
 
 const prettyPrint = LOG_TO_CONSOLE ? {translateTime: true} : false;
+// When logging, we default to 'info', as most logs happen at this level.
+// Some very large classes are serialized at the 'trace' level
+// We probably don't want these logged to the console, but strictly enabling this
+// in the browser might sometimes be helpful
+// eslint-disable-next-line no-undef
+export const LOG_LEVEL = LOG_TO_FILE || LOG_TO_CONSOLE ? process.env.LOG_LEVEL || 'info' : 'silent';
 
-const opts = {name, prettyPrint, browser};
+const opts = {name, prettyPrint, browser, level: LOG_LEVEL};
 export const logger = pino(opts);

--- a/packages/xstate-wallet/src/config.ts
+++ b/packages/xstate-wallet/src/config.ts
@@ -51,6 +51,12 @@ export const JEST_WORKER_ID: string | undefined = process.env.JEST_WORKER_ID;
 // TODO: Embed this inside logger.ts
 export const ADD_LOGS = !!LOG_DESTINATION;
 
+// When logging, we default to 'info', as most logs happen at this level.
+// Some very large classes are serialized at the 'trace' level
+// We probably don't want these logged to the console, but strictly enabling this
+// in the browser might sometimes be helpful
+export const LOG_LEVEL = ADD_LOGS ? process.env.LOG_LEVEL || 'info' : 'silent';
+
 export const HUB = {
   destination: HUB_DESTINATION,
   signingAddress: HUB_ADDRESS,

--- a/packages/xstate-wallet/src/logger.ts
+++ b/packages/xstate-wallet/src/logger.ts
@@ -1,6 +1,6 @@
 import pino from 'pino';
 
-import {LOG_DESTINATION, ADD_LOGS, JEST_WORKER_ID} from './config';
+import {LOG_DESTINATION, ADD_LOGS, JEST_WORKER_ID, LOG_LEVEL} from './config';
 import _ from 'lodash';
 
 const IS_BROWSER_CONTEXT = JEST_WORKER_ID === undefined;
@@ -40,5 +40,5 @@ const browser: any = IS_BROWSER_CONTEXT
 
 const prettyPrint = LOG_TO_CONSOLE ? {translateTime: true} : false;
 
-const opts = {name, prettyPrint, browser};
+const opts = {name, prettyPrint, browser, level: LOG_LEVEL};
 export const logger = destination ? pino(opts, destination) : pino(opts);


### PR DESCRIPTION
I noticed that even after disabling logs for production we were seeing log entries from channel provider and xstate wallet.

This PR copies the `LOG_LEVEL` logic from w3t to these packages so that logs will be disabled properly.