### PR TITLE
Fix releaseFunds Error

### DIFF
--- a/packages/xstate-wallet/src/store/dexie-backend.ts
+++ b/packages/xstate-wallet/src/store/dexie-backend.ts
@@ -115,7 +115,8 @@ export class Backend implements DBBackend {
   }
 
   public async setBudget(key: string, value: DomainBudget) {
-    return this.put(ObjectStores.budgets, value, key);
+    const result = await this.put(ObjectStores.budgets, value, key);
+    return result.value;
   }
 
   public async deleteBudget(key: string) {

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -487,8 +487,8 @@ export class Store {
         // Delete the funds assigned to the channel
         delete assetBudget.channels[targetChannelId];
 
-        const result = await this.backend.setBudget(applicationDomain, currentBudget);
-        return result;
+        await this.backend.setBudget(applicationDomain, currentBudget);
+        return currentBudget;
       }
     );
 

--- a/packages/xstate-wallet/src/utils/helpers.ts
+++ b/packages/xstate-wallet/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 import {StateNodeConfig, DoneInvokeEvent, TransitionConfig} from 'xstate';
-import {hexZeroPad, hexlify} from '@ethersproject/bytes';
+import {hexZeroPad} from '@ethersproject/bytes';
 import {BigNumber} from 'ethers';
 export function unreachable(x: never) {
   return x;
@@ -57,7 +57,7 @@ export function createDestination(address: string): string {
 }
 
 export function formatAmount(amount: BigNumber): string {
-  return hexZeroPad(hexlify(amount), 32);
+  return hexZeroPad(BigNumber.from(amount).toHexString(), 32);
 }
 
 export function arrayToRecord<T, K extends keyof T>(


### PR DESCRIPTION
Fixes #2074 

The `setBudget` method in the dexie backend was not properly returning a budget, causing serialization failures later when we try and send out a notification. This only occurred with `releaseFunds` as we were returning the result from the dexie backend instead of the value being passed into `setBudget`



