### PR TITLE
Fix some logging issues

### DIFF
--- a/packages/channel-provider/src/logger.ts
+++ b/packages/channel-provider/src/logger.ts
@@ -30,7 +30,9 @@ const browser: any = IS_BROWSER_CONTEXT
         warn: postMessageAndCallToConsoleFn(console.warn),
         info: postMessageAndCallToConsoleFn(console.info),
         debug: postMessageAndCallToConsoleFn(console.debug),
-        trace: postMessageAndCallToConsoleFn(console.trace)
+        // Firefox & chrome automatically expand trace calls, which is pretty annoying.
+        // So, we direct trace calls to console.debug instead.
+        trace: postMessageAndCallToConsoleFn(console.debug)
       }
     }
   : undefined;

--- a/packages/channel-provider/src/messaging-service.ts
+++ b/packages/channel-provider/src/messaging-service.ts
@@ -109,8 +109,6 @@ export class MessagingService {
         } else if (isJsonRpcErrorResponse(event.data)) {
           reject(new RpcError(event.data.error));
         }
-      } else {
-        logger.error({event}, 'Received a non JsonRpc response');
       }
     };
 

--- a/packages/web3torrent/src/logger.ts
+++ b/packages/web3torrent/src/logger.ts
@@ -200,7 +200,9 @@ const browser: any = IS_BROWSER_CONTEXT
         warn: appendAndCallToConsoleFn(console.warn),
         info: appendAndCallToConsoleFn(console.info),
         debug: appendAndCallToConsoleFn(console.debug),
-        trace: appendAndCallToConsoleFn(console.trace)
+        // Firefox & chrome automatically expand trace calls, which is pretty annoying.
+        // So, we direct trace calls to console.debug instead.
+        trace: appendAndCallToConsoleFn(console.debug)
       }
     }
   : undefined;

--- a/packages/xstate-wallet/config/webpack.config.js
+++ b/packages/xstate-wallet/config/webpack.config.js
@@ -69,31 +69,15 @@ module.exports = function(webpackEnv) {
   const publicUrl = isEnvProduction ? publicPath.slice(0, -1) : isEnvDevelopment && '';
 
   // This is based on what CRA was doing
-  const rawEnv = Object.keys(process.env)
-    .filter(key => {
-      return (
-        [
-          'CHAIN_NETWORK_ID',
-          'INFURA_API_KEY',
-          'CLEAR_STORAGE_ON_START',
-          'ETH_ASSET_HOLDER_ADDRESS',
-          'HUB_ADDRESS',
-          'HUB_DESTINATION',
-          'LOG_DESTINATION',
-          'NITRO_ADJUDICATOR_ADDRESS',
-          'USE_INDEXED_DB'
-        ].indexOf(key) > -1
-      );
-    })
-    .reduce(
-      (env, key) => {
-        env[key] = process.env[key];
-        return env;
-      },
-      {
-        PUBLIC_URL: publicUrl
-      }
-    );
+  const rawEnv = Object.keys(process.env).reduce(
+    (env, key) => {
+      env[key] = process.env[key];
+      return env;
+    },
+    {
+      PUBLIC_URL: publicUrl
+    }
+  );
   const stringifiedEnv = {
     'process.env': Object.keys(rawEnv).reduce((env, key) => {
       env[key] = JSON.stringify(rawEnv[key]);

--- a/packages/xstate-wallet/src/config.ts
+++ b/packages/xstate-wallet/src/config.ts
@@ -38,7 +38,7 @@ if (!process.env.HUB_DESTINATION) {
 export const HUB_DESTINATION = process.env.HUB_DESTINATION as Destination;
 
 export const LOG_DESTINATION: string | undefined = process.env.LOG_DESTINATION
-  ? process.env.destination === 'console'
+  ? process.env.LOG_DESTINATION === 'console'
     ? 'console'
     : `${process.env.LOG_DESTINATION}/wallet.log`
   : undefined;

--- a/packages/xstate-wallet/src/logger.ts
+++ b/packages/xstate-wallet/src/logger.ts
@@ -33,7 +33,9 @@ const browser: any = IS_BROWSER_CONTEXT
         warn: postMessageAndCallConsoleFn(console.warn),
         info: postMessageAndCallConsoleFn(console.info),
         debug: postMessageAndCallConsoleFn(console.debug),
-        trace: postMessageAndCallConsoleFn(console.trace)
+        // Firefox & chrome automatically expand trace calls, which is pretty annoying.
+        // So, we direct trace calls to console.debug instead.
+        trace: postMessageAndCallConsoleFn(console.debug)
       }
     }
   : undefined;


### PR DESCRIPTION
1. When I tried to set the log level to `trace`, it created an infinite loop:

<img width="1920" alt="Screen Shot 2020-06-10 at 4 38 06 PM" src="https://user-images.githubusercontent.com/8432675/84325946-c596dd80-ab30-11ea-8e66-c39d50e584a5.png">

Most of the non-Json-RPC message is a `PINO_LOG` message containing the error `"Received a non JsonRpc message"` :P

2. @kerzhner noticed that chrome expands trace calls. Firefox also seems to. So, trace log messages are redirected to `console.debug` instead.

3. `LOG_LEVEL` was not getting through the wallet's webpack config.

Fixes https://github.com/statechannels/monorepo/issues/2134