### PR TITLE
Log out version

### DIFF
--- a/packages/xstate-wallet/src/index.ts
+++ b/packages/xstate-wallet/src/index.ts
@@ -21,6 +21,8 @@ if (NODE_ENV === 'production') {
 const log = logger.info.bind(logger);
 
 (async function() {
+  log({version: GIT_VERSION}, 'Wallet initializing');
+
   const chain = new ChainWatcher();
 
   const backend = USE_INDEXED_DB ? new Backend() : new MemoryBackend();


### PR DESCRIPTION
Now that we're relying on saved logs a lot more it probably make sense to log out the version so we can tell what changes are/aren't included when the log was generated.