### PR TITLE
Build step out of memory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ jobs:
             then
                 yarn build:ci
             else
-                yarn build:ci:incremental
+                yarn build:ci
             fi
       - upload_logs:
           file: build-stats

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ jobs:
             then
                 yarn build:ci
             else
-                yarn build:ci
+                yarn build:ci:incremental
             fi
       - upload_logs:
           file: build-stats

--- a/packages/tic-tac-toe/package.json
+++ b/packages/tic-tac-toe/package.json
@@ -163,7 +163,7 @@
   "scripts": {
     "build:ci": "run-s prepare build",
     "build:netlify:production": "yarn build",
-    "build": "NODE_ENV=production ember build --environment=production",
+    "build": "JOBS=1 NODE_ENV=production ember build --environment=production",
     "clearContracts": "rm -rf ./build/contracts",
     "contracts:compile": "node ./bin/compile.js",
     "eslint:check": "eslint \"**/*.{js,ts}\" --cache --max-warnings=0",


### PR DESCRIPTION
We are starting to consistently observe the circleci `build` step running out of memory for the `master` branch. One of the issues seems to be that ember spins up many processes for building tic-tac-toe. On the surface, this is likely due to ember calculating machine resources as opposed to container resources. This seems related to [this issue](https://github.com/emberjs/ember.js/issues/15641).