### PR TITLE
Serialize wires when logging

### DIFF
--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -2,6 +2,7 @@ import {Request, Wire} from 'bittorrent-protocol';
 import {Instance as ParseTorrent} from 'parse-torrent';
 import WebTorrent, {Torrent, TorrentOptions} from 'webtorrent';
 import {PaidStreamingExtension} from './paid-streaming-extension';
+import _ from 'lodash';
 
 export enum ClientEvents {
   PEER_STATUS_CHANGED = 'peer_status_changed',
@@ -77,6 +78,17 @@ export type PaidStreamingWire = Omit<Wire, 'requests'> &
     _onCancel(index: number, offset: number, length: number): void;
     _onPiece(index: number, offset: number, buffer: Buffer): void;
   };
+
+export const isPaidStreamingWire = (obj: any): obj is PaidStreamingWire =>
+  typeof obj === 'object' && 'paidStreamingExtension' in obj;
+
+export type SerializedPaidStreamingWire = {
+  peerId: string;
+  amChoking: boolean;
+  amInterested: boolean;
+  peerChoking: boolean;
+  peerInterested: boolean;
+};
 
 export type ExtendedHandshake = PaidStreamingExtendedHandshake & {
   m: {


### PR DESCRIPTION
See https://github.com/statechannels/monorepo/issues/2041#issuecomment-637737955. One log line was 21MB

Now, the logs look like

```
[1591154850501] INFO  (web3torrent): << blockPeer
    module: "web3torrent-lib"
    from: {
      "0x5d89f9b1da7b81f99ab786b78839d96a03cf3a4ff15f97e24d6d10d2a820dafe": {
        "id": "0x18238000f59E26c69140F8072ac606c1309cc928",
        "wire": {
          "peerId": "2d5757303030372d422b36505049584376707237",
          "amChoking": false,
          "amInterested": false,
          "peerChoking": true,
          "peerInterested": true
        },
        "buffer": "0",
        "beneficiaryBalance": "0",
        "uploaded": 0
      }
    }
    peerAccount: "0x18238000f59E26c69140F8072ac606c1309cc928"
    seedingChannelId: "0x5d89f9b1da7b81f99ab786b78839d96a03cf3a4ff15f97e24d6d10d2a820dafe"
    browserId: 0
```

(We should probably avoid logging the `torrent` at all.)

```
~/Downloads via ☕ v11.0.2 on ☁️  us-west-1
❯ du -sh multiple-leecher.A.7.pino.log.*
2.0M    multiple-leecher.A.7.pino.log.new
6.3M    multiple-leecher.A.7.pino.log.old

~/Downloads via ☕ v11.0.2 on ☁️  us-west-1
❯ wc -l multiple-leecher.A.7.pino.log.*
    1879 multiple-leecher.A.7.pino.log.new
    1212 multiple-leecher.A.7.pino.log.old
    3091 total
```

After this change, each line is ~1KB. Before this change, each line is ~5KB.