### PR TITLE
🐷 Add delay before starting the close channel logic

### DIFF
--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -269,6 +269,10 @@ export class PaymentChannelClient {
   }
 
   async closeChannel(channelId: string): Promise<ChannelState> {
+    logger.info(`Waiting for my turn to close channel ${channelId}`);
+    // Let an existing channel update happen before waiting for my turn
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
     const closing = this.channelState(channelId)
       .pipe(first(cs => this.canUpdateChannel(cs)))
       .subscribe(cs => {


### PR DESCRIPTION
With this delay added, both the `seed-download-cancel` and `stress` tests pass 100% of the time locally.