### PR TITLE
Serialize torrents, PSEs, PSEWires, and Buffers

### DIFF
--- a/packages/web3torrent/src/library/paid-streaming-extension.ts
+++ b/packages/web3torrent/src/library/paid-streaming-extension.ts
@@ -154,20 +154,6 @@ export abstract class PaidStreamingExtension implements Extension {
     }
   }
 
-  serialize(): PaidStreamingExtensionSerialized {
-    return {
-      pseAccount: this.pseAccount,
-      pseAddress: this.pseAddress,
-      seedingChannelId: this.seedingChannelId,
-      peerAccount: this.peerAccount,
-      peerOutcomeAddress: this.peerOutcomeAddress,
-      leechingChannelId: this.leechingChannelId,
-      isForceChoking: this.isForceChoking,
-      isBeingChoked: this.isBeingChoked,
-      blockedRequests: this.blockedRequests
-    };
-  }
-
   protected messageHandler({command, data}) {
     switch (command) {
       case PaidStreamingExtensionNotices.ACK:

--- a/packages/web3torrent/src/library/paid-streaming-extension.ts
+++ b/packages/web3torrent/src/library/paid-streaming-extension.ts
@@ -11,22 +11,6 @@ import {
 
 const log = logger.child({module: 'paid-streaming-extension'});
 
-export type PaidStreamingExtensionSerialized = Pick<
-  PaidStreamingExtension,
-  | 'pseAccount'
-  | 'pseAddress'
-  | 'seedingChannelId'
-  | 'peerAccount'
-  | 'peerOutcomeAddress'
-  | 'leechingChannelId'
-  | 'isForceChoking'
-  | 'isBeingChoked'
-  | 'blockedRequests'
->;
-
-export const isPaidStreamingExtension = (obj: any): obj is PaidStreamingExtension =>
-  typeof obj === 'object' && '_isPaidStreamingExtension' in obj && obj._isPaidStreamingExtension;
-
 export abstract class PaidStreamingExtension implements Extension {
   private _isPaidStreamingExtension = true;
   protected wire: PaidStreamingWire;

--- a/packages/web3torrent/src/library/paid-streaming-extension.ts
+++ b/packages/web3torrent/src/library/paid-streaming-extension.ts
@@ -24,7 +24,11 @@ export type PaidStreamingExtensionSerialized = Pick<
   | 'blockedRequests'
 >;
 
+export const isPaidStreamingExtension = (obj: any): obj is PaidStreamingExtension =>
+  typeof obj === 'object' && '_isPaidStreamingExtension' in obj && obj._isPaidStreamingExtension;
+
 export abstract class PaidStreamingExtension implements Extension {
+  private _isPaidStreamingExtension = true;
   protected wire: PaidStreamingWire;
   protected messageBus: EventEmitter;
   protected pseId: string = '';

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -1,7 +1,7 @@
 import {Request, Wire} from 'bittorrent-protocol';
 import {Instance as ParseTorrent} from 'parse-torrent';
 import WebTorrent, {Torrent, TorrentOptions} from 'webtorrent';
-import {PaidStreamingExtension, PaidStreamingExtensionSerialized} from './paid-streaming-extension';
+import {PaidStreamingExtension} from './paid-streaming-extension';
 import _ from 'lodash';
 
 export enum ClientEvents {
@@ -57,7 +57,7 @@ export enum PaidStreamingExtensionNotices {
 }
 
 export type PaidStreamingExtendedHandshake = {
-  pseAccount: string;
+  pseAccount: string; // WARNING: This is not a string. It is a Buffer.
   outcomeAddress: string;
 };
 
@@ -80,8 +80,12 @@ export type PaidStreamingWire = Omit<Wire, 'requests'> &
   };
 
 export const isPaidStreamingWire = (obj: any): obj is PaidStreamingWire =>
+  obj !== null &&
   typeof obj === 'object' &&
-  'paidStreamingExtension' in obj &&
+  // Even though the PaidStreamingWire claims to have a paidStreamingExtension property,
+  // it doesn't always appear to be present
+  // TODO: Why??
+  // 'paidStreamingExtension' in obj &&
   'peerExtendedHandshake' in obj &&
   'extended' in obj;
 
@@ -94,7 +98,7 @@ export type SerializedPaidStreamingWire = Pick<
   | 'peerInterested'
   | 'peerExtendedHandshake'
   | 'extendedHandshake'
-> & {paidStreamingExtension: PaidStreamingExtensionSerialized};
+> & {paidStreamingExtension: any};
 
 export type ExtendedHandshake = PaidStreamingExtendedHandshake & {
   m: {

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -1,7 +1,7 @@
 import {Request, Wire} from 'bittorrent-protocol';
 import {Instance as ParseTorrent} from 'parse-torrent';
 import WebTorrent, {Torrent, TorrentOptions} from 'webtorrent';
-import {PaidStreamingExtension} from './paid-streaming-extension';
+import {PaidStreamingExtension, PaidStreamingExtensionSerialized} from './paid-streaming-extension';
 import _ from 'lodash';
 
 export enum ClientEvents {
@@ -85,13 +85,16 @@ export const isPaidStreamingWire = (obj: any): obj is PaidStreamingWire =>
   'peerExtendedHandshake' in obj &&
   'extended' in obj;
 
-export type SerializedPaidStreamingWire = {
-  peerId: string;
-  amChoking: boolean;
-  amInterested: boolean;
-  peerChoking: boolean;
-  peerInterested: boolean;
-};
+export type SerializedPaidStreamingWire = Pick<
+  PaidStreamingWire,
+  | 'peerId'
+  | 'amChoking'
+  | 'amInterested'
+  | 'peerChoking'
+  | 'peerInterested'
+  | 'peerExtendedHandshake'
+  | 'extendedHandshake'
+> & {paidStreamingExtension: PaidStreamingExtensionSerialized};
 
 export type ExtendedHandshake = PaidStreamingExtendedHandshake & {
   m: {

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -80,7 +80,10 @@ export type PaidStreamingWire = Omit<Wire, 'requests'> &
   };
 
 export const isPaidStreamingWire = (obj: any): obj is PaidStreamingWire =>
-  typeof obj === 'object' && 'paidStreamingExtension' in obj;
+  typeof obj === 'object' &&
+  'paidStreamingExtension' in obj &&
+  'peerExtendedHandshake' in obj &&
+  'extended' in obj;
 
 export type SerializedPaidStreamingWire = {
   peerId: string;

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -578,7 +578,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
       return;
     }
     log.debug({requests: wire.requests}, `<< START ${wire.paidStreamingExtension.peerAccount}`);
-    log.trace({pieces: torrent.pieces});
+    log.trace({torrent});
     torrent._updateWireWrapper(wire); // schedules a wire update (which checks it's wires and tries to make new requests and replace dead ones)
     // this is an internal function implemented here: https://github.com/webtorrent/webtorrent/blob/7ff77c3e95b2dddfa70dd49cf924073383dd565a/lib/torrent.js#L1182
     // As we changed the way peers comunicated (and it has indeed changed since the PoC days)

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -337,7 +337,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
         }
       }
     });
-    log.info({wireData: wire.paidStreamingExtension?.serialize()}, 'Wire Setup completed');
+    log.info({wireData: wire.paidStreamingExtension}, 'Wire Setup completed');
   }
 
   /** Creates a payment channel, and sets the channelId property, sent to the leecher on the STOP events to leeching peers  */
@@ -574,7 +574,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
   protected jumpStart(torrent: ExtendedTorrent, wire: PaidStreamingWire) {
     if (torrent.done) {
       log.debug('<< JUMPSTART: FINISHED');
-      log.trace({torrent, wire: wire.paidStreamingExtension.serialize()});
+      log.trace({torrent, wire: wire.paidStreamingExtension});
       return;
     }
     log.debug({requests: wire.requests}, `<< START ${wire.paidStreamingExtension.peerAccount}`);

--- a/packages/web3torrent/src/logger.ts
+++ b/packages/web3torrent/src/logger.ts
@@ -29,13 +29,19 @@ const serializePaidStreamingWire = ({
   amChoking,
   amInterested,
   peerChoking,
-  peerInterested
+  peerInterested,
+  paidStreamingExtension,
+  peerExtendedHandshake,
+  extendedHandshake
 }: PaidStreamingWire): SerializedPaidStreamingWire => ({
   peerId,
   amChoking,
   amInterested,
   peerChoking,
-  peerInterested
+  peerInterested,
+  paidStreamingExtension: serializePaidStreamingExtension(paidStreamingExtension),
+  peerExtendedHandshake,
+  extendedHandshake
 });
 
 const serializePaidStreamingExtension = ({

--- a/packages/web3torrent/src/logger.ts
+++ b/packages/web3torrent/src/logger.ts
@@ -2,11 +2,6 @@ import pino from 'pino';
 import {LOG_DESTINATION, ADD_LOGS, LOG_LEVEL, VERSION} from './constants';
 import _ from 'lodash';
 import {PaidStreamingWire, SerializedPaidStreamingWire, isPaidStreamingWire} from './library/types';
-import {
-  PaidStreamingExtension,
-  PaidStreamingExtensionSerialized,
-  isPaidStreamingExtension
-} from './library/paid-streaming-extension';
 
 const IS_BROWSER_CONTEXT = process.env.JEST_WORKER_ID === undefined;
 const LOG_TO_CONSOLE = LOG_DESTINATION === 'console';
@@ -54,7 +49,7 @@ const serializePaidStreamingExtension = ({
   isForceChoking,
   isBeingChoked,
   blockedRequests
-}: PaidStreamingExtension): PaidStreamingExtensionSerialized => ({
+}: any) => ({
   pseAccount,
   pseAddress,
   seedingChannelId,
@@ -65,6 +60,10 @@ const serializePaidStreamingExtension = ({
   isBeingChoked,
   blockedRequests
 });
+
+// This type "guard" is unfortunately not type safe, since that leads to circular module references
+export const isPaidStreamingExtension = (obj: any) =>
+  typeof obj === 'object' && '_isPaidStreamingExtension' in obj && obj._isPaidStreamingExtension;
 
 const torrentDataReplacer = () => {
   const seen = new WeakSet();

--- a/packages/web3torrent/src/logger.ts
+++ b/packages/web3torrent/src/logger.ts
@@ -30,7 +30,7 @@ const torrentDataReplacer = () => {
       seen.add(value);
     }
 
-    if (key === 'wire' && isPaidStreamingWire(value)) {
+    if (isPaidStreamingWire(value)) {
       return serializePaidStreamingWire(value);
     } else {
       return value;

--- a/packages/web3torrent/src/logger.ts
+++ b/packages/web3torrent/src/logger.ts
@@ -142,7 +142,17 @@ const serializer = () => {
   };
 };
 
-const serializeLogObject = o => JSON.stringify(o, serializer()) + '\n';
+const serializeLogObject = (o: any): string => {
+  try {
+    return JSON.stringify(o, serializer()) + '\n';
+  } catch (error) {
+    // In case the above code does not work.
+    console.error(error);
+    console.error('Failed to serialize a log object');
+    return typeof o;
+  }
+};
+
 class LogBlob {
   private parts = [];
   private _blob?: Blob;

--- a/packages/web3torrent/src/logger.ts
+++ b/packages/web3torrent/src/logger.ts
@@ -2,6 +2,11 @@ import pino from 'pino';
 import {LOG_DESTINATION, ADD_LOGS, LOG_LEVEL, VERSION} from './constants';
 import _ from 'lodash';
 import {PaidStreamingWire, SerializedPaidStreamingWire, isPaidStreamingWire} from './library/types';
+import {
+  PaidStreamingExtension,
+  PaidStreamingExtensionSerialized,
+  isPaidStreamingExtension
+} from './library/paid-streaming-extension';
 
 const IS_BROWSER_CONTEXT = process.env.JEST_WORKER_ID === undefined;
 const LOG_TO_CONSOLE = LOG_DESTINATION === 'console';
@@ -19,8 +24,41 @@ const destination =
 // Since WebTorrentPaidStreamingClient contains circular references, we use
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value#Examples
 
-export const serializePaidStreamingWire = (wire: PaidStreamingWire): SerializedPaidStreamingWire =>
-  _.pick(wire, 'peerId', 'amChoking', 'amInterested', 'peerChoking', 'peerInterested');
+const serializePaidStreamingWire = ({
+  peerId,
+  amChoking,
+  amInterested,
+  peerChoking,
+  peerInterested
+}: PaidStreamingWire): SerializedPaidStreamingWire => ({
+  peerId,
+  amChoking,
+  amInterested,
+  peerChoking,
+  peerInterested
+});
+
+const serializePaidStreamingExtension = ({
+  pseAccount,
+  pseAddress,
+  seedingChannelId,
+  peerAccount,
+  peerOutcomeAddress,
+  leechingChannelId,
+  isForceChoking,
+  isBeingChoked,
+  blockedRequests
+}: PaidStreamingExtension): PaidStreamingExtensionSerialized => ({
+  pseAccount,
+  pseAddress,
+  seedingChannelId,
+  peerAccount,
+  peerOutcomeAddress,
+  leechingChannelId,
+  isForceChoking,
+  isBeingChoked,
+  blockedRequests
+});
 
 const torrentDataReplacer = () => {
   const seen = new WeakSet();
@@ -32,6 +70,8 @@ const torrentDataReplacer = () => {
 
     if (isPaidStreamingWire(value)) {
       return serializePaidStreamingWire(value);
+    } else if (isPaidStreamingExtension(value)) {
+      return serializePaidStreamingExtension(value);
     } else {
       return value;
     }

--- a/packages/web3torrent/src/logger.ts
+++ b/packages/web3torrent/src/logger.ts
@@ -2,6 +2,7 @@ import pino from 'pino';
 import {LOG_DESTINATION, ADD_LOGS, LOG_LEVEL, VERSION} from './constants';
 import _ from 'lodash';
 import {PaidStreamingWire, SerializedPaidStreamingWire, isPaidStreamingWire} from './library/types';
+import {Torrent} from 'webtorrent';
 
 const IS_BROWSER_CONTEXT = process.env.JEST_WORKER_ID === undefined;
 const LOG_TO_CONSOLE = LOG_DESTINATION === 'console';
@@ -12,32 +13,37 @@ const name = 'web3torrent';
 const destination =
   LOG_TO_FILE && !IS_BROWSER_CONTEXT ? pino.destination(LOG_DESTINATION) : undefined;
 
-// If we are in a browser, but we want to LOG_TO_FILE, we assume that the
-// log statements are meant to be stored as JSON objects
-// So, we log serialized objects, appending the name (which the pino browser-api appears to remove?)
+/*
+ * web3torrent logs lots of BIG classes.
+ * These serializers makes them more reasonable to log.
+ *
+ ****** WARNING ********
+ * Due to circular import bugs, making the serializers type safe is difficult or impossible.
+ * Even worse, the types defined by web3torrent are not faithful to the values passed to the logger.
+ * EG. a PaidStreamingExtensionWire does not always have a paidStreamingExtension property
+ */
 
-// Since WebTorrentPaidStreamingClient contains circular references, we use
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value#Examples
+const isObject = (obj: any): obj is Record<string, any> => obj !== null && typeof obj === 'object';
 
-const serializePaidStreamingWire = ({
-  peerId,
-  amChoking,
-  amInterested,
-  peerChoking,
-  peerInterested,
-  paidStreamingExtension,
-  peerExtendedHandshake,
-  extendedHandshake
-}: PaidStreamingWire): SerializedPaidStreamingWire => ({
-  peerId,
-  amChoking,
-  amInterested,
-  peerChoking,
-  peerInterested,
-  paidStreamingExtension: serializePaidStreamingExtension(paidStreamingExtension),
-  peerExtendedHandshake,
-  extendedHandshake
-});
+/*
+ * Some things which are typed as "string" are actually things like Buffer.from('some string').toJson()
+ * EXAMPLE (from my clipboard)
+ * ❯ pbpaste | head -n 1 | jq -c '.torrent.wires[].peerExtendedHandshake'
+ * {"m":{"paidStreamingExtension":2,"ut_metadata":1},"metadata_size":723,"outcomeAddress":{"type":"Buffer","data":[48,120,68,57,57,57,53,66,65,69,49,50,70,69,101,51,50,55,50,53,54,70,70,101,99,49,101,51,49,56,52,100,52,57,50,98,68,57,52,67,51,49]},"pseAccount":{"type":"Buffer","data":[48,120,57,51,99,102,48,50,97,57,50,100,65,56,52,57,50,66,49,57,68,68,51,52,65,52,54,66,99,67,98,57,50,56,70,48,57,54,55,49,50,54]}}
+ *
+ * After running serializeBuffer, it looks like:
+ * ❯ pbpaste | head -n 1 | jq -c '.torrent.wires[].peerExtendedHandshake'
+ * {"m":{"paidStreamingExtension":2,"ut_metadata":1},"metadata_size":723,"outcomeAddress":"0xD9995BAE12FEe327256FFec1e3184d492bD94C31","pseAccount":"0xEF9b144621dE6a0a994197062FDCf204a23a93f4"}
+ */
+
+type Bufferish = Buffer | {type: 'Buffer'; data: any};
+const isBuffer = (obj: any): obj is Bufferish =>
+  Buffer.isBuffer(obj) || (isObject(obj) && obj.type === 'Buffer');
+const serializeBuffer = (b: Bufferish) => Buffer.from(b).toString();
+
+// This type "guard" is unfortunately not type safe, since that leads to circular module references
+const isPaidStreamingExtension = (obj: any) =>
+  isObject(obj) && '_isPaidStreamingExtension' in obj && obj._isPaidStreamingExtension;
 
 const serializePaidStreamingExtension = ({
   pseAccount,
@@ -61,29 +67,82 @@ const serializePaidStreamingExtension = ({
   blockedRequests
 });
 
-// This type "guard" is unfortunately not type safe, since that leads to circular module references
-export const isPaidStreamingExtension = (obj: any) =>
-  typeof obj === 'object' && '_isPaidStreamingExtension' in obj && obj._isPaidStreamingExtension;
+const serializePaidStreamingWire = ({
+  peerId,
+  amChoking,
+  amInterested,
+  peerChoking,
+  peerInterested,
+  paidStreamingExtension,
+  peerExtendedHandshake,
+  extendedHandshake
+}: PaidStreamingWire): SerializedPaidStreamingWire => ({
+  peerId,
+  amChoking,
+  amInterested,
+  peerChoking,
+  peerInterested,
+  paidStreamingExtension,
+  peerExtendedHandshake,
+  extendedHandshake
+});
 
-const torrentDataReplacer = () => {
+// TODO: Should we even log torrents?
+const isTorrent = (obj: any): obj is Torrent =>
+  isObject(obj) && 'infoHash' in obj && 'magnetURI' in obj && 'torrentFile' in obj;
+
+const serializeTorrent = o => ({
+  created: o.created,
+  createdBy: o.createdBy,
+  destroyed: o.destroyed,
+  done: o.done,
+  files: o.files,
+  infoHash: o.infoHash,
+  lastPieceLength: o.lastPieceLength,
+  length: o.length,
+  magnetURI: o.magnetURI,
+  maxWebConns: o.maxWebConns,
+  name: o.name,
+  paused: o.paused,
+  pieceLength: o.pieceLength,
+  ready: o.ready,
+  received: o.received,
+  strategy: o.strategy,
+  uploaded: o.uploaded,
+  urlList: o.urlList,
+  usingPaidStreaming: o.usingPaidStreaming,
+  wires: o.wires
+});
+
+// If we are in a browser, but we want to LOG_TO_FILE, we assume that the
+// log statements are meant to be stored as JSON objects
+// So, we log serialized objects, appending the name (which the pino browser-api appears to remove?)
+
+// Since WebTorrentPaidStreamingClient contains circular references, we use
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value#Examples
+const serializer = () => {
   const seen = new WeakSet();
-  return (key, value) => {
+  return (_, value) => {
     if (typeof value === 'object' && value !== null) {
       if (seen.has(value)) return;
       seen.add(value);
     }
 
-    if (isPaidStreamingWire(value)) {
+    if (isBuffer(value)) {
+      return serializeBuffer(value);
+    } else if (isPaidStreamingWire(value)) {
       return serializePaidStreamingWire(value);
     } else if (isPaidStreamingExtension(value)) {
       return serializePaidStreamingExtension(value);
+    } else if (isTorrent(value)) {
+      return serializeTorrent(value);
     } else {
       return value;
     }
   };
 };
 
-const serializeLogObject = o => JSON.stringify(o, torrentDataReplacer()) + '\n';
+const serializeLogObject = o => JSON.stringify(o, serializer()) + '\n';
 class LogBlob {
   private parts = [];
   private _blob?: Blob;


### PR DESCRIPTION
While addressing the comments on https://github.com/statechannels/monorepo/pull/2064, I went down a deeper rabbit hole which will hopefully clean up the web3torrent logs.

The final product:
```
[1591221673660] TRACE (web3torrent):
    module: "web3torrent-lib"
    torrent: {
      "destroyed": false,
      "done": false,
      "files": [
        {
          "_events": {},
          "_eventsCount": 0,
          "_destroyed": false,
          "name": "web3torrent-tests-stub",
          "path": "web3torrent-tests-stub",
          "length": 520000,
          "offset": 0,
          "done": false,
          "_startPiece": 0,
          "_endPiece": 31
        }
      ],
      "infoHash": "797ac8cd087fa1ef4f1a21b7b71e3fe9e014989c",
      "lastPieceLength": 12096,
      "length": 520000,
      "magnetURI": "magnet:?xt=urn:btih:797ac8cd087fa1ef4f1a21b7b71e3fe9e014989c&dn=web3torrent-tests-stub&tr=http%3A%2F%2Flocalhost%3A8000%2Fannounce&tr=udp%3A%2F%2Flocalhost%3A8000&tr=ws%3A%2F%2Flocalhost%3A8000",
      "maxWebConns": 4,
      "name": "web3torrent-tests-stub",
      "paused": false,
      "pieceLength": 16384,
      "ready": true,
      "received": 388928,
      "strategy": "sequential",
      "uploaded": 0,
      "urlList": [],
      "usingPaidStreaming": true,
      "wires": [
        {
          "peerId": "2d5757303030372d2b47676277752f7a6761376a",
          "amChoking": true,
          "amInterested": true,
          "peerChoking": false,
          "peerInterested": false,
          "paidStreamingExtension": {
            "pseAccount": "0x219996A3884c7f99991Ddf71be6C29362Dae435A",
            "pseAddress": "0xd4Fa489Eacc52BA59438993f37Be9fcC20090E39",
            "peerAccount": "0x0a7441FcA8310E3E14dA8Fb3789505112FcB115f",
            "peerOutcomeAddress": "0xD9995BAE12FEe327256FFec1e3184d492bD94C31",
            "leechingChannelId": "0xf021ddeb77a2a328903df51a1903aaab18376e27774df524dfba07c8047dc560",
            "isForceChoking": false,
            "isBeingChoked": false,
            "blockedRequests": []
          },
          "peerExtendedHandshake": {
            "m": {
              "paidStreamingExtension": 2,
              "ut_metadata": 1
            },
            "metadata_size": 723,
            "outcomeAddress": "0xD9995BAE12FEe327256FFec1e3184d492bD94C31",
            "pseAccount": "0x0a7441FcA8310E3E14dA8Fb3789505112FcB115f"
          },
          "extendedHandshake": {
            "pseAccount": "0x219996A3884c7f99991Ddf71be6C29362Dae435A",
            "outcomeAddress": "0xd4Fa489Eacc52BA59438993f37Be9fcC20090E39",
            "metadata_size": 723
          }
        }
      ]
    }
```

# Why I did this
## Disk usage
Compare with an [old log line](https://github.com/statechannels/monorepo/files/4726556/old.log). 

This old log line is only 24KB. Yesterday, I was trying to clean up a log file that had a single line containing 21MB of data. @geoknee generated a log file with 1GB of data after downloading 5MB.

## Performance and readability
I am pretty sure that we are hamstringing webtorrent. We will need to debug this, and to do that we will probably need to parse wire and torrent details in the logs.
