### PR TITLE
[web3torrent] Reuse channels on new wires

### DIFF
--- a/.env.circle-integration-w3t-with-hub
+++ b/.env.circle-integration-w3t-with-hub
@@ -10,12 +10,12 @@ USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 
 # For e2e-test
 BROWSER_LOG_DESTINATION = 'browser.log'
-HEADLESS = 'false'
+HEADLESS = 'true'
 USE_DAPPETEER = 'false'
 TARGET_NETWORK = 'localhost'
 WEB3TORRENT_URL = 'http://localhost:3000'
 SCREENSHOT_DIR = 'screenshots'
-CLOSE_BROWSERS = 'false'
+CLOSE_BROWSERS = 'true'
 
 ## simple-hub
 SIMPLE_HUB_DEPLOYER_ACCOUNT_INDEX = '1'

--- a/.env.circle-integration-w3t-with-hub
+++ b/.env.circle-integration-w3t-with-hub
@@ -10,12 +10,12 @@ USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 
 # For e2e-test
 BROWSER_LOG_DESTINATION = 'browser.log'
-HEADLESS = 'true'
+HEADLESS = 'false'
 USE_DAPPETEER = 'false'
 TARGET_NETWORK = 'localhost'
 WEB3TORRENT_URL = 'http://localhost:3000'
 SCREENSHOT_DIR = 'screenshots'
-CLOSE_BROWSERS = 'true'
+CLOSE_BROWSERS = 'false'
 
 ## simple-hub
 SIMPLE_HUB_DEPLOYER_ACCOUNT_INDEX = '1'

