### PR TITLE
[nitro-protocol] Add some more exports and a test for nullApp

### DIFF
--- a/packages/nitro-protocol/src/index.ts
+++ b/packages/nitro-protocol/src/index.ts
@@ -41,19 +41,22 @@ export {validTransition, ForceMoveAppContractInterface} from './contract/force-m
 export {
   encodeAllocation,
   encodeOutcome,
+  decodeOutcome,
   Outcome,
   Allocation,
   AllocationItem,
   Guarantee,
   isAllocationOutcome,
   isGuaranteeOutcome,
+  encodeGuarantee,
   AssetOutcome,
   GuaranteeAssetOutcome,
   AllocationAssetOutcome,
   hashOutcome,
 } from './contract/outcome';
+export {channelDataToChannelStorageHash} from './contract/channel-storage';
 
-export {State, VariablePart, getVariablePart, getFixedPart} from './contract/state';
+export {State, VariablePart, getVariablePart, getFixedPart, hashAppPart} from './contract/state';
 export {createDepositTransaction as createERC20DepositTransaction} from './contract/transaction-creators/erc20-asset-holder';
 export {
   createDepositTransaction as createETHDepositTransaction,
@@ -65,7 +68,7 @@ import {State} from './contract/state';
 export {hashState} from './contract/state';
 
 import {Signature} from 'ethers/utils';
-export {signState, getStateSignerAddress} from './signatures';
+export {signState, getStateSignerAddress, signChallengeMessage} from './signatures';
 
 import * as Signatures from './signatures';
 import * as Transactions from './transactions';

--- a/packages/nitro-protocol/test/contracts/ConsensusApp/nullApp.test.ts
+++ b/packages/nitro-protocol/test/contracts/ConsensusApp/nullApp.test.ts
@@ -1,0 +1,48 @@
+import {expectRevert} from '@statechannels/devtools';
+import {Contract, Wallet} from 'ethers';
+import {AddressZero} from 'ethers/constants';
+import {getTestProvider, setupContracts} from '../../test-helpers';
+import NitroAdjudicatorArtifact from '../../../build/contracts/TESTNitroAdjudicator.json';
+import {getVariablePart, State, Channel} from '../../../src';
+
+const provider = getTestProvider();
+
+let NitroAdjudicator: Contract;
+beforeAll(async () => {
+  NitroAdjudicator = await setupContracts(
+    provider,
+    NitroAdjudicatorArtifact,
+    process.env.TEST_NITRO_ADJUDICATOR_ADDRESS
+  );
+});
+
+describe('null app', () => {
+  // eslint-disable-next-line jest/expect-expect
+  it('should revert when validTransition is called', async () => {
+    const channel: Channel = {
+      participants: [Wallet.createRandom().address, Wallet.createRandom().address],
+      chainId: '0x1',
+      channelNonce: '0x1',
+    };
+    const fromState: State = {
+      channel,
+      outcome: [],
+      turnNum: 1,
+      isFinal: false,
+      challengeDuration: 0x0,
+      appDefinition: AddressZero,
+      appData: '0x0',
+    };
+    const toState: State = {...fromState, turnNum: 2};
+
+    expectRevert(async () => {
+      await NitroAdjudicator.validTransition(
+        1,
+        [false, false],
+        [getVariablePart(fromState), getVariablePart(toState)],
+        5,
+        AddressZero
+      );
+    }, 'VM Exception while processing transaction: revert');
+  });
+});


### PR DESCRIPTION
I stopped short of clearing out the ConsensusApp entirely, since this is imported into the `simple-hub` and `xstate-wallet`.

For now the documentation will explain both approaches, and the test I added is a signal for the null app in our source code. 