### PR TITLE
Kill channels after two keep-alive pings with zero progress

### DIFF
--- a/packages/web3torrent/src/library/paid-streaming-extension.ts
+++ b/packages/web3torrent/src/library/paid-streaming-extension.ts
@@ -47,6 +47,11 @@ export abstract class PaidStreamingExtension implements Extension {
 
   blockedRequests: [number, number, number][] = [];
 
+  // this value is meant to be bumped to mirror wire.downloaded
+  // and incremented every time a keep-alive is sent; useful for
+  // detecting if there has been progress over a keep-alive period
+  _keepAliveIncrementalDownloaded: number = 0;
+
   constructor(wireToUse: PaidStreamingWire) {
     this.wire = wireToUse;
     this.messageBus = new EventEmitter();

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -228,10 +228,12 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
         wire._clearTimeout();
       }
 
-      if (!wire.amChoking && wire.downloaded === wire['prevDownloaded']) {
-        this.closeChannel(wire, wire.paidStreamingExtension.leechingChannelId);
-      } else {
-        wire['prevDownloaded'] = wire.downloaded;
+      if (wire.paidStreamingExtension.leechingChannelId) {
+        if (wire.downloaded === wire.paidStreamingExtension._keepAliveIncrementalDownloaded) {
+          this.closeChannel(wire, wire.paidStreamingExtension.leechingChannelId);
+        } else {
+          wire.paidStreamingExtension._keepAliveIncrementalDownloaded = wire.downloaded;
+        }
       }
 
       this.emitTorrentUpdated(torrent.infoHash);

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -227,6 +227,13 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
       if (!torrent.done && wire.amChoking) {
         wire._clearTimeout();
       }
+
+      if (!wire.amChoking && wire.downloaded === wire['prevDownloaded']) {
+        this.closeChannel(wire, wire.paidStreamingExtension.leechingChannelId);
+      } else {
+        wire['prevDownloaded'] = wire.downloaded;
+      }
+
       this.emitTorrentUpdated(torrent.infoHash);
     });
 


### PR DESCRIPTION
Implements @tomclose's [suggestion](https://github.com/statechannels/monorepo/issues/1992#issuecomment-635242533) from #1992:

> We should handle closing the channel in the case where someone doesn't have data for you for some time. This should happen before the torrent timeout kicks in. This would lead to the channels ending in a closed state, instead of in a disconnected state

I tested on [`ags/close-channels-on-my-turn`](https://github.com/statechannels/monorepo/pull/1997) by starting the stress test and killing two of the windows leaving no peer with the full file but two partially downloading from each other and it worked.

<img width="808" alt="Screen Shot 2020-05-28 at 14 32 20" src="https://user-images.githubusercontent.com/1933029/83179823-8ad48480-a0f0-11ea-996c-96b0c6d9dbc9.png">
