### PR TITLE
Add a log statement when querying the chain

### DIFF
--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -391,7 +391,18 @@ export class ChainWatcher implements Chain {
     const [turnNumRecord, finalizesAt] = result.map(BigNumber.from);
 
     const blockNum = BigNumber.from(await this.provider.getBlockNumber());
-
+    chainLogger.info(
+      {
+        amount,
+        channelStorage: {
+          turnNumRecord,
+          finalizesAt
+        },
+        finalized: finalizesAt.gt(0) && finalizesAt.lte(blockNum),
+        blockNum
+      },
+      'Chain query result'
+    );
     // TODO: Fetch other info
     return {
       amount,


### PR DESCRIPTION
I think this might help with investigating #1995. One theory I have is that `getChainInfo` is returning stale/cached info sometimes so hopefully this log entry can confirm/refute that.