### PR TITLE
Refactor some web3torrent stuff

### DIFF
--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -237,9 +237,9 @@ export class PaymentChannelClient {
     }
   }
 
-  async createChannel({beneficiary, payer}: Peers): Promise<ChannelState> {
-    const participants = formatParticipants({beneficiary, payer});
-    const allocations = formatAllocations({beneficiary, payer});
+  async createChannel(peers: Peers): Promise<ChannelState> {
+    const participants = formatParticipants(peers);
+    const allocations = formatAllocations(peers);
 
     const appDefinition = SINGLE_ASSET_PAYMENT_CONTRACT_ADDRESS;
     const channelResult = await this.channelClient.createChannel(
@@ -324,9 +324,9 @@ export class PaymentChannelClient {
     return convertToChannelState(channelResult);
   }
 
-  async updateChannel(channelId: string, {beneficiary, payer}: Peers): Promise<ChannelState> {
-    const allocations = formatAllocations({beneficiary, payer});
-    const participants = formatParticipants({beneficiary, payer});
+  async updateChannel(channelId: string, peers: Peers): Promise<ChannelState> {
+    const allocations = formatAllocations(peers);
+    const participants = formatParticipants(peers);
 
     const channelResult = await this.channelClient.updateChannel(
       channelId,

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -94,13 +94,13 @@ const convertToChannelState = (channelResult: ChannelResult): ChannelState => {
   };
 };
 
-const formatParticipants = ({beneficiary, payer}: Peers) => {
-  const formatParticipant = ({signingAddress, outcomeAddress}: Peer): Participant => ({
-    participantId: signingAddress,
-    signingAddress,
-    destination: outcomeAddress
-  });
+const formatParticipant = ({signingAddress, outcomeAddress}: Peer): Participant => ({
+  participantId: signingAddress,
+  signingAddress,
+  destination: outcomeAddress
+});
 
+const formatParticipants = ({beneficiary, payer}: Peers) => {
   const participants: [Participant, Participant] = [undefined, undefined];
   participants[Index.Payer] = formatParticipant(payer);
   participants[Index.Beneficiary] = formatParticipant(beneficiary);
@@ -108,12 +108,12 @@ const formatParticipants = ({beneficiary, payer}: Peers) => {
   return participants;
 };
 
-const formatAllocations = ({beneficiary, payer}: Peers) => {
-  const formatItem = (p: Peer): AllocationItem => ({
-    amount: hexZeroPad(bigNumberify(p.balance).toHexString(), 32),
-    destination: p.outcomeAddress
-  });
+const formatItem = (p: Peer): AllocationItem => ({
+  amount: hexZeroPad(bigNumberify(p.balance).toHexString(), 32),
+  destination: p.outcomeAddress
+});
 
+const formatAllocations = ({beneficiary, payer}: Peers) => {
   const allocationItems: [AllocationItem, AllocationItem] = [undefined, undefined];
   allocationItems[Index.Payer] = formatItem(payer);
   allocationItems[Index.Beneficiary] = formatItem(beneficiary);

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -238,21 +238,18 @@ export class PaymentChannelClient {
   }
 
   async createChannel(peers: Peers): Promise<ChannelState> {
-    const participants = formatParticipants(peers);
-    const allocations = formatAllocations(peers);
-
-    const appDefinition = SINGLE_ASSET_PAYMENT_CONTRACT_ADDRESS;
     const channelResult = await this.channelClient.createChannel(
-      participants,
-      allocations,
-      appDefinition,
+      formatParticipants(peers),
+      formatAllocations(peers),
+      SINGLE_ASSET_PAYMENT_CONTRACT_ADDRESS,
       APP_DATA,
       FUNDING_STRATEGY
     );
 
-    this.insertIntoChannelCache(convertToChannelState(channelResult));
+    const channelState = convertToChannelState(channelResult);
+    this.insertIntoChannelCache(channelState);
 
-    return convertToChannelState(channelResult);
+    return channelState;
   }
 
   onMessageQueued(callback: (message: Message) => void) {
@@ -325,17 +322,16 @@ export class PaymentChannelClient {
   }
 
   async updateChannel(channelId: string, peers: Peers): Promise<ChannelState> {
-    const allocations = formatAllocations(peers);
-    const participants = formatParticipants(peers);
-
     const channelResult = await this.channelClient.updateChannel(
       channelId,
-      participants,
-      allocations,
+      formatParticipants(peers),
+      formatAllocations(peers),
       APP_DATA
     );
-    this.updateChannelCache(convertToChannelState(channelResult));
-    return convertToChannelState(channelResult);
+
+    const channelState = convertToChannelState(channelResult);
+    this.updateChannelCache(channelState);
+    return channelState;
   }
 
   /**

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -50,7 +50,7 @@ export const peer = (
 ): Peer => ({
   signingAddress,
   outcomeAddress,
-  balance: utils.bigNumberify(balance).toString()
+  balance: utils.bigNumberify(balance).toHexString()
 });
 export interface ChannelState {
   channelId: string;
@@ -110,7 +110,7 @@ const formatParticipants = ({beneficiary, payer}: Peers) => {
 
 const formatAllocations = ({beneficiary, payer}: Peers) => {
   const formatItem = (p: Peer): AllocationItem => ({
-    amount: p.balance,
+    amount: hexZeroPad(bigNumberify(p.balance).toHexString(), 32),
     destination: p.outcomeAddress
   });
 

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -15,7 +15,7 @@ import {
   TorrentCallback,
   ExtendedTorrentOptions
 } from './types';
-import {ChannelState, PaymentChannelClient} from '../clients/payment-channel-client';
+import {ChannelState, PaymentChannelClient, peer} from '../clients/payment-channel-client';
 import {
   defaultTrackers,
   WEI_PER_BYTE,
@@ -340,14 +340,17 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
   protected async createPaymentChannel(torrent: WebTorrent.Torrent, wire: PaidStreamingWire) {
     const {peerAccount, peerOutcomeAddress} = wire.paidStreamingExtension;
 
-    const {channelId} = await this.paymentChannelClient.createChannel(
-      this.pseAccount, // seeder
-      peerAccount, // leecher
-      hexZeroPad(INITIAL_SEEDER_BALANCE.toHexString(), 32), // seederBalance,
-      hexZeroPad(WEI_PER_BYTE.mul(torrent.length).toHexString(), 32), // leecherBalance,
-      this.paymentChannelClient.myEthereumSelectedAddress, // seederOutcomeAddress,
-      peerOutcomeAddress // leecherOutcomeAddress
+    const seeder = peer(
+      this.pseAccount,
+      this.paymentChannelClient.myEthereumSelectedAddress,
+      hexZeroPad(INITIAL_SEEDER_BALANCE.toHexString(), 32)
     );
+    const leecher = peer(
+      peerAccount,
+      peerOutcomeAddress,
+      hexZeroPad(WEI_PER_BYTE.mul(torrent.length).toHexString(), 32)
+    );
+    const {channelId} = await this.paymentChannelClient.createChannel(seeder, leecher);
 
     wire.paidStreamingExtension.seedingChannelId = channelId;
     this.peersList[torrent.infoHash][channelId] = {

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -15,7 +15,7 @@ import {
   TorrentCallback,
   ExtendedTorrentOptions
 } from './types';
-import {ChannelState, PaymentChannelClient, peer} from '../clients/payment-channel-client';
+import {ChannelState, PaymentChannelClient, peer, Peers} from '../clients/payment-channel-client';
 import {
   defaultTrackers,
   WEI_PER_BYTE,
@@ -350,7 +350,8 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
       peerOutcomeAddress,
       hexZeroPad(WEI_PER_BYTE.mul(torrent.length).toHexString(), 32)
     );
-    const {channelId} = await this.paymentChannelClient.createChannel(seeder, leecher);
+    const peers: Peers = {beneficiary: seeder, payer: leecher};
+    const {channelId} = await this.paymentChannelClient.createChannel(peers);
 
     wire.paidStreamingExtension.seedingChannelId = channelId;
     this.peersList[torrent.infoHash][channelId] = {


### PR DESCRIPTION
- `PaymentChannelClient` uses the `Peer` and `Peers` types to prevent accidentally passing strings in the wrong order
- `formatAllocations`/`Participants` uses `Index` to order the peers in the outcomes/participants