### PR TITLE
Pino log levels are configurable from browser console

### DIFF
--- a/.env.production-ropsten
+++ b/.env.production-ropsten
@@ -1,8 +1,7 @@
 ## all
 NODE_ENV = 'production'
 LOG_DESTINATION = 'console'
-# TODO: This should be set to info before we release
-LOG_LEVEL = 'debug'
+LOG_LEVEL = 'info'
 # e2e-tests
 BROWSER_LOG_DESTINATION = 'browser.log'
 HEADLESS = 'true'

--- a/packages/channel-provider/src/logger.ts
+++ b/packages/channel-provider/src/logger.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 import pino from 'pino';
 import _ from 'lodash';
 
@@ -39,7 +38,8 @@ const browser: any = IS_BROWSER_CONTEXT
 const prettyPrint = LOG_TO_CONSOLE ? {translateTime: true} : false;
 
 const ADD_LOGS = LOG_TO_FILE || LOG_TO_CONSOLE;
-const LOG_LEVEL = ADD_LOGS ? (process.env.LOG_LEVEL ?? 'info') : 'silent';
+// eslint-disable-next-line no-undef
+const LOG_LEVEL = ADD_LOGS ? process.env.LOG_LEVEL ?? 'info' : 'silent';
 const level = window.localStorage.LOG_LEVEL ?? LOG_LEVEL;
 
 const opts = {name, prettyPrint, browser, level};

--- a/packages/channel-provider/src/logger.ts
+++ b/packages/channel-provider/src/logger.ts
@@ -39,7 +39,7 @@ const browser: any = IS_BROWSER_CONTEXT
 const prettyPrint = LOG_TO_CONSOLE ? {translateTime: true} : false;
 
 const ADD_LOGS = LOG_TO_FILE || LOG_TO_CONSOLE;
-const LOG_LEVEL = ADD_LOGS ? (process.env.LOG_LEVEL ? process.env.LOG_LEVEL : 'info') : 'silent';
+const LOG_LEVEL = ADD_LOGS ? (process.env.LOG_LEVEL ?? 'info') : 'silent';
 const level = window.localStorage.LOG_LEVEL ?? LOG_LEVEL;
 
 const opts = {name, prettyPrint, browser, level};

--- a/packages/channel-provider/src/logger.ts
+++ b/packages/channel-provider/src/logger.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import pino from 'pino';
 import _ from 'lodash';
 
@@ -36,12 +37,21 @@ const browser: any = IS_BROWSER_CONTEXT
   : undefined;
 
 const prettyPrint = LOG_TO_CONSOLE ? {translateTime: true} : false;
-// When logging, we default to 'info', as most logs happen at this level.
-// Some very large classes are serialized at the 'trace' level
-// We probably don't want these logged to the console, but strictly enabling this
-// in the browser might sometimes be helpful
-// eslint-disable-next-line no-undef
-export const LOG_LEVEL = LOG_TO_FILE || LOG_TO_CONSOLE ? process.env.LOG_LEVEL || 'info' : 'silent';
 
-const opts = {name, prettyPrint, browser, level: LOG_LEVEL};
+const ADD_LOGS = LOG_TO_FILE || LOG_TO_CONSOLE;
+const LOG_LEVEL = ADD_LOGS ? (process.env.LOG_LEVEL ? process.env.LOG_LEVEL : 'info') : 'silent';
+const level = window.localStorage.LOG_LEVEL ?? LOG_LEVEL;
+
+const opts = {name, prettyPrint, browser, level};
 export const logger = pino(opts);
+
+window.addEventListener('message', event => {
+  if (event.data.type === 'SET_LOG_LEVEL') {
+    const {level} = event.data;
+    logger.level = level;
+    console.log(`provider: level CLEARED from ${logger.level} to ${level}`);
+  } else if (event.data.type === 'CLEAR_LOG_LEVEL') {
+    logger.level = LOG_LEVEL;
+    console.log(`provider: level CHANGED from ${logger.level} to ${LOG_LEVEL}`);
+  }
+});

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -191,6 +191,4 @@ export const LOG_DESTINATION = ADD_LOGS
     : path.join(process.env.LOG_DESTINATION, 'web3torrent.log')
   : undefined;
 
-export const LOG_LEVEL = ADD_LOGS
-  ? process.env.LOG_LEVEL ?? 'info'
-  : 'silent';
+export const LOG_LEVEL = ADD_LOGS ? process.env.LOG_LEVEL ?? 'info' : 'silent';

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -191,8 +191,8 @@ export const LOG_DESTINATION = ADD_LOGS
     : path.join(process.env.LOG_DESTINATION, 'web3torrent.log')
   : undefined;
 
-// When logging, we default to 'info', as most logs happen at this level.
-// Some very large classes are serialized at the 'trace' level
-// We probably don't want these logged to the console, but strictly enabling this
-// in the browser might sometimes be helpful
-export const LOG_LEVEL = ADD_LOGS ? process.env.LOG_LEVEL || 'info' : 'silent';
+export const LOG_LEVEL = ADD_LOGS
+  ? process.env.LOG_LEVEL
+    ? process.env.LOG_LEVEL
+    : 'info'
+  : 'silent';

--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -192,7 +192,5 @@ export const LOG_DESTINATION = ADD_LOGS
   : undefined;
 
 export const LOG_LEVEL = ADD_LOGS
-  ? process.env.LOG_LEVEL
-    ? process.env.LOG_LEVEL
-    : 'info'
+  ? process.env.LOG_LEVEL ?? 'info'
   : 'silent';

--- a/packages/xstate-wallet/src/config.ts
+++ b/packages/xstate-wallet/src/config.ts
@@ -54,14 +54,12 @@ export const CHALLENGE_DURATION = BigNumber.from(process.env.CHALLENGE_DURATION 
 
 export const JEST_WORKER_ID: string | undefined = process.env.JEST_WORKER_ID;
 
-// TODO: Embed this inside logger.ts
 export const ADD_LOGS = !!LOG_DESTINATION;
-
-// When logging, we default to 'info', as most logs happen at this level.
-// Some very large classes are serialized at the 'trace' level
-// We probably don't want these logged to the console, but strictly enabling this
-// in the browser might sometimes be helpful
-export const LOG_LEVEL = ADD_LOGS ? process.env.LOG_LEVEL || 'info' : 'silent';
+export const LOG_LEVEL = ADD_LOGS
+  ? process.env.LOG_LEVEL
+    ? process.env.LOG_LEVEL
+    : 'info'
+  : 'silent';
 
 export const HUB = {
   destination: HUB_DESTINATION,


### PR DESCRIPTION
Closes https://github.com/statechannels/monorepo/issues/2057

USAGE:

```
> window.setLogLevel('trace')
logger.ts:244 web3torrent: level CHANGED from debug to trace
undefined
logger.ts:55 wallet: level CHANGED from info to trace

> window.setLogLevel('debugf')
logger.ts:250 Uncaught Error: Invalid log level debugf
    at setLogLevel (logger.ts:250)
    at <anonymous>:1:8
setLogLevel @ logger.ts:250
(anonymous) @ VM14010:1

> window.setLogLevel('debug')
logger.ts:244 web3torrent: level CHANGED from trace to debug
undefined
logger.ts:55 wallet: level CHANGED from trace to debug

> window.setLogLevel()
logger.ts:236 web3torrent: level CLEARED from debug to debug
undefined
logger.ts:59 wallet: level CLEARED from debug to info
```