### PR TITLE
Check for window.ethereum.on function type in web3torrent

### DIFF
--- a/packages/web3torrent/src/App.tsx
+++ b/packages/web3torrent/src/App.tsx
@@ -35,7 +35,7 @@ const App: React.FC = () => {
   }, [initialized]);
 
   useEffect(() => {
-    if (window.ethereum) {
+    if (window.ethereum && typeof window.ethereum.on === 'function') {
       const listener = chainId => setCurrentNetwork(Number(chainId));
       window.ethereum.on('networkChanged', listener);
       return () => {


### PR DESCRIPTION
Related to #2077.

On mobile wallets this property does not exist because there is no way to change networks without navigating away from the page on these wallets. That shouldn't prevent the page from loading.

Should resolve https://sentry.io/organizations/statechannels/issues/1717293691/?project=5228838&referrer=slack.