### PR TITLE
[xstate-wallet] Use ethers to reload page on network change

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "lint:write": "lerna run lint:write --no-sort --no-bail",
     "postinstall": "patch-package",
     "preinstall": "npx typesync",
-    "prepare": "lerna run --concurrency 8 --stream prepare",
     "publish": "lerna publish --yes from-package patch",
     "release:netlify": "lerna run release:netlify --stream -- --auth $NETLIFY_ACCESS_TOKEN --message $(git rev-parse --short HEAD) $([ $(git rev-parse --abbrev-ref HEAD) = master ] && echo --prod)",
     "release:netlify:incremental": "lerna run release:netlify --stream --since $(git merge-base $CIRCLE_BRANCH origin/master) -- --auth $NETLIFY_ACCESS_TOKEN --message $(git rev-parse --short HEAD)",
@@ -65,7 +64,8 @@
       "packages/*"
     ],
     "nohoist": [
-      "**/ethers"
+      "**/ethers",
+      "**/ethers/**"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "lint:write": "lerna run lint:write --no-sort --no-bail",
     "postinstall": "patch-package",
     "preinstall": "npx typesync",
+    "prepare": "lerna run --concurrency 8 --stream prepare",
     "publish": "lerna publish --yes from-package patch",
     "release:netlify": "lerna run release:netlify --stream -- --auth $NETLIFY_ACCESS_TOKEN --message $(git rev-parse --short HEAD) $([ $(git rev-parse --abbrev-ref HEAD) = master ] && echo --prod)",
     "release:netlify:incremental": "lerna run release:netlify --stream --since $(git merge-base $CIRCLE_BRANCH origin/master) -- --auth $NETLIFY_ACCESS_TOKEN --message $(git rev-parse --short HEAD)",
@@ -64,8 +65,7 @@
       "packages/*"
     ],
     "nohoist": [
-      "**/ethers",
-      "**/ethers/**"
+      "**/ethers"
     ]
   }
 }

