### PR TITLE
[web3torrent] Update UI on last exchange event

### DIFF
--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -75,7 +75,7 @@ const File: React.FC<Props> = props => {
         event => subscriber.next(event)
       );
     })
-      .pipe(throttleTime(1_000 / MAX_FPS, undefined, {trailing: false, leading: true}))
+      .pipe(throttleTime(1_000 / MAX_FPS, undefined, {trailing: true, leading: false}))
       .subscribe(onTorrentUpdate);
 
     return subscription.unsubscribe;


### PR DESCRIPTION
I believe that with current options there is a chance the UI would reflect a stale state after the exchange is finished between the leecher and seeder.