### PR TITLE
Use Existing Contracts when Querying the Chain

### DIFF
--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -372,21 +372,14 @@ export class ChainWatcher implements Chain {
   }
 
   public async getChainInfo(channelId: string): Promise<ChannelChainInfo> {
-    const ethAssetHolder = new Contract(
-      ETH_ASSET_HOLDER_ADDRESS,
-      ContractArtifacts.EthAssetHolderArtifact.abi,
-      this.provider
-    );
-
-    const nitroAdjudicator = new Contract(
-      NITRO_ADJUDICATOR_ADDRESS,
-      ContractArtifacts.NitroAdjudicatorArtifact.abi,
-      this.provider
-    );
+    if (!this._assetHolders || !this._assetHolders[0] || !this._adjudicator) {
+      throw new Error('Not connected to contracts');
+    }
+    const ethAssetHolder = this._assetHolders[0];
 
     const amount: BigNumber = await ethAssetHolder.holdings(channelId);
 
-    const result = await nitroAdjudicator.getChannelStorage(channelId);
+    const result = await this._adjudicator.getChannelStorage(channelId);
 
     const [turnNumRecord, finalizesAt] = result.map(BigNumber.from);
 


### PR DESCRIPTION
While looking into logs/code for #1995 I noticed that when we query the chain we construct brand new `Contract`s instead of using the existing `Contract`s that we store on the `chain`.

I'm wondering if this may be the cause of #1995 due to some internal `ether` workings, so I've changed the query to use the existing contracts. Even if it does not solve #1995 I think it makes sense to use the existing `Contract`s instead of creating new ones each time we perform a query.