### PR TITLE
Use 'id' instead of 'key' for absolute xstate node reference

### DIFF
--- a/packages/xstate-wallet/src/workflows/ledger-funding.ts
+++ b/packages/xstate-wallet/src/workflows/ledger-funding.ts
@@ -53,6 +53,7 @@ const checkTarget = (store: Store) => async (ctx: Init) => {
 };
 
 export const config: MachineConfig<any, any, any> = {
+  id: WORKFLOW,
   key: WORKFLOW,
   initial: 'acquiringLock',
   states: {


### PR DESCRIPTION
It [seems like](https://xstate.js.org/docs/guides/ids.html#identifying-state-nodes) `id` is what you're supposed to use when doing direct references of state nodes. Might help with #2003?