### PR TITLE
[web3torrent] performance tweaks

### DIFF
--- a/packages/web3torrent/src/constants.ts
+++ b/packages/web3torrent/src/constants.ts
@@ -8,7 +8,7 @@ export const COMMIT_HASH = process.env.COMMIT_HASH;
 
 export const WEI_PER_BYTE = utils.bigNumberify(1); // cost per byte
 export const BLOCK_LENGTH = 1 << 14; // Standard request length.
-export const PEER_TRUST = 4; //amount of trust between peers. It's equivalent to the amount of request to pre-pay.
+export const PEER_TRUST = 5; //amount of trust between peers. It's equivalent to the amount of request to pre-pay.
 // The recomended value is 5 ( the size of the queue of requests made by the leecher to the seeder)
 
 // Currently unused

--- a/packages/web3torrent/src/library/paid-streaming-extension.ts
+++ b/packages/web3torrent/src/library/paid-streaming-extension.ts
@@ -188,18 +188,18 @@ export abstract class PaidStreamingExtension implements Extension {
     const _onPiece = wire._onPiece; // handler for the "piece recieved" event
     wire._onPiece = function(index, offset, buffer) {
       _onPiece.apply(wire, [index, offset, buffer]);
-      log.info(`<< _onPiece: ${index} OFFSET: ${offset} DOWNLOADED: ${wire.downloaded}`);
+      log.trace(`<< _onPiece: ${index} OFFSET: ${offset} DOWNLOADED: ${wire.downloaded}`);
     };
     const blockedRequests = this.blockedRequests;
     const _onRequest = wire._onRequest; // handler for the "request recieved" event
     wire._onRequest = function(index, offset, length) {
-      log.info(`_onRequest: ${index}`);
+      log.trace(`_onRequest: ${index}`);
 
       if (this.paidStreamingExtension.isForceChoking) {
         // if the seeder is already blocking, do not even send the request to the client.
         // Just block and add the request to the blockedRequests array
         blockedRequests.push([index, offset, length]);
-        log.info(`_onRequest: ${index}, ${offset}, ${length} - IGNORED`);
+        log.trace(`_onRequest: ${index}, ${offset}, ${length} - IGNORED`);
       } else {
         messageBus.emit(PaidStreamingExtensionEvents.REQUEST, index, length, function(allow) {
           if (allow) {

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -475,8 +475,8 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     torrent.on(TorrentEvents.READY, emitTorrentUpdated(TorrentEvents.READY));
     torrent.on(TorrentEvents.WARNING, emitTorrentUpdated(TorrentEvents.WARNING));
     // These events are too frequent
-    // torrent.on(TorrentEvents.DOWNLOAD, emitTorrentUpdated);
-    // torrent.on(TorrentEvents.UPLOAD, emitTorrentUpdated);
+    // torrent.on(TorrentEvents.DOWNLOAD, emitTorrentUpdated(TorrentEvents.DOWNLOAD));
+    // torrent.on(TorrentEvents.UPLOAD, emitTorrentUpdated(TorrentEvents.UPLOAD));
 
     torrent.usingPaidStreaming = true;
     return torrent;
@@ -595,7 +595,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
 
   /** Emit an event that triggers a UI re-render */
   private emitTorrentUpdated(infoHash, trigger) {
-    // log.debug(`emitTorrentUpdate: ${trigger}`);
+    // log.trace(`emitTorrentUpdate: ${trigger}`);
     this.emit(WebTorrentPaidStreamingClient.torrentUpdatedEventName(infoHash));
   }
 

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -469,7 +469,8 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
       this.emitTorrentUpdated(torrent.infoHash, TorrentEvents.ERROR);
     });
 
-    const emitTorrentUpdated = trigger => () => this.emitTorrentUpdated(torrent.infoHash, trigger);
+    const emitTorrentUpdated = (trigger: string) => () =>
+      this.emitTorrentUpdated(torrent.infoHash, trigger);
     torrent.on(TorrentEvents.NOPEERS, emitTorrentUpdated(TorrentEvents.NOPEERS));
     torrent.on(TorrentEvents.METADATA, emitTorrentUpdated(TorrentEvents.METADATA));
     torrent.on(TorrentEvents.READY, emitTorrentUpdated(TorrentEvents.READY));
@@ -594,7 +595,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
   }
 
   /** Emit an event that triggers a UI re-render */
-  private emitTorrentUpdated(infoHash, trigger) {
+  private emitTorrentUpdated(infoHash, trigger: string) {
     // log.trace(`emitTorrentUpdate: ${trigger}`);
     this.emit(WebTorrentPaidStreamingClient.torrentUpdatedEventName(infoHash));
   }

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -69,7 +69,7 @@ const File: React.FC<Props> = props => {
       );
 
     const MAX_FPS = 10;
-    new Observable(subscriber => {
+    const subscription = new Observable(subscriber => {
       web3TorrentClient.addListener(
         WebTorrentPaidStreamingClient.torrentUpdatedEventName(infoHash),
         event => subscriber.next(event)
@@ -78,11 +78,7 @@ const File: React.FC<Props> = props => {
       .pipe(throttleTime(1_000 / MAX_FPS, undefined, {trailing: false, leading: true}))
       .subscribe(onTorrentUpdate);
 
-    return () =>
-      web3TorrentClient.removeListener(
-        WebTorrentPaidStreamingClient.torrentUpdatedEventName(infoHash),
-        onTorrentUpdate
-      );
+    return subscription.unsubscribe;
   }, [infoHash, torrentLength, torrentName, web3TorrentClient]);
 
   useEffect(() => {


### PR DESCRIPTION
PR description:
- Do not update UI on the most frequent webtorrent events: request, notice, upload, and download.
- Always after `onChannelUpdated`.
- Reduce frames-per-second to at most 10.
- Bump peer trust from 4 to 5.