### PR TITLE
Hotfix getProvider

### DIFF
--- a/packages/xstate-wallet/src/utils/contract-utils.ts
+++ b/packages/xstate-wallet/src/utils/contract-utils.ts
@@ -1,7 +1,7 @@
 import {Contract} from 'ethers';
 import {ContractArtifacts} from '@statechannels/nitro-protocol';
 
-import {ETH_ASSET_HOLDER_ADDRESS, CHAIN_NETWORK_ID} from '../config';
+import {ETH_ASSET_HOLDER_ADDRESS} from '../config';
 import {MOCK_TOKEN, MOCK_ASSET_HOLDER_ADDRESS, ETH_TOKEN} from '../constants';
 import {BigNumber} from 'ethers';
 

--- a/packages/xstate-wallet/src/utils/contract-utils.ts
+++ b/packages/xstate-wallet/src/utils/contract-utils.ts
@@ -24,7 +24,7 @@ export function tokenAddress(assetHolderAddress: string): string | undefined {
 export function getProvider(): Web3Provider | JsonRpcProvider {
   if (window.ethereum) {
     if (window.ethereum.mockingInfuraProvider) {
-      return new InfuraProvider(CHAIN_NETWORK_ID);
+      return new InfuraProvider('ropsten');
     }
     return new Web3Provider(window.ethereum);
   } else {


### PR DESCRIPTION
```javascript
> const e = require('@ethersproject/providers')

> new e.InfuraProvider('ropsten')
InfuraProvider {
  _isProvider: true,
  formatter: Formatter {
    formats: {
      transaction: [Object],
      transactionRequest: [Object],
      receiptLog: [Object],
      receipt: [Object],
      block: [Object],
      blockWithTransactions: [Object],
      filter: [Object],
      filterLog: [Object]
    }
  },
  _network: {
    name: 'ropsten',
    chainId: 3,
    ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
    _defaultProvider: [Function (anonymous)]
  },
  _maxInternalBlockNumber: -1024,
  _lastBlockNumber: -2,
  _events: [],
  _pollingInterval: 4000,
  _emitted: { block: -2 },
  _fastQueryDate: 0,
  connection: {
    url: 'https://ropsten.infura.io/v3/84842078b09946638c03157f83405213'
  },
  _nextId: 42,
  apiKey: '84842078b09946638c03157f83405213',
  projectId: '84842078b09946638c03157f83405213',
  projectSecret: null
}

> new e.InfuraProvider('3')
Uncaught TypeError: Cannot read property 'name' of null
    at InfuraProvider.getUrl (/Users/liam/Documents/Projects/statechannels/monorepo/node_modules/@ethersproject/providers/lib/infura-provider.js:68:25)
    at InfuraProvider.UrlJsonRpcProvider [as constructor] (/Users/liam/Documents/Projects/statechannels/monorepo/node_modules/@ethersproject/providers/lib/url-json-rpc-provider.js:66:72)
    at new InfuraProvider (/Users/liam/Documents/Projects/statechannels/monorepo/node_modules/@ethersproject/providers/lib/infura-provider.js:25:42)
```