--- a/packages/simple-hub/package.json
+++ b/packages/simple-hub/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "author": "",
   "dependencies": {
-    "@ethersproject/experimental": "5.0.0-beta.140",
+    "@ethersproject/experimental": "5.0.0-beta.143",
     "@firebase/app": "0.5.2",
     "@firebase/database": "0.5.19",
     "@sentry/node": "5.15.5",
@@ -13,7 +13,7 @@
     "async-lock": "1.2.2",
     "dotenv": "8.2.0",
     "dotenv-expand": "5.1.0",
-    "ethers": "5.0.0-beta.187",
+    "ethers": "5.0.0-beta.191",
     "firebase": "7.11.0",
     "fp-ts": "2.5.3",
     "lodash": "4.17.15",

--- a/packages/xstate-wallet/package.json
+++ b/packages/xstate-wallet/package.json
@@ -30,7 +30,7 @@
     "@xstate/react": "1.0.0-rc.3",
     "async-lock": "1.2.2",
     "dexie": "3.0.0",
-    "ethers": "5.0.0-beta.187",
+    "ethers": "5.0.0-beta.191",
     "eventemitter3": "4.0.0",
     "filter-async-rxjs-pipe": "0.1.5",
     "guid-typescript": "1.0.9",

--- a/packages/xstate-wallet/src/utils/contract-utils.ts
+++ b/packages/xstate-wallet/src/utils/contract-utils.ts
@@ -6,7 +6,6 @@ import {MOCK_TOKEN, MOCK_ASSET_HOLDER_ADDRESS, ETH_TOKEN} from '../constants';
 import {BigNumber, providers} from 'ethers';
 
 let provider: providers.Web3Provider | providers.JsonRpcProvider;
-let network: string;
 
 export function assetHolderAddress(tokenAddress: string): string | undefined {
   if (BigNumber.from(tokenAddress).isZero()) return ETH_ASSET_HOLDER_ADDRESS;
@@ -31,29 +30,13 @@ export function getProvider(): providers.Web3Provider | providers.JsonRpcProvide
     } else {
       // https://github.com/ethers-io/ethers.js/issues/861#issuecomment-638031278
       provider = new providers.Web3Provider(window.ethereum, 'any');
-      provider.on('network', (newNetwork, oldNetwork) => {
+      provider.on('network', (_, oldNetwork) => {
         // When a Provider makes its initial connection, it emits a "network"
         // event with a null oldNetwork along with the newNetwork. So, if the
         // oldNetwork exists, it represents a changing network
         if (oldNetwork) {
-          window.location.reload();
+          //window.location.reload();
         }
-      });
-      // The code below is reloads the page on network change. This is needed due to:
-      // - Metamask no longer reloads the page on chain change: https://medium.com/metamask/no-longer-reloading-pages-on-network-change-fbf041942b44
-      // - ethers does not have an elegant way to update the provider on network change: https://github.com/MetaMask/metamask-extension/issues/8077#issuecomment-637338683
-
-      // window.ethereum.networkVersion seems to be initialized asynchronously and can be undefined.
-      // https://ethereum.stackexchange.com/questions/82994/window-ethereum-networkversion-undefined#comment103120_82995
-      network = window.ethereum.networkVersion;
-      // The correct event to use is chainChanged: https://docs.metamask.io/guide/ethereum-provider.html#methods-new-api
-      // As of Metmask version 7.7.9, this event does not seem to be working.
-      // Note about the callback below:
-      // - If window.ethereum.networkVersion is undefined, this callback will fire when the networkVersion is initialized.
-      // - If window.ethereum.networkVersion is defined, this callback will only fire when the network is changed in Metamask.
-      window.ethereum.on('networkChanged', (newNetwork: string) => {
-        if (!network) network = newNetwork;
-        if (network !== newNetwork) window.location.reload();
       });
     }
   } else {

--- a/packages/xstate-wallet/src/utils/contract-utils.ts
+++ b/packages/xstate-wallet/src/utils/contract-utils.ts
@@ -29,7 +29,16 @@ export function getProvider(): providers.Web3Provider | providers.JsonRpcProvide
     if (window.ethereum.mockingInfuraProvider) {
       provider = new providers.InfuraProvider('ropsten', INFURA_API_KEY);
     } else {
-      provider = new providers.Web3Provider(window.ethereum);
+      // https://github.com/ethers-io/ethers.js/issues/861#issuecomment-638031278
+      provider = new providers.Web3Provider(window.ethereum, 'any');
+      provider.on('network', (newNetwork, oldNetwork) => {
+        // When a Provider makes its initial connection, it emits a "network"
+        // event with a null oldNetwork along with the newNetwork. So, if the
+        // oldNetwork exists, it represents a changing network
+        if (oldNetwork) {
+          window.location.reload();
+        }
+      });
       // The code below is reloads the page on network change. This is needed due to:
       // - Metamask no longer reloads the page on chain change: https://medium.com/metamask/no-longer-reloading-pages-on-network-change-fbf041942b44
       // - ethers does not have an elegant way to update the provider on network change: https://github.com/MetaMask/metamask-extension/issues/8077#issuecomment-637338683

--- a/packages/xstate-wallet/src/utils/contract-utils.ts
+++ b/packages/xstate-wallet/src/utils/contract-utils.ts
@@ -35,7 +35,7 @@ export function getProvider(): providers.Web3Provider | providers.JsonRpcProvide
         // event with a null oldNetwork along with the newNetwork. So, if the
         // oldNetwork exists, it represents a changing network
         if (oldNetwork) {
-          //window.location.reload();
+          window.location.reload();
         }
       });
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1983,21 +1983,6 @@
     bech32 "^1.1.3"
     crypto-addr-codec "^0.1.7"
 
-"@ethersproject/abi@>=5.0.0-beta.137":
-  version "5.0.0-beta.152"
-  resolved "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.0-beta.152.tgz#371cd363c9d2df7ca23dcf970cd9c47ac776f1e9"
-  integrity sha512-+1+ukofyBYNJo8IdIK8lBENkEycgXW1ny1zWT7oYD8GKvczYYrgucRQnJPgt3u9MJYZdje4yxDQFoGd6d4BpRA==
-  dependencies:
-    "@ethersproject/address" ">=5.0.0-beta.128"
-    "@ethersproject/bignumber" ">=5.0.0-beta.130"
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/constants" ">=5.0.0-beta.128"
-    "@ethersproject/hash" ">=5.0.0-beta.128"
-    "@ethersproject/keccak256" ">=5.0.0-beta.127"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-    "@ethersproject/properties" ">=5.0.0-beta.131"
-    "@ethersproject/strings" ">=5.0.0-beta.130"
-
 "@ethersproject/abi@>=5.0.0-beta.153":
   version "5.0.0-beta.155"
   resolved "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.0-beta.155.tgz#b02cc0d54a44fd499be9778be53ed112220e3ecd"
@@ -2013,23 +1998,10 @@
     "@ethersproject/properties" ">=5.0.0-beta.140"
     "@ethersproject/strings" ">=5.0.0-beta.136"
 
-"@ethersproject/abstract-provider@>=5.0.0-beta.131":
-  version "5.0.0-beta.139"
-  resolved "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.0-beta.139.tgz#a3b52c5494dcf67d277e2c0443813d9de746f8b4"
-  integrity sha512-cK/7qj0bIG3Dd7xD9q+6ztXr+WXw/i2MglFLC3GadhjFr5YhdcD1rPkD5nU7H0o2BoL/jkvLJL6FYOZyCDS0Nw==
-  dependencies:
-    "@ethersproject/bignumber" ">=5.0.0-beta.130"
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-    "@ethersproject/networks" ">=5.0.0-beta.129"
-    "@ethersproject/properties" ">=5.0.0-beta.131"
-    "@ethersproject/transactions" ">=5.0.0-beta.128"
-    "@ethersproject/web" ">=5.0.0-beta.129"
-
 "@ethersproject/abstract-provider@>=5.0.0-beta.139":
-  version "5.0.0-beta.140"
-  resolved "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.0-beta.140.tgz#50650c31e7fe019fd3c519bf5500025225790f02"
-  integrity sha512-4Hu2xie/0Zqsk3RMYucxwHlG9SGgxLWj0becYanusMnBWJVSN+d0pXzaE5gHPlzPIytY5IihFelF3Bfz3OZfNg==
+  version "5.0.0-beta.142"
+  resolved "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.0-beta.142.tgz#932986a2fc7f392d406f888a46d9fc6f4b234cb4"
+  integrity sha512-NnSgbGb3bpArL1ygaFVtg5sQjVhODQrdw/KlGGfPhIff37xfeoQPWMdN9ZbkTn+LqMdRCAEBTh5eEPCeWVLwgQ==
   dependencies:
     "@ethersproject/bignumber" ">=5.0.0-beta.138"
     "@ethersproject/bytes" ">=5.0.0-beta.137"
@@ -2039,39 +2011,16 @@
     "@ethersproject/transactions" ">=5.0.0-beta.135"
     "@ethersproject/web" ">=5.0.0-beta.138"
 
-"@ethersproject/abstract-signer@>=5.0.0-beta.132":
-  version "5.0.0-beta.141"
-  resolved "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.0-beta.141.tgz#e8cf65cea082905db6b678f0dd35d35c4869063b"
-  integrity sha512-94ldEV+H2BI00lBEWKf0HlX7IrbMcPPFYbSnj2f1/cqB2y8RNttEe0gR39ALrCUeqY+ceLnKxIz2tOY9sllMFw==
-  dependencies:
-    "@ethersproject/abstract-provider" ">=5.0.0-beta.131"
-    "@ethersproject/bignumber" ">=5.0.0-beta.130"
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-    "@ethersproject/properties" ">=5.0.0-beta.131"
-
 "@ethersproject/abstract-signer@>=5.0.0-beta.142":
-  version "5.0.0-beta.144"
-  resolved "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.0-beta.144.tgz#b55c6b82032c7d4415668639719963a2b9b5a090"
-  integrity sha512-sYrAIcQ7m5GXhWHqD5dB+29cPNweGzlKRIWj0h61AV7ZNopjk0ozh1BbpRpmRtUKJ6MVlkaSA4uHEGAYk3iEqw==
+  version "5.0.0-beta.145"
+  resolved "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.0-beta.145.tgz#9b9ce8e06e60dbf6c234a779fcc93b645ad683d2"
+  integrity sha512-ZgowV8Zi7DVFg/eJRhaDCVNu7eCqKJVE/HiGS6M5RyKJWMyXgFcxznSF+Apawy9sfL3CmWfdciuTpdybj/KBig==
   dependencies:
     "@ethersproject/abstract-provider" ">=5.0.0-beta.139"
     "@ethersproject/bignumber" ">=5.0.0-beta.138"
     "@ethersproject/bytes" ">=5.0.0-beta.137"
     "@ethersproject/logger" ">=5.0.0-beta.137"
     "@ethersproject/properties" ">=5.0.0-beta.140"
-
-"@ethersproject/address@>=5.0.0-beta.128":
-  version "5.0.0-beta.134"
-  resolved "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.0-beta.134.tgz#9c1790c87b763dc547ac12e2dbc9fa78d0799a71"
-  integrity sha512-FHhUVJTUIg2pXvOOhIt8sB1cQbcwrzZKzf9CPV7JM1auli20nGoYhyMFYGK7u++GXzTMJduIkU1OwlIBupewDw==
-  dependencies:
-    "@ethersproject/bignumber" ">=5.0.0-beta.130"
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/keccak256" ">=5.0.0-beta.127"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-    "@ethersproject/rlp" ">=5.0.0-beta.126"
-    bn.js "^4.4.0"
 
 "@ethersproject/address@>=5.0.0-beta.134":
   version "5.0.0-beta.135"
@@ -2085,27 +2034,12 @@
     "@ethersproject/rlp" ">=5.0.0-beta.132"
     bn.js "^4.4.0"
 
-"@ethersproject/base64@>=5.0.0-beta.126":
-  version "5.0.0-beta.133"
-  resolved "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.0-beta.133.tgz#9efbd373d374502734896637ac550f3a730de8a7"
-  integrity sha512-y9aveGc/WQQuRwQ/uAQDmoZ3ybDzTcUvQ1fgQeO9m+H0A/YBGW+Rkm04NcM3xoul3BP8jpulRKcUIUvVwERdbw==
-  dependencies:
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-
 "@ethersproject/base64@>=5.0.0-beta.133":
   version "5.0.0-beta.134"
   resolved "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.0-beta.134.tgz#fda26d16a7ea9000f6565fa49929bd745b80dd13"
   integrity sha512-vM7GQgZ/7tShWJo91Oicq9CFv9c1VuZG1/8lGQlXkF797g12r053b9RrYaaOld2OoVLXzfbAR9Fr7I9nuISlxw==
   dependencies:
     "@ethersproject/bytes" ">=5.0.0-beta.137"
-
-"@ethersproject/basex@>=5.0.0-beta.127":
-  version "5.0.0-beta.132"
-  resolved "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.0-beta.132.tgz#c3c662c60d31f53e296d2638783dc5e5f68ec2f1"
-  integrity sha512-BlTGjIW5O03Tl3cVrBWPYnSnhEdz7h3sAely82xDZPutUw9PyPy/PF7IN19iVNgv5ZKQlaDmQZ6M2OGzVOuIPw==
-  dependencies:
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/properties" ">=5.0.0-beta.131"
 
 "@ethersproject/basex@>=5.0.0-beta.132":
   version "5.0.0-beta.133"
@@ -2114,16 +2048,6 @@
   dependencies:
     "@ethersproject/bytes" ">=5.0.0-beta.137"
     "@ethersproject/properties" ">=5.0.0-beta.140"
-
-"@ethersproject/bignumber@>=5.0.0-beta.130":
-  version "5.0.0-beta.138"
-  resolved "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.0-beta.138.tgz#a635f2f9a6f1b262cc38e1c7ee561fb13d79fda4"
-  integrity sha512-DTlOEJw6jAFz7/qkY8p4mPGGHVwgYUUC5rk1Pbg2/gR/gHPFDim+uBY+XGavh0QSWd1i3hXKafVPre92j4fs5g==
-  dependencies:
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-    "@ethersproject/properties" ">=5.0.0-beta.131"
-    bn.js "^4.4.0"
 
 "@ethersproject/bignumber@>=5.0.0-beta.138":
   version "5.0.0-beta.139"
@@ -2135,26 +2059,12 @@
     "@ethersproject/properties" ">=5.0.0-beta.140"
     bn.js "^4.4.0"
 
-"@ethersproject/bytes@>=5.0.0-beta.129":
-  version "5.0.0-beta.137"
-  resolved "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.0-beta.137.tgz#a9a35e2b358886289225d28212f4071ae391c161"
-  integrity sha512-uBwchZzGP912Wcani6vM7RLtsnN69Uc9WTLvewsniKrpHpSx0/k33WUcQVosmkwPgUtqflKyGjcIqaea1Z9WHw==
-  dependencies:
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-
 "@ethersproject/bytes@>=5.0.0-beta.137":
   version "5.0.0-beta.138"
   resolved "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.0-beta.138.tgz#86e1f6c4016443f2b5236627fa656e7c56077a56"
   integrity sha512-q4vaIthv89RJQ0V6gdzh1xuluJE1uYbnfzBUYTegicaXX6jRTCjDDhyiQhyEnNi7pKrGtuOrR3v3+7WtAR8Imw==
   dependencies:
     "@ethersproject/logger" ">=5.0.0-beta.137"
-
-"@ethersproject/constants@>=5.0.0-beta.128":
-  version "5.0.0-beta.133"
-  resolved "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.0-beta.133.tgz#af4ccd7232f3ed73aebe066a695ede32c497a394"
-  integrity sha512-VCTpk3AF00mlWQw1vg+fI6qCo0qO5EVWK574t4HNBKW6X748jc9UJPryKUz9JgZ64ZQupyLM92wHilsG/YTpNQ==
-  dependencies:
-    "@ethersproject/bignumber" ">=5.0.0-beta.130"
 
 "@ethersproject/constants@>=5.0.0-beta.133":
   version "5.0.0-beta.134"
@@ -2163,26 +2073,10 @@
   dependencies:
     "@ethersproject/bignumber" ">=5.0.0-beta.138"
 
-"@ethersproject/contracts@>=5.0.0-beta.137":
-  version "5.0.0-beta.150"
-  resolved "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.0-beta.150.tgz#0038ddbacdabbd3061dd69bbd3dd009561fe6c75"
-  integrity sha512-ODHv8o3dJPXo2vTtQ1dmla6KhykTtYlgQxwgyyYXt/r2PhMVyFQsljVYkJRUuHgC17WYBopmWGeVeYAxNeOhtQ==
-  dependencies:
-    "@ethersproject/abi" ">=5.0.0-beta.137"
-    "@ethersproject/abstract-provider" ">=5.0.0-beta.131"
-    "@ethersproject/abstract-signer" ">=5.0.0-beta.132"
-    "@ethersproject/address" ">=5.0.0-beta.128"
-    "@ethersproject/bignumber" ">=5.0.0-beta.130"
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/constants" ">=5.0.0-beta.128"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-    "@ethersproject/properties" ">=5.0.0-beta.131"
-    "@ethersproject/transactions" ">=5.0.0-beta.128"
-
 "@ethersproject/contracts@>=5.0.0-beta.151":
-  version "5.0.0-beta.152"
-  resolved "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.0-beta.152.tgz#6ca53dbf556011e179345508e05730cda3861f5b"
-  integrity sha512-sYdSNqmX59uH1eDqQvR4QlYaslQ80zqvrWaugUeSqz97/EyZ2aVF61R/BJ+mKLnv/smwerkNlGKCjxubmdmM/w==
+  version "5.0.0-beta.156"
+  resolved "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.0-beta.156.tgz#2e8f1a25f1a2b27fe990ff3d5e9bde9653cbb734"
+  integrity sha512-O05PhobckKBqPx7+7c/qxYXQxSqhgwjaXHWlL9fUzIWCz9m3qVYdRHSyKSqyQdFf+AC6DnnGvr0JZBAYoKP/9A==
   dependencies:
     "@ethersproject/abi" ">=5.0.0-beta.153"
     "@ethersproject/abstract-provider" ">=5.0.0-beta.139"
@@ -2193,27 +2087,16 @@
     "@ethersproject/constants" ">=5.0.0-beta.133"
     "@ethersproject/logger" ">=5.0.0-beta.137"
     "@ethersproject/properties" ">=5.0.0-beta.140"
-    "@ethersproject/transactions" ">=5.0.0-beta.135"
 
-"@ethersproject/experimental@5.0.0-beta.140":
-  version "5.0.0-beta.140"
-  resolved "https://registry.npmjs.org/@ethersproject/experimental/-/experimental-5.0.0-beta.140.tgz#727cc77634b0a6f66260b0580a27ce46d0e84e0a"
-  integrity sha512-a03L0kQi0sAMNRplrI3siQM8Uf20NROKHMTYTlGWMUDzzEc3JGaJ2/CLksdlahNYZXpHoGsBejtELaFMOEgSfA==
+"@ethersproject/experimental@5.0.0-beta.143":
+  version "5.0.0-beta.143"
+  resolved "https://registry.npmjs.org/@ethersproject/experimental/-/experimental-5.0.0-beta.143.tgz#b6bb0cda61061dbf6f2241a982079b5684bde78b"
+  integrity sha512-3toy/bXsq9Dsk5wUuLZQwkI8qce7T8LN7Ob9TADIKy7C8MCdPdboV0w3iUls+LRY6Ymx78e4kjZS+k1FUGcDSQ==
   dependencies:
     "@ensdomains/address-encoder" "^0.1.2"
-    "@ethersproject/web" ">=5.0.0-beta.129"
-    ethers ">=5.0.0-beta.156"
-    scrypt-js "3.0.0"
-
-"@ethersproject/hash@>=5.0.0-beta.128":
-  version "5.0.0-beta.133"
-  resolved "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.0-beta.133.tgz#bda0c74454a82359642033f27c5157963495fcdf"
-  integrity sha512-tfF11QxFlJCy92rMtUZ0kImchWhlYXkN5Gj5cYfTcCdWEUKwNq1LljDnlrjV2JabO6s5enb8uiUj4RBTo2+Rgw==
-  dependencies:
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/keccak256" ">=5.0.0-beta.127"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-    "@ethersproject/strings" ">=5.0.0-beta.130"
+    "@ethersproject/web" ">=5.0.0-beta.138"
+    ethers ">=5.0.0-beta.186"
+    scrypt-js "3.0.1"
 
 "@ethersproject/hash@>=5.0.0-beta.133":
   version "5.0.0-beta.134"
@@ -2224,24 +2107,6 @@
     "@ethersproject/keccak256" ">=5.0.0-beta.131"
     "@ethersproject/logger" ">=5.0.0-beta.137"
     "@ethersproject/strings" ">=5.0.0-beta.136"
-
-"@ethersproject/hdnode@>=5.0.0-beta.130":
-  version "5.0.0-beta.139"
-  resolved "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.0-beta.139.tgz#e0fb1d0703fcaff5f1615cbf38e832e5f1ba880d"
-  integrity sha512-VOg9bZDNO1OC5Ryph3iNof1i4Te5b3thiEyGqOIQaN2esfGWkt6nUvHRy5na6knjyBY68zVr7yj39LdX5rsOPA==
-  dependencies:
-    "@ethersproject/abstract-signer" ">=5.0.0-beta.132"
-    "@ethersproject/basex" ">=5.0.0-beta.127"
-    "@ethersproject/bignumber" ">=5.0.0-beta.130"
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-    "@ethersproject/pbkdf2" ">=5.0.0-beta.127"
-    "@ethersproject/properties" ">=5.0.0-beta.131"
-    "@ethersproject/sha2" ">=5.0.0-beta.129"
-    "@ethersproject/signing-key" ">=5.0.0-beta.129"
-    "@ethersproject/strings" ">=5.0.0-beta.130"
-    "@ethersproject/transactions" ">=5.0.0-beta.128"
-    "@ethersproject/wordlists" ">=5.0.0-beta.128"
 
 "@ethersproject/hdnode@>=5.0.0-beta.139":
   version "5.0.0-beta.140"
@@ -2261,30 +2126,10 @@
     "@ethersproject/transactions" ">=5.0.0-beta.135"
     "@ethersproject/wordlists" ">=5.0.0-beta.136"
 
-"@ethersproject/json-wallets@>=5.0.0-beta.129":
-  version "5.0.0-beta.138"
-  resolved "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.0-beta.138.tgz#2855bf900b286c8a83d6c8492cc39419db7a48bb"
-  integrity sha512-cyJ8WX5/hYduA0I8SWujY+usO9DV1mmpmEfLrkd8JWecdByMhWTXZfgsJY92u98AoKyGm8vjAIVuLcA++Xuffg==
-  dependencies:
-    "@ethersproject/abstract-signer" ">=5.0.0-beta.132"
-    "@ethersproject/address" ">=5.0.0-beta.128"
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/hdnode" ">=5.0.0-beta.130"
-    "@ethersproject/keccak256" ">=5.0.0-beta.127"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-    "@ethersproject/pbkdf2" ">=5.0.0-beta.127"
-    "@ethersproject/properties" ">=5.0.0-beta.131"
-    "@ethersproject/random" ">=5.0.0-beta.128"
-    "@ethersproject/strings" ">=5.0.0-beta.130"
-    "@ethersproject/transactions" ">=5.0.0-beta.128"
-    aes-js "3.0.0"
-    scrypt-js "3.0.0"
-    uuid "2.0.1"
-
 "@ethersproject/json-wallets@>=5.0.0-beta.138":
-  version "5.0.0-beta.139"
-  resolved "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.0-beta.139.tgz#64b42e6ecfe8f52313893a3f83cf16ffcedc07a4"
-  integrity sha512-YThwWsKw8Q4RyIaGyfYDolt6UlbvQnYuQc6wp7dkDSlPfEakQIMQtnj1gpsi6NEsGpbFG+WkPaz2jDItLmyYiQ==
+  version "5.0.0-beta.140"
+  resolved "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.0-beta.140.tgz#d9ae4d3632d4d89eba337fe0ed51e66370425233"
+  integrity sha512-Wz9YcjBrxklgBYh/ae+1vn3gG5JK9oMWMVthA/uOLgqy8Uecw51o5lg8hyjAN4vXKbkkx6dX5C8vxC2JNCLlCw==
   dependencies:
     "@ethersproject/abstract-signer" ">=5.0.0-beta.142"
     "@ethersproject/address" ">=5.0.0-beta.134"
@@ -2298,16 +2143,8 @@
     "@ethersproject/strings" ">=5.0.0-beta.136"
     "@ethersproject/transactions" ">=5.0.0-beta.135"
     aes-js "3.0.0"
-    scrypt-js "3.0.0"
+    scrypt-js "3.0.1"
     uuid "2.0.1"
-
-"@ethersproject/keccak256@>=5.0.0-beta.127":
-  version "5.0.0-beta.131"
-  resolved "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.0-beta.131.tgz#b5778723ee75208065b9b9ad30c71d480f41bb31"
-  integrity sha512-KQnqMwGV0IMOjAr/UTFO8DuLrmN1uaMvcV3zh9hiXhh3rCuY+WXdeUh49w1VQ94kBKmaP0qfGb7z4SdhUWUHjw==
-  dependencies:
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    js-sha3 "0.5.7"
 
 "@ethersproject/keccak256@>=5.0.0-beta.131":
   version "5.0.0-beta.132"
@@ -2317,17 +2154,10 @@
     "@ethersproject/bytes" ">=5.0.0-beta.137"
     js-sha3 "0.5.7"
 
-"@ethersproject/logger@>=5.0.0-beta.129", "@ethersproject/logger@>=5.0.0-beta.137":
+"@ethersproject/logger@>=5.0.0-beta.137":
   version "5.0.0-beta.137"
   resolved "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.0-beta.137.tgz#781582b8b04d0ced01e9c1608c9887d31d95b8ee"
   integrity sha512-H36iMhWOY+tco1+o2NZUdQT8Gc6Y9795RSPgvluatvjvyt3X6mHtWXes4F8Rc5N/95px++a/ODYVSkSmlr68+A==
-
-"@ethersproject/networks@>=5.0.0-beta.129":
-  version "5.0.0-beta.136"
-  resolved "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.0-beta.136.tgz#8d6fdae297c0ce7ebe1893e601c4a57f7e38dc7a"
-  integrity sha512-skMDix0LVOhpfCItbg6Z1fXLK6vAtUkzAKaslDxVczEPUvjQ0kiJ5ceurmL+ROOO1owURGxUac5BrIarbO7Zgw==
-  dependencies:
-    "@ethersproject/logger" ">=5.0.0-beta.129"
 
 "@ethersproject/networks@>=5.0.0-beta.136":
   version "5.0.0-beta.137"
@@ -2335,14 +2165,6 @@
   integrity sha512-fVdDXjKkTpFUiJP1SpNaqX+377C72RcXpsc679i42DfSsTIciYkxSzi8g7k9E6YBVW40EdcCSiC1LSWZRHHR8Q==
   dependencies:
     "@ethersproject/logger" ">=5.0.0-beta.137"
-
-"@ethersproject/pbkdf2@>=5.0.0-beta.127":
-  version "5.0.0-beta.135"
-  resolved "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.0-beta.135.tgz#5c04e6545ec64e13668dafec13bc8fe02836739e"
-  integrity sha512-j5bMqkEPwd7NcbF1Z4FI5rNZvydEKWx4EcxJd0vMN/DLSk0wilCVRcFuuz5w+sSc6sERbkNpD7AQh8a5whZsvQ==
-  dependencies:
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/sha2" ">=5.0.0-beta.129"
 
 "@ethersproject/pbkdf2@>=5.0.0-beta.135":
   version "5.0.0-beta.136"
@@ -2352,46 +2174,17 @@
     "@ethersproject/bytes" ">=5.0.0-beta.137"
     "@ethersproject/sha2" ">=5.0.0-beta.136"
 
-"@ethersproject/properties@>=5.0.0-beta.131":
-  version "5.0.0-beta.139"
-  resolved "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.0-beta.139.tgz#b56c494bbeb47b2d1bab95a52bbf1ee0a8040274"
-  integrity sha512-IFMEWxWkx8ATeGtY56pnHXK40eJgfO9UeEsK/24Qzwyl5jA5Lhz6OoElaW3UG5LLupHmLoRuLyuG1WNg2olC3A==
-  dependencies:
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-
 "@ethersproject/properties@>=5.0.0-beta.140":
-  version "5.0.0-beta.141"
-  resolved "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.0-beta.141.tgz#063e5a870f8bfb249de4de6218e6a104e253f24a"
-  integrity sha512-jWHVLlH8tmdMw6L9USaidZsiY/IOV4Br01PKM711oDZ8McBXrbW1FzcgpuzV91SNNMYek9kvrJJzAOPL2vANTQ==
+  version "5.0.0-beta.143"
+  resolved "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.0-beta.143.tgz#604ba072ee91e386e1bfab70413c34165fa9c913"
+  integrity sha512-Stagr55S1G8g7edhv5kkHoVaaebYzwlutzYv7hWT2Ad+LPLIT7mkFf88DX8i0eWLQ8hBaSbCfKrc7uS6K7MdEw==
   dependencies:
     "@ethersproject/logger" ">=5.0.0-beta.137"
 
-"@ethersproject/providers@>=5.0.0-beta.141":
-  version "5.0.0-beta.164"
-  resolved "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.0-beta.164.tgz#eecfc7a5bb67249d0c36c3e98ec25a7eb1c9e00b"
-  integrity sha512-c8pu+eYROr88dfDuW9aImESq2nHupzE5fFERHwLMQnl5eW20iEy37/1CEIRhjhBsHtRA/JpFPSRKPr4o1RcF4Q==
-  dependencies:
-    "@ethersproject/abstract-provider" ">=5.0.0-beta.131"
-    "@ethersproject/abstract-signer" ">=5.0.0-beta.132"
-    "@ethersproject/address" ">=5.0.0-beta.128"
-    "@ethersproject/bignumber" ">=5.0.0-beta.130"
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/constants" ">=5.0.0-beta.128"
-    "@ethersproject/hash" ">=5.0.0-beta.128"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-    "@ethersproject/networks" ">=5.0.0-beta.129"
-    "@ethersproject/properties" ">=5.0.0-beta.131"
-    "@ethersproject/random" ">=5.0.0-beta.128"
-    "@ethersproject/rlp" ">=5.0.0-beta.126"
-    "@ethersproject/strings" ">=5.0.0-beta.130"
-    "@ethersproject/transactions" ">=5.0.0-beta.128"
-    "@ethersproject/web" ">=5.0.0-beta.129"
-    ws "7.2.3"
-
 "@ethersproject/providers@>=5.0.0-beta.166":
-  version "5.0.0-beta.167"
-  resolved "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.0-beta.167.tgz#55cd0fe624847296637cc450940f9c36aff9daca"
-  integrity sha512-012isSL0umU11TVLw91VnJ5ikJHFXoZ+BPnChOAHtl3g7XtE/REiX+WN+9AxmBC28tUo2GeCWhTBDSsvQiw8Lw==
+  version "5.0.0-beta.171"
+  resolved "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.0-beta.171.tgz#2be647ebc7c1a9a1d07c240fb52dc8ae1dfe9d36"
+  integrity sha512-DqwZcfURXPpjIK8IABlsLlhT1Y7HHGf+0I24Hylf/K+dPu30Xg2dXrUDwIi4v+jj6ZaVohbRNeShuwg59yRyUw==
   dependencies:
     "@ethersproject/abstract-provider" ">=5.0.0-beta.139"
     "@ethersproject/abstract-signer" ">=5.0.0-beta.142"
@@ -2410,14 +2203,6 @@
     "@ethersproject/web" ">=5.0.0-beta.138"
     ws "7.2.3"
 
-"@ethersproject/random@>=5.0.0-beta.128":
-  version "5.0.0-beta.135"
-  resolved "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.0-beta.135.tgz#7a7ec131c2d6b5a6ee062e3e9b805bfd931ec1e6"
-  integrity sha512-wYboNR0L8eYCpwYT2PiOD7mwPMj26i94FyQmt4DONAsBrvLCrEYYFmY2uqUMBrb5E4DVoubh4ObevAYTjriYaQ==
-  dependencies:
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-
 "@ethersproject/random@>=5.0.0-beta.135":
   version "5.0.0-beta.136"
   resolved "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.0-beta.136.tgz#5f5e89f50e0fb7d286daeb0286fe44eb243ddeb4"
@@ -2426,14 +2211,6 @@
     "@ethersproject/bytes" ">=5.0.0-beta.137"
     "@ethersproject/logger" ">=5.0.0-beta.137"
 
-"@ethersproject/rlp@>=5.0.0-beta.126":
-  version "5.0.0-beta.132"
-  resolved "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.0-beta.132.tgz#f7d31e0ee8792180ffd5c73969aa5b2f8804e967"
-  integrity sha512-P2oZkSMMazvMB0OaOM9GJnmLzHHSeCKqOp9bPAAY/rb65ICdtNjQMRYhOwinBFabrdV2z5TKWpwA9KIBkI0rTg==
-  dependencies:
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-
 "@ethersproject/rlp@>=5.0.0-beta.132":
   version "5.0.0-beta.133"
   resolved "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.0-beta.133.tgz#e51b2e8d51fd70a5872f85f11741193a6b118110"
@@ -2441,15 +2218,6 @@
   dependencies:
     "@ethersproject/bytes" ">=5.0.0-beta.137"
     "@ethersproject/logger" ">=5.0.0-beta.137"
-
-"@ethersproject/sha2@>=5.0.0-beta.129":
-  version "5.0.0-beta.136"
-  resolved "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.0-beta.136.tgz#34e7c7892e395dea7ba24daead59767a31a586b2"
-  integrity sha512-MUxCjFhCPRSggkoQN5H1nbDlC5GpAJpvIWInTTqVP0bN/0vRZ8BuyoYi1Xb961xpSoYlZwJjK8e6/5j346f6Hw==
-  dependencies:
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-    hash.js "1.1.3"
 
 "@ethersproject/sha2@>=5.0.0-beta.136":
   version "5.0.0-beta.137"
@@ -2460,16 +2228,6 @@
     "@ethersproject/logger" ">=5.0.0-beta.137"
     hash.js "1.1.3"
 
-"@ethersproject/signing-key@>=5.0.0-beta.129":
-  version "5.0.0-beta.135"
-  resolved "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.0-beta.135.tgz#f739e800aad9e01b77a8ec2c353b9b66ce5738fa"
-  integrity sha512-D4w5svi8F8eYs+LTuroKzOR8le6ZKtmH/mDmtuz15vz3XdOkLPGVne5mqqqLJd8APBnOEDtsAqmg7ZCrAk8Mag==
-  dependencies:
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-    "@ethersproject/properties" ">=5.0.0-beta.131"
-    elliptic "6.5.2"
-
 "@ethersproject/signing-key@>=5.0.0-beta.135":
   version "5.0.0-beta.136"
   resolved "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.0-beta.136.tgz#e24c93aeba25b8631673e490ce8ba519a3f90186"
@@ -2479,17 +2237,6 @@
     "@ethersproject/logger" ">=5.0.0-beta.137"
     "@ethersproject/properties" ">=5.0.0-beta.140"
     elliptic "6.5.2"
-
-"@ethersproject/solidity@>=5.0.0-beta.126":
-  version "5.0.0-beta.131"
-  resolved "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.0-beta.131.tgz#7d826e98cc0a29e25f0ff52ae17c07483f5d93d4"
-  integrity sha512-i5vuj2CXGMkVPo08bmElC2cvhjRDNRZZ8nzvx2WCi75Zh42xD0XNV77E9ZLYgS0WoZSiAi/F71nXSBnM7FAqJg==
-  dependencies:
-    "@ethersproject/bignumber" ">=5.0.0-beta.130"
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/keccak256" ">=5.0.0-beta.127"
-    "@ethersproject/sha2" ">=5.0.0-beta.129"
-    "@ethersproject/strings" ">=5.0.0-beta.130"
 
 "@ethersproject/solidity@>=5.0.0-beta.131":
   version "5.0.0-beta.132"
@@ -2502,15 +2249,6 @@
     "@ethersproject/sha2" ">=5.0.0-beta.136"
     "@ethersproject/strings" ">=5.0.0-beta.136"
 
-"@ethersproject/strings@>=5.0.0-beta.130":
-  version "5.0.0-beta.136"
-  resolved "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.0-beta.136.tgz#053cbf4f9f96a7537cbc50300597f2d707907f51"
-  integrity sha512-Hb9RvTrgGcOavHvtQZz+AuijB79BO3g1cfF2MeMfCU9ID4j3mbZv/olzDMS2pK9r4aERJpAS94AmlWzCgoY2LQ==
-  dependencies:
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/constants" ">=5.0.0-beta.128"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-
 "@ethersproject/strings@>=5.0.0-beta.136":
   version "5.0.0-beta.137"
   resolved "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.0-beta.137.tgz#1e9730a701e7a44c3f1b4e1c7e134665cdd51d7b"
@@ -2519,21 +2257,6 @@
     "@ethersproject/bytes" ">=5.0.0-beta.137"
     "@ethersproject/constants" ">=5.0.0-beta.133"
     "@ethersproject/logger" ">=5.0.0-beta.137"
-
-"@ethersproject/transactions@>=5.0.0-beta.128":
-  version "5.0.0-beta.135"
-  resolved "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.0-beta.135.tgz#4ad0752c8a2f9b65f3dddf9885a20b4c68e5cd67"
-  integrity sha512-QdXLrm+e4XyaC1QSFW+mfj4/g7/ia/OiAdOQxYcuUsbSHI5ijXFeF2JBzvMuP8pprIfhFkiCuxWI8oXiFGAdRA==
-  dependencies:
-    "@ethersproject/address" ">=5.0.0-beta.128"
-    "@ethersproject/bignumber" ">=5.0.0-beta.130"
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/constants" ">=5.0.0-beta.128"
-    "@ethersproject/keccak256" ">=5.0.0-beta.127"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-    "@ethersproject/properties" ">=5.0.0-beta.131"
-    "@ethersproject/rlp" ">=5.0.0-beta.126"
-    "@ethersproject/signing-key" ">=5.0.0-beta.129"
 
 "@ethersproject/transactions@>=5.0.0-beta.135":
   version "5.0.0-beta.136"
@@ -2550,15 +2273,6 @@
     "@ethersproject/rlp" ">=5.0.0-beta.132"
     "@ethersproject/signing-key" ">=5.0.0-beta.135"
 
-"@ethersproject/units@>=5.0.0-beta.127":
-  version "5.0.0-beta.132"
-  resolved "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.0-beta.132.tgz#54c03c821e515a09ef79a22704ad57994ee66c45"
-  integrity sha512-3GZDup1uTydvqaP5wpwoRF36irp6kx/gd3buPG+aoGWLPCoPjyk76OiGoxNQKfEaynOdZ7zG2lM8WevlBDJ57g==
-  dependencies:
-    "@ethersproject/bignumber" ">=5.0.0-beta.130"
-    "@ethersproject/constants" ">=5.0.0-beta.128"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-
 "@ethersproject/units@>=5.0.0-beta.132":
   version "5.0.0-beta.133"
   resolved "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.0-beta.133.tgz#0c96958f30d923590749ec4c072762352d40ed54"
@@ -2567,27 +2281,6 @@
     "@ethersproject/bignumber" ">=5.0.0-beta.138"
     "@ethersproject/constants" ">=5.0.0-beta.133"
     "@ethersproject/logger" ">=5.0.0-beta.137"
-
-"@ethersproject/wallet@>=5.0.0-beta.130":
-  version "5.0.0-beta.140"
-  resolved "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.0-beta.140.tgz#118123ab25c0ed6fe82391bc3e070b47d37bc676"
-  integrity sha512-woVhEFsoTmOWf8AByKuP5XvQ/8gsmOSxvthEblgfyKyFh3wsO2cEV+6F0ITerj62reJ1MPof+RDUYaw0JCSCYA==
-  dependencies:
-    "@ethersproject/abstract-provider" ">=5.0.0-beta.131"
-    "@ethersproject/abstract-signer" ">=5.0.0-beta.132"
-    "@ethersproject/address" ">=5.0.0-beta.128"
-    "@ethersproject/bignumber" ">=5.0.0-beta.130"
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/hash" ">=5.0.0-beta.128"
-    "@ethersproject/hdnode" ">=5.0.0-beta.130"
-    "@ethersproject/json-wallets" ">=5.0.0-beta.129"
-    "@ethersproject/keccak256" ">=5.0.0-beta.127"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-    "@ethersproject/properties" ">=5.0.0-beta.131"
-    "@ethersproject/random" ">=5.0.0-beta.128"
-    "@ethersproject/signing-key" ">=5.0.0-beta.129"
-    "@ethersproject/transactions" ">=5.0.0-beta.128"
-    "@ethersproject/wordlists" ">=5.0.0-beta.128"
 
 "@ethersproject/wallet@>=5.0.0-beta.140":
   version "5.0.0-beta.141"
@@ -2610,36 +2303,15 @@
     "@ethersproject/transactions" ">=5.0.0-beta.135"
     "@ethersproject/wordlists" ">=5.0.0-beta.136"
 
-"@ethersproject/web@>=5.0.0-beta.129":
-  version "5.0.0-beta.137"
-  resolved "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.0-beta.137.tgz#fed0f0640bc5f59a2b4da82d69c7bd106cbf558e"
-  integrity sha512-A5pyWFSVjUHK/etvAkX3tOTMe6Vn1oOReFUCZ/wUzECJE4fLLLPs1e+MKkkcEKtJygeo8rc0sDuNj/EjN8U7+Q==
-  dependencies:
-    "@ethersproject/base64" ">=5.0.0-beta.126"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-    "@ethersproject/properties" ">=5.0.0-beta.131"
-    "@ethersproject/strings" ">=5.0.0-beta.130"
-
 "@ethersproject/web@>=5.0.0-beta.138":
-  version "5.0.0-beta.140"
-  resolved "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.0-beta.140.tgz#3567555e2123c8b548e83d616e6b4f0f68705e9c"
-  integrity sha512-KvPIQjFsB876DLzSI/2PNuANIAdqi0bKJpOm6+Pi1A98bgM9LDpRhJFd6iyvhXtNkl2ZTUqjGU2fcKP+Itxd/Q==
+  version "5.0.0-beta.141"
+  resolved "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.0-beta.141.tgz#280c4289b4abc420d2a6934930581e74f4ca68f5"
+  integrity sha512-imk6Jeq2Z7ZNkihDCuz8VF1gijYdGmVNThpHSGoWhIf6V35jR/u1LGkA2bMFqjge/orYzVrzEhLp428kW3wrGA==
   dependencies:
     "@ethersproject/base64" ">=5.0.0-beta.133"
     "@ethersproject/logger" ">=5.0.0-beta.137"
     "@ethersproject/properties" ">=5.0.0-beta.140"
     "@ethersproject/strings" ">=5.0.0-beta.136"
-
-"@ethersproject/wordlists@>=5.0.0-beta.128":
-  version "5.0.0-beta.136"
-  resolved "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.0-beta.136.tgz#6a42791804727ecba25e0c4bce5214fee3f47a54"
-  integrity sha512-KBRUlUljdnQh2jGXZi6tvAU8rdUzsg5/ErWIcO2lhcMn7LKaLGhedmKHsHDwETWLzHWbsEK6728R9UHrTvaakw==
-  dependencies:
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/hash" ">=5.0.0-beta.128"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-    "@ethersproject/properties" ">=5.0.0-beta.131"
-    "@ethersproject/strings" ">=5.0.0-beta.130"
 
 "@ethersproject/wordlists@>=5.0.0-beta.136":
   version "5.0.0-beta.137"
@@ -16848,10 +16520,10 @@ ethers@4.0.45, ethers@^4.0.27, ethers@~4.0.4:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@5.0.0-beta.187:
-  version "5.0.0-beta.187"
-  resolved "https://registry.npmjs.org/ethers/-/ethers-5.0.0-beta.187.tgz#1a1eb92f1a7c11d3b5551acb78f7ff3950c39879"
-  integrity sha512-7pu8fXDClxhPkRvJu3tS90eJTl0mH4LhXPT4YCA70AgdBIdvGdI9WErjaQDZaDSCEik3ZmV4DJkgctVM20VHJg==
+ethers@5.0.0-beta.191, ethers@>=5.0.0-beta.186:
+  version "5.0.0-beta.191"
+  resolved "https://registry.npmjs.org/ethers/-/ethers-5.0.0-beta.191.tgz#ddc2bdd0eea69421e9e6ec07e4d1f33f5d16d81f"
+  integrity sha512-dg5XCbRtXl4fgZQF3tlPx+MBuFg/+mXsI/EyFxng6Bsrf0UEA3qfdOIlma5DtNHp3nOBCmCkHERwlHbfbkyQSQ==
   dependencies:
     "@ethersproject/abi" ">=5.0.0-beta.153"
     "@ethersproject/abstract-provider" ">=5.0.0-beta.139"
@@ -16882,41 +16554,6 @@ ethers@5.0.0-beta.187:
     "@ethersproject/wallet" ">=5.0.0-beta.140"
     "@ethersproject/web" ">=5.0.0-beta.138"
     "@ethersproject/wordlists" ">=5.0.0-beta.136"
-
-ethers@>=5.0.0-beta.156:
-  version "5.0.0-beta.184"
-  resolved "https://registry.npmjs.org/ethers/-/ethers-5.0.0-beta.184.tgz#674ac8a06b48ffcab9a6ca771c311909f311c95b"
-  integrity sha512-Mty0RSwnGGAxHCMb57KGT4IzO29o2x+cMRYqJjEXM/UuTV1gwTgZnDlMdflkRoQ9Axpu4fcQFt04jPFEHydbSw==
-  dependencies:
-    "@ethersproject/abi" ">=5.0.0-beta.137"
-    "@ethersproject/abstract-provider" ">=5.0.0-beta.131"
-    "@ethersproject/abstract-signer" ">=5.0.0-beta.132"
-    "@ethersproject/address" ">=5.0.0-beta.128"
-    "@ethersproject/base64" ">=5.0.0-beta.126"
-    "@ethersproject/bignumber" ">=5.0.0-beta.130"
-    "@ethersproject/bytes" ">=5.0.0-beta.129"
-    "@ethersproject/constants" ">=5.0.0-beta.128"
-    "@ethersproject/contracts" ">=5.0.0-beta.137"
-    "@ethersproject/hash" ">=5.0.0-beta.128"
-    "@ethersproject/hdnode" ">=5.0.0-beta.130"
-    "@ethersproject/json-wallets" ">=5.0.0-beta.129"
-    "@ethersproject/keccak256" ">=5.0.0-beta.127"
-    "@ethersproject/logger" ">=5.0.0-beta.129"
-    "@ethersproject/networks" ">=5.0.0-beta.129"
-    "@ethersproject/pbkdf2" ">=5.0.0-beta.127"
-    "@ethersproject/properties" ">=5.0.0-beta.131"
-    "@ethersproject/providers" ">=5.0.0-beta.141"
-    "@ethersproject/random" ">=5.0.0-beta.128"
-    "@ethersproject/rlp" ">=5.0.0-beta.126"
-    "@ethersproject/sha2" ">=5.0.0-beta.129"
-    "@ethersproject/signing-key" ">=5.0.0-beta.129"
-    "@ethersproject/solidity" ">=5.0.0-beta.126"
-    "@ethersproject/strings" ">=5.0.0-beta.130"
-    "@ethersproject/transactions" ">=5.0.0-beta.128"
-    "@ethersproject/units" ">=5.0.0-beta.127"
-    "@ethersproject/wallet" ">=5.0.0-beta.130"
-    "@ethersproject/web" ">=5.0.0-beta.129"
-    "@ethersproject/wordlists" ">=5.0.0-beta.128"
 
 "ethers@git+https://github.com/LimeChain/ethers.js.git#master":
   version "4.0.29"
@@ -29571,10 +29208,10 @@ scrypt-js@2.0.4:
   resolved "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz#32f8c5149f0797672e551c07e230f834b6af5f16"
   integrity sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==
 
-scrypt-js@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.0.tgz#52361c1f272eeaab09ec1f806ea82078bca58b15"
-  integrity sha512-7CC7aufwukEvqdmllR0ny0QaSg0+S22xKXrXz3ZahaV6J+fgD2YAtrjtImuoDWog17/Ty9Q4HBmnXEXJ3JkfQA==
+scrypt-js@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
+  integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
 
 scrypt.js@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
The latest version of ethers contains the following: https://github.com/ethers-io/ethers.js/issues/861#issuecomment-638031278.

This allows us to remove the bespoke on-network-change reloading logic.