### PR TITLE
Manually fetch budget after download

### DIFF
--- a/packages/web3torrent/src/hooks/use-budget.ts
+++ b/packages/web3torrent/src/hooks/use-budget.ts
@@ -32,5 +32,13 @@ export function useBudget({ready}: {ready: boolean}) {
     setLoading(false);
   };
 
-  return {budget, loading, createBudget, closeBudget};
+  const getBudget = async () => {
+    setLoading(true);
+    await paymentChannelClient.getBudget();
+    setBudget(paymentChannelClient.budgetCache);
+
+    setLoading(false);
+  };
+
+  return {budget, loading, createBudget, closeBudget, getBudget};
 }

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -94,7 +94,7 @@ const File: React.FC<Props> = props => {
   }, [props.ready, web3TorrentClient.paymentChannelClient]);
 
   const {mySigningAddress: me} = web3TorrentClient.paymentChannelClient;
-  const {budget, closeBudget} = useBudget(props);
+  const {budget, closeBudget, getBudget} = useBudget(props);
   const showBudget = budget?.budgets?.length;
 
   return (
@@ -136,6 +136,7 @@ const File: React.FC<Props> = props => {
               setErrorLabel('');
               try {
                 await download(torrent.magnetURI);
+                await getBudget();
               } catch (error) {
                 setLoading(false);
                 setErrorLabel(getUserFriendlyError(error.code));


### PR DESCRIPTION
Fixes #2058 by manually fetching the budget after the download has started.