--- a/packages/web3torrent/.storybook/web3torrent-client.mock.js
+++ b/packages/web3torrent/.storybook/web3torrent-client.mock.js
@@ -2,7 +2,7 @@ const React = require('react');
 const utils = require('./../src/utils/test-utils');
 
 function mockWeb3TorrentClient() {
-  const _peers = utils.createMockTorrentPeers();
+  const _peers = utils.createMockPeersByChannel();
   const torrent = utils.createMockTorrentUI({
     numPeers: Object.keys(_peers).length,
     _peers,

--- a/packages/web3torrent/README.md
+++ b/packages/web3torrent/README.md
@@ -19,7 +19,7 @@ As the client is a custom, extended version of [Webtorrent](https://github.com/w
 **There is a couple of extra properties and methods to take into account, the rest you can assume are pretty much the same**:
 
 - `pseAccount` it's an ID, wich identifies the client (peer). This can be set when the client is instantiated (by passing an object with the key `pseAccount`). We use the state channel wallet signing address for this ID.
-- `peersList` holds a list of torrents (identified by infoHash), in wich every torrent has a list of allowed peers (identified by pseAccount)
+- `channelsByInfoHash` holds a list of torrents (identified by infoHash), in wich every torrent has a list of allowed peers (identified by pseAccount)
   this list is used by each peer Client, to control which peer is trying to leech files, and see who is allowed to do so.
 - `togglePeer (affectedTorrent, peerAccount)` is a method that allows a user to choke/unchoke a peer
 

--- a/packages/web3torrent/src/clients/web3torrent-client.test.ts
+++ b/packages/web3torrent/src/clients/web3torrent-client.test.ts
@@ -2,8 +2,8 @@ import WebTorrent, {TorrentOptions} from 'webtorrent';
 import {PaidStreamingTorrent, WebTorrentAddInput, WebTorrentSeedInput} from '../library/types';
 import {TorrentCallback} from '../library/web3torrent-lib';
 import {Status} from '../types';
-import {createMockExtendedTorrent, createMockTorrentPeers, pseAccount} from '../utils/test-utils';
-import {download, getTorrentPeers, upload, web3TorrentClient} from './web3torrent-client';
+import {createMockExtendedTorrent, createMockPeersByChannel, pseAccount} from '../utils/test-utils';
+import {download, getPeersByChannel, upload, web3TorrentClient} from './web3torrent-client';
 import {getStatus} from '../utils/torrent-status-checker';
 
 describe('Web3TorrentClient', () => {
@@ -92,19 +92,21 @@ describe('Web3TorrentClient', () => {
     });
   });
 
-  describe('getTorrentPeers()', () => {
+  describe('getPeersByChannel()', () => {
     const mockInfoHash = '124203';
 
     beforeEach(() => {
-      web3TorrentClient.peersList[mockInfoHash] = createMockTorrentPeers();
+      web3TorrentClient.channelsByInfoHash[mockInfoHash] = createMockPeersByChannel();
     });
 
     it('should return peers for a given torrent', () => {
-      expect(getTorrentPeers(mockInfoHash)).toEqual(web3TorrentClient.peersList[mockInfoHash]);
+      expect(getPeersByChannel(mockInfoHash)).toEqual(
+        web3TorrentClient.channelsByInfoHash[mockInfoHash]
+      );
     });
 
     afterEach(() => {
-      web3TorrentClient.peersList = {};
+      web3TorrentClient.channelsByInfoHash = {};
     });
   });
 });

--- a/packages/web3torrent/src/clients/web3torrent-client.ts
+++ b/packages/web3torrent/src/clients/web3torrent-client.ts
@@ -14,7 +14,7 @@ export const web3TorrentClient = new WebTorrentPaidStreamingClient({
 
 export const Web3TorrentClientContext = React.createContext(web3TorrentClient);
 
-export const getTorrentPeers = infoHash => web3TorrentClient.channelsByInfoHash[infoHash];
+export const getPeersByChannel = infoHash => web3TorrentClient.channelsByInfoHash[infoHash];
 
 const doesBudgetExist = async (): Promise<boolean> => {
   const budget = await web3TorrentClient.paymentChannelClient.getBudget();

--- a/packages/web3torrent/src/clients/web3torrent-client.ts
+++ b/packages/web3torrent/src/clients/web3torrent-client.ts
@@ -14,7 +14,7 @@ export const web3TorrentClient = new WebTorrentPaidStreamingClient({
 
 export const Web3TorrentClientContext = React.createContext(web3TorrentClient);
 
-export const getTorrentPeers = infoHash => web3TorrentClient.peersList[infoHash];
+export const getTorrentPeers = infoHash => web3TorrentClient.channelsByInfoHash[infoHash];
 
 const doesBudgetExist = async (): Promise<boolean> => {
   const budget = await web3TorrentClient.paymentChannelClient.getBudget();

--- a/packages/web3torrent/src/components/torrent-info/TorrentInfo.test.tsx
+++ b/packages/web3torrent/src/components/torrent-info/TorrentInfo.test.tsx
@@ -2,9 +2,9 @@ import Enzyme, {mount, ReactWrapper} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import prettier from 'prettier-bytes';
 import React from 'react';
-import {TorrentPeers} from '../../library/types';
+import {PeersByChannel} from '../../library/types';
 import {Status, TorrentUI} from '../../types';
-import {createMockTorrentUI, createMockTorrentPeers} from '../../utils/test-utils';
+import {createMockTorrentUI, createMockPeersByChannel} from '../../utils/test-utils';
 import {DownloadInfo, DownloadInfoProps} from './download-info/DownloadInfo';
 import {MagnetLinkButton} from './magnet-link-button/MagnetLinkButton';
 import {TorrentInfo, TorrentInfoProps} from './TorrentInfo';
@@ -16,7 +16,7 @@ Enzyme.configure({adapter: new Adapter()});
 type MockTorrentInfo = {
   torrentInfoWrapper: ReactWrapper<TorrentInfoProps>;
   torrent: Partial<TorrentUI>;
-  peers: TorrentPeers;
+  peers: PeersByChannel;
   sectionElement: ReactWrapper;
   fileNameElement: ReactWrapper;
   fileSizeElement: ReactWrapper;
@@ -29,7 +29,7 @@ type MockTorrentInfo = {
 
 const mockTorrentInfo = (torrentProps?: Partial<TorrentUI>): MockTorrentInfo => {
   const torrent = createMockTorrentUI(torrentProps);
-  const peers = createMockTorrentPeers();
+  const peers = createMockPeersByChannel();
   const torrentInfoWrapper = mount(
     <TorrentInfo torrent={torrent} channelCache={{}} mySigningAddress="0x0" />
   );

--- a/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.stories.tsx
+++ b/packages/web3torrent/src/components/torrent-info/download-info/DownloadInfo.stories.tsx
@@ -6,7 +6,7 @@ import '../../../App.scss';
 import {Status, TorrentUI} from '../../../types';
 import {DownloadInfo} from './DownloadInfo';
 import './DownloadInfo.scss';
-import {createMockTorrentPeers} from '../../../utils/test-utils';
+import {createMockPeersByChannel} from '../../../utils/test-utils';
 
 const a = '0xFb4A85D4bBf25e10Fc0Bed72f864dD1ead0006e7';
 const b = '0xBaaed72f864dD1ead0006e7Fb4A85D4bBf25e10F';
@@ -41,7 +41,7 @@ storiesOf('Web3Torrent', module)
           downloadSpeed: number('Download speed (bytes/s)', 200000, {}, 'Torrent data'),
           uploadSpeed: number('Upload speed (bytes/s)', 100000, {}, 'Torrent data'),
           numPeers: number('Number of peers', 50, {}, 'Torrent data'),
-          _peers: createMockTorrentPeers(),
+          _peers: createMockPeersByChannel(),
           wires: [
             {
               paidStreamingExtension: {

--- a/packages/web3torrent/src/components/torrent-info/peer-network-stats/PeerNetworkStats.stories.tsx
+++ b/packages/web3torrent/src/components/torrent-info/peer-network-stats/PeerNetworkStats.stories.tsx
@@ -6,7 +6,7 @@ import '../../../App.scss';
 import {TorrentUI} from '../../../types';
 import {PeerNetworkStats} from './PeerNetworkStats';
 import './PeerNetworkStats.scss';
-import {createMockTorrentPeers} from '../../../utils/test-utils';
+import {createMockPeersByChannel} from '../../../utils/test-utils';
 
 const a = '0xFb4A85D4bBf25e10Fc0Bed72f864dD1ead0006e7';
 const b = '0xBaaed72f864dD1ead0006e7Fb4A85D4bBf25e10F';
@@ -23,7 +23,7 @@ storiesOf('Web3Torrent', module)
       torrent={
         ({
           numPeers: 2,
-          _peers: createMockTorrentPeers(),
+          _peers: createMockPeersByChannel(),
           wires: [
             {
               paidStreamingExtension: {

--- a/packages/web3torrent/src/components/torrent-info/peer-network-stats/PeerNetworkStats.test.tsx
+++ b/packages/web3torrent/src/components/torrent-info/peer-network-stats/PeerNetworkStats.test.tsx
@@ -1,9 +1,13 @@
 import Enzyme, {mount, ReactWrapper} from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
-import {TorrentPeers} from '../../../library/types';
+import {PeersByChannel} from '../../../library/types';
 import {TorrentUI, Status} from '../../../types';
-import {createMockTorrentUI, createMockTorrentPeers, testSelector} from '../../../utils/test-utils';
+import {
+  createMockTorrentUI,
+  createMockPeersByChannel,
+  testSelector
+} from '../../../utils/test-utils';
 import {PeerNetworkStats, PeerNetworkStatsProps} from './PeerNetworkStats';
 import {getFormattedETA} from '../../../utils/torrent-status-checker';
 
@@ -11,14 +15,14 @@ Enzyme.configure({adapter: new Adapter()});
 
 type MockPeerNetworkStats = {
   torrent: Partial<TorrentUI>;
-  peers: TorrentPeers;
+  peers: PeersByChannel;
   PeerNetworkStatsWrapper: ReactWrapper<PeerNetworkStatsProps>;
   uploadingSectionElement: ReactWrapper;
   numPeersElement: ReactWrapper;
 };
 
 const mockPeerNetworkStats = (noPeers = false, isOriginalSeed = true): MockPeerNetworkStats => {
-  const peers = noPeers ? {} : createMockTorrentPeers();
+  const peers = noPeers ? {} : createMockPeersByChannel();
   const torrent = createMockTorrentUI({
     numPeers: Object.keys(peers).length,
     originalSeed: isOriginalSeed,

--- a/packages/web3torrent/src/library/client-seeding.test.ts
+++ b/packages/web3torrent/src/library/client-seeding.test.ts
@@ -85,8 +85,8 @@ describe('Seeding and Leeching', () => {
 
   it('should reach a ready-for-leeching, choked state', done => {
     seeder.seed(defaultFile as File, defaultSeedingOptions(), seededTorrent => {
-      seeder.once(ClientEvents.PEER_STATUS_CHANGED, ({torrentPeers, seedingChannelId}) => {
-        expect(torrentPeers[seedingChannelId].wire.paidStreamingExtension.isForceChoking).toEqual(
+      seeder.once(ClientEvents.PEER_STATUS_CHANGED, ({PeersByChannel, seedingChannelId}) => {
+        expect(PeersByChannel[seedingChannelId].wire.paidStreamingExtension.isForceChoking).toEqual(
           true
         );
         done();
@@ -98,10 +98,10 @@ describe('Seeding and Leeching', () => {
   it('should be able to unchoke and finish a download', async done => {
     seeder.seed(defaultFile as File, defaultSeedingOptions(), seededTorrent => {
       seeder.once(ClientEvents.PEER_STATUS_CHANGED, ({peerAccount, seedingChannelId}) => {
-        seeder.once(ClientEvents.PEER_STATUS_CHANGED, ({torrentPeers, seedingChannelId}) => {
-          expect(torrentPeers[seedingChannelId].wire.paidStreamingExtension.isForceChoking).toEqual(
-            true
-          );
+        seeder.once(ClientEvents.PEER_STATUS_CHANGED, ({PeersByChannel, seedingChannelId}) => {
+          expect(
+            PeersByChannel[seedingChannelId].wire.paidStreamingExtension.isForceChoking
+          ).toEqual(true);
         });
         seeder.togglePeerByChannel(seededTorrent.infoHash, seedingChannelId);
 

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -143,11 +143,11 @@ export type PeerByChannel = {
 };
 
 export type PeersByChannel = {
-  [key: string /* ChannelId */]: PeerByChannel;
+  [channelId: string]: PeerByChannel;
 };
 
 export type ChannelsByInfoHash = {
-  [key: string /* InfoHash */]: PeersByChannel;
+  [infoHash: string]: PeersByChannel;
 };
 
 // channelsByInfoHash[infoHash][channelId] = peerbyChannel: PeerByChannel

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -163,12 +163,12 @@ declare module 'webtorrent' {
     on(
       event: ClientEvents.PEER_STATUS_CHANGED,
       callback: ({
-        torrentPeers,
+        PeersByChannel,
         torrentInfoHash,
         peerAccount,
         seedingChannelId
       }: {
-        torrentPeers: PeersByChannel;
+        PeersByChannel: PeersByChannel;
         torrentInfoHash: string;
         peerAccount: string;
         seedingChannelId: string;

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -134,7 +134,7 @@ export type WebTorrentAddInput = string | Buffer | ParseTorrent;
 
 export type PeerWire = Pick<PaidStreamingWire, 'uploaded'>;
 
-export type PeerByTorrent = {
+export type PeerByChannel = {
   id: string;
   wire: PaidStreamingWire | PeerWire;
   buffer: string;
@@ -142,13 +142,15 @@ export type PeerByTorrent = {
   uploaded: number;
 };
 
-export type TorrentPeers = {
-  [key: string /* ChannelId */]: PeerByTorrent;
+export type PeersByChannel = {
+  [key: string /* ChannelId */]: PeerByChannel;
 };
 
-export type PeersByTorrent = {
-  [key: string /* InfoHash */]: TorrentPeers;
+export type ChannelsByInfoHash = {
+  [key: string /* InfoHash */]: PeersByChannel;
 };
+
+// channelsByInfoHash[infoHash][channelId] = peerbyChannel: PeerByChannel
 
 declare module 'webtorrent' {
   export interface Instance {
@@ -166,7 +168,7 @@ declare module 'webtorrent' {
         peerAccount,
         seedingChannelId
       }: {
-        torrentPeers: TorrentPeers;
+        torrentPeers: PeersByChannel;
         torrentInfoHash: string;
         peerAccount: string;
         seedingChannelId: string;

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -7,7 +7,7 @@ import {
   PaidStreamingExtensionNotices,
   PaidStreamingTorrent,
   PaidStreamingWire,
-  PeersByTorrent,
+  ChannelsByInfoHash,
   TorrentEvents,
   WebTorrentAddInput,
   WebTorrentSeedInput,
@@ -38,7 +38,7 @@ export * from './types';
 
 // A Whimsical diagram explaining the functionality of Web3Torrent: https://whimsical.com/Sq6whAwa8aTjbwMRJc7vPU
 export default class WebTorrentPaidStreamingClient extends WebTorrent {
-  peersList: PeersByTorrent;
+  peersList: ChannelsByInfoHash;
   torrents: PaidStreamingTorrent[] = [];
   paymentChannelClient: PaymentChannelClient;
 
@@ -234,6 +234,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
       PaidStreamingExtensionEvents.REQUEST,
       async (index: number, size: number, response: (allow: boolean) => void) => {
         const reqPrice = bigNumberify(size).mul(WEI_PER_BYTE);
+
         const {seedingChannelId, peerAccount: peer, isForceChoking} = wire.paidStreamingExtension;
         const knownPeer = this.peersList[torrent.infoHash][seedingChannelId];
 

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -238,19 +238,13 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
         const {peerAccount: peer, isForceChoking} = wire.paidStreamingExtension;
 
         // Check to see if we have a running channel with this peer..
-        const existingUploadingChannelId = Object.keys(
-          this.channelsByInfoHash[torrent.infoHash]
-        ).find((channelId: string) => {
-          peer === this.paymentChannelClient.channelCache[channelId].payer &&
-            this.paymentChannelClient.channelCache[channelId].status !== 'closing' &&
-            this.paymentChannelClient.channelCache[channelId].status !== 'closed';
+        const existingUploadingChannelId = _.findKey(this.channelsByInfoHash[torrent.infoHash], {
+          id: peer
         });
 
         if (!existingUploadingChannelId) {
-          console.log(this.channelsByInfoHash[torrent.infoHash]);
-          console.log(this.paymentChannelClient.channelCache);
           // ...if not, create a new channel and block it to await payments
-          await this.createPaymentChannel(torrent, wire); // this will update wire.paidStreamingExtenstion and this.paymentChannelClient.channelCache so we don't re-enter this block unecessarily
+          await this.createPaymentChannel(torrent, wire); // this will update this.paymentChannelClient.channelCache so we don't re-enter this block unecessarily
           log.info(`${peer} >> REQUEST BLOCKED (NEW CHANNEL): ${index}`);
           response(false);
           this.blockPeer(torrent.infoHash, wire);

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -152,7 +152,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
   blockPeer(torrentInfoHash: string, wire: PaidStreamingWire) {
     wire.paidStreamingExtension.stop();
     this.emit(ClientEvents.PEER_STATUS_CHANGED, {
-      torrentPeers: this.channelsByInfoHash[torrentInfoHash],
+      PeersByChannel: this.channelsByInfoHash[torrentInfoHash],
       torrentInfoHash,
       peerAccount: wire.paidStreamingExtension.peerAccount,
       seedingChannelId: wire.paidStreamingExtension.seedingChannelId
@@ -179,7 +179,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     );
     wire.paidStreamingExtension.start();
     this.emit(ClientEvents.PEER_STATUS_CHANGED, {
-      torrentPeers: this.channelsByInfoHash[torrentInfoHash],
+      PeersByChannel: this.channelsByInfoHash[torrentInfoHash],
       torrentInfoHash,
       peerAccount: wire.paidStreamingExtension.peerAccount,
       seedingChannelId: wire.paidStreamingExtension.seedingChannelId

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -239,6 +239,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
         const knownPeer = this.peersList[torrent.infoHash][seedingChannelId];
 
         if (!knownPeer || !seedingChannelId) {
+          // If we don't know the peer OR if *this wire* has no seedingChannelId set, create a new channel (which sets the seedingChannelId)
           await this.createPaymentChannel(torrent, wire);
           log.info(`${peer} >> REQUEST BLOCKED (NEW WIRE): ${index}`);
           response(false);

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -241,14 +241,17 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
         const existingUploadingChannelId = Object.keys(this.peersList[torrent.infoHash]).find(
           (channelId: string) => {
             peer === this.paymentChannelClient.channelCache[channelId].payer &&
-              this.paymentChannelClient.channelCache[channelId].status === 'running';
+              this.paymentChannelClient.channelCache[channelId].status !== 'closing' &&
+              this.paymentChannelClient.channelCache[channelId].status !== 'closed';
           }
         );
 
         if (!existingUploadingChannelId) {
+          console.log(this.peersList[torrent.infoHash]);
+          console.log(this.paymentChannelClient.channelCache);
           // ...if not, create a new channel and block it to await payments
-          await this.createPaymentChannel(torrent, wire);
-          log.info(`${peer} >> REQUEST BLOCKED (NEW WIRE): ${index}`);
+          await this.createPaymentChannel(torrent, wire); // this will update this.peersList and this.paymentChannelClient.channelCache so we don't re-enter this block unecessarily
+          log.info(`${peer} >> REQUEST BLOCKED (NEW CHANNEL): ${index}`);
           response(false);
           this.blockPeer(torrent.infoHash, wire);
         } else {

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -248,7 +248,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
 
           // If it's running, and not associated with any existing wire
           if (
-            this.paymentChannelClient.channelCache[preExistingChannelId].status == 'running' &&
+            this.paymentChannelClient.channelCache[preExistingChannelId]?.status == 'running' &&
             !thisTorrent.wires.find(
               wire => wire.paidStreamingExtension.seedingChannelId == preExistingChannelId
             )

--- a/packages/web3torrent/src/utils/test-utils.ts
+++ b/packages/web3torrent/src/utils/test-utils.ts
@@ -38,7 +38,7 @@ export function createMockTorrentUI(props?: Partial<TorrentUI>): TorrentUI {
   };
 }
 
-export function createMockTorrentPeers(): PeersByChannel {
+export function createMockPeersByChannel(): PeersByChannel {
   return {
     '7595267661936611': {
       id: '7595267661936611',

--- a/packages/web3torrent/src/utils/test-utils.ts
+++ b/packages/web3torrent/src/utils/test-utils.ts
@@ -1,4 +1,4 @@
-import {TorrentPeers, ExtendedTorrent} from '../library/types';
+import {PeerByChannel, ExtendedTorrent, PeersByChannel} from '../library/types';
 import {TorrentUI} from '../types';
 import {EmptyTorrentUI} from '../constants';
 
@@ -38,7 +38,7 @@ export function createMockTorrentUI(props?: Partial<TorrentUI>): TorrentUI {
   };
 }
 
-export function createMockTorrentPeers(): TorrentPeers {
+export function createMockTorrentPeers(): PeersByChannel {
   return {
     '7595267661936611': {
       id: '7595267661936611',


### PR DESCRIPTION
During wire setup, we currently attach a callback, firing on every wire REQUEST received by the seeder, that creates a new channel on the _first request for this wire_. 

This PR makes it so that on that first request, we check to see whether our client's `peersList` contains a channel with the peer making the request. If so, we we will use that. If not, proceed as before. 

I believe this should stop the client getting polluted with new channels in the case of a deadlock or period of inactivity.

See #1992 