### PR TITLE
[web3torrent] Channel list UI

### DIFF
--- a/.env.virtual-funding
+++ b/.env.virtual-funding
@@ -9,7 +9,7 @@ GANACHE_PORT = '8545'
 LOG_DESTINATION = 'console'
 SHOW_VERBOSE_GANACHE_OUTPUT = 'true'
 USE_GANACHE_DEPLOYMENT_CACHE = 'true'
-LOG_LEVEL= 'debug'
+LOG_LEVEL= 'trace'
 ## e2e-tests
 HEADLESS = 'true'
 USE_DAPPETEER = 'false'

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -164,6 +164,7 @@ export type ChannelCache = Record<string, ChannelState | undefined>;
 export class PaymentChannelClient {
   channelCache: ChannelCache = {};
   budgetCache?: DomainBudget;
+  channelIdToTorrentMap: Record<string, string> = {};
 
   get mySigningAddress(): string | undefined {
     return this.channelClient.signingAddress;

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -156,11 +156,13 @@ if (process.env.FAKE_CHANNEL_PROVIDER === 'true') {
   require('@statechannels/channel-provider');
 }
 
+export type ChannelCache = Record<string, ChannelState | undefined>;
+
 // This Client targets at _unidirectional_, single asset (ETH) payment channel with 2 participants running on Nitro protocol
 // The beneficiary proposes the channel, but accepts payments
 // The payer joins the channel, and makes payments
 export class PaymentChannelClient {
-  channelCache: Record<string, ChannelState | undefined> = {};
+  channelCache: ChannelCache = {};
   budgetCache?: DomainBudget;
 
   get mySigningAddress(): string | undefined {
@@ -460,7 +462,7 @@ export class PaymentChannelClient {
     }
   }
 
-  async getChannels(): Promise<Record<string, ChannelState | undefined>> {
+  async getChannels(): Promise<ChannelCache> {
     const channelResults = await this.channelClient.getChannels(false);
     channelResults.map(convertToChannelState).forEach(cr => (this.channelCache[cr.channelId] = cr));
     return this.channelCache;

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -164,7 +164,6 @@ export type ChannelCache = Record<string, ChannelState | undefined>;
 export class PaymentChannelClient {
   channelCache: ChannelCache = {};
   budgetCache?: DomainBudget;
-  channelIdToTorrentMap: Record<string, string> = {};
 
   get mySigningAddress(): string | undefined {
     return this.channelClient.signingAddress;
@@ -243,7 +242,7 @@ export class PaymentChannelClient {
     }
   }
 
-  async createChannel(peers: Peers, torrentHash: string): Promise<ChannelState> {
+  async createChannel(peers: Peers): Promise<ChannelState> {
     const channelResult = await this.channelClient.createChannel(
       formatParticipants(peers),
       formatAllocations(peers),
@@ -254,8 +253,6 @@ export class PaymentChannelClient {
 
     const channelState = convertToChannelState(channelResult);
     this.insertIntoChannelCache(channelState);
-    this.updateChannelIdToTorrentMap(channelState.channelId, torrentHash);
-
     return channelState;
   }
 
@@ -281,9 +278,8 @@ export class PaymentChannelClient {
     return this.channelClient.onChannelProposed(cr => web3tCallback(convertToChannelState(cr)));
   }
 
-  async joinChannel(channelId: string, torrentHash: string) {
+  async joinChannel(channelId: string) {
     const channelResult = await this.channelClient.joinChannel(channelId);
-    this.updateChannelIdToTorrentMap(channelId, torrentHash);
     this.insertIntoChannelCache(convertToChannelState(channelResult));
   }
 
@@ -331,8 +327,7 @@ export class PaymentChannelClient {
     return convertToChannelState(channelResult);
   }
 
-  async updateChannel(channelId: string, peers: Peers, torrentHash: string): Promise<ChannelState> {
-    this.updateChannelIdToTorrentMap(channelId, torrentHash);
+  async updateChannel(channelId: string, peers: Peers): Promise<ChannelState> {
     const channelResult = await this.channelClient.updateChannel(
       channelId,
       formatParticipants(peers),
@@ -383,7 +378,7 @@ export class PaymentChannelClient {
   }
 
   // payer may use this method to make payments (if they have sufficient funds)
-  async makePayment(channelId: string, amount: string, torrentHash: string) {
+  async makePayment(channelId: string, amount: string) {
     let amountWillPay = amount;
     // First, wait for my turn
     const {payer, beneficiary} = await this.channelState(channelId)
@@ -402,14 +397,10 @@ export class PaymentChannelClient {
     }
 
     try {
-      await this.updateChannel(
-        channelId,
-        {
-          beneficiary: {...beneficiary, balance: add(beneficiary.balance, amountWillPay)},
-          payer: {...payer, balance: subtract(payer.balance, amountWillPay)}
-        },
-        torrentHash
-      );
+      await this.updateChannel(channelId, {
+        beneficiary: {...beneficiary, balance: add(beneficiary.balance, amountWillPay)},
+        payer: {...payer, balance: subtract(payer.balance, amountWillPay)}
+      });
     } catch (error) {
       if (error.error.code === ErrorCode.UpdateChannel.NotYourTurn) {
         logger.warn({channelId}, 'Possible race condition detected');
@@ -420,9 +411,9 @@ export class PaymentChannelClient {
   }
 
   // beneficiary may use this method to accept payments
-  async acceptChannelUpdate(channelState: ChannelState, torrentHash: string) {
+  async acceptChannelUpdate(channelState: ChannelState) {
     const {channelId, beneficiary, payer} = channelState;
-    await this.updateChannel(channelId, {beneficiary, payer}, torrentHash);
+    await this.updateChannel(channelId, {beneficiary, payer});
   }
 
   amProposer(channelIdOrChannelState: string | ChannelState): boolean {
@@ -486,13 +477,6 @@ export class PaymentChannelClient {
 
     this.budgetCache = undefined;
     return this.budgetCache;
-  }
-
-  updateChannelIdToTorrentMap(channelId: string, torrentHash: string) {
-    this.channelIdToTorrentMap = {
-      ...this.channelIdToTorrentMap,
-      [channelId]: torrentHash
-    };
   }
 }
 

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -30,8 +30,6 @@ import {logger} from '../logger';
 import {concat, of, Observable} from 'rxjs';
 import _ from 'lodash';
 
-import {isJsonRpcErrorResponse} from '@statechannels/channel-provider';
-
 const log = logger.child({module: 'payment-channel-client'});
 const hexZeroPad = utils.hexZeroPad;
 

--- a/packages/web3torrent/src/components/torrent-info/TorrentInfo.tsx
+++ b/packages/web3torrent/src/components/torrent-info/TorrentInfo.tsx
@@ -7,13 +7,13 @@ import {MagnetLinkButton} from './magnet-link-button/MagnetLinkButton';
 import './TorrentInfo.scss';
 import {PeerNetworkStats} from './peer-network-stats/PeerNetworkStats';
 import {calculateWei, prettyPrintWei} from '../../utils/calculateWei';
-import {ChannelState} from '../../clients/payment-channel-client';
+import {ChannelCache} from '../../clients/payment-channel-client';
 import {FaFileDownload, FaFileUpload} from 'react-icons/fa';
 import {ChannelsList} from './channels-list/ChannelsList';
 
 export type TorrentInfoProps = {
   torrent: TorrentUI;
-  channelCache: Record<string, ChannelState>;
+  channelCache: ChannelCache;
   mySigningAddress: string;
 };
 

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -1,7 +1,7 @@
-import _, {Dictionary} from 'lodash';
+import _ from 'lodash';
 import prettier from 'prettier-bytes';
 import React from 'react';
-import {ChannelState} from '../../../clients/payment-channel-client';
+import {ChannelCache} from '../../../clients/payment-channel-client';
 import './ChannelsList.scss';
 import {prettyPrintWei, prettyPrintBytes} from '../../../utils/calculateWei';
 import {utils} from 'ethers';
@@ -11,19 +11,16 @@ import {Badge, Avatar, Tooltip} from '@material-ui/core';
 
 type UploadInfoProps = {
   torrent: TorrentUI;
-  channels: Dictionary<ChannelState>;
+  channels: ChannelCache;
   mySigningAddress: string;
 };
 
 function channelIdToTableRow(
   channelId: string,
-  channels: Dictionary<ChannelState>,
+  channels: ChannelCache,
   torrent: TorrentUI,
   participantType: 'payer' | 'beneficiary'
-  // Challenging doesn't work in virtual channels: https://github.com/statechannels/monorepo/issues/1773
-  // clickHandler: (string) => Promise<ChannelState>
 ) {
-  // let channelButton;
   const channel = channels[channelId];
   const isBeneficiary = participantType === 'beneficiary';
   const wire = torrent.wires.find(
@@ -31,24 +28,8 @@ function channelIdToTableRow(
       wire.paidStreamingExtension.leechingChannelId === channelId ||
       wire.paidStreamingExtension.seedingChannelId === channelId
   );
-  // if (channel.status === 'closing') {
-  //   channelButton = <button disabled>Closing ...</button>;
-  // } else if (channel.status === 'closed') {
-  //   channelButton = <button disabled>Closed</button>;
-  // } else if (channel.status === 'challenging') {
-  //   channelButton = <button disabled>Challenging</button>;
-  // } else {
-  //   channelButton = getPeerStatus(torrent, wire) ? <button disabled>Running</button> : null;
-  // Challenging doesn't work in virtual channels: https://github.com/statechannels/monorepo/issues/1773
-  // (
-  //   <button className="button-alt" onClick={() => clickHandler(channelId)}>
-  //     Challenge Channel
-  //   </button>
-  // );
-  // }
 
   let dataTransferred: string;
-  // const peerAccount = isBeneficiary ? channel['payer'] : channel['beneficiary']; // If I am the payer, my peer is the beneficiary and vice versa
   const peerOutcomeAddress = isBeneficiary
     ? channel.payer.outcomeAddress
     : channel.beneficiary.outcomeAddress;
@@ -166,8 +147,6 @@ export const ChannelsList: React.FC<UploadInfoProps> = ({torrent, channels, mySi
               channels[key].beneficiary.signingAddress === mySigningAddress
                 ? 'beneficiary'
                 : 'payer'
-              // Challenging doesn't work in virtual channels: https://github.com/statechannels/monorepo/issues/1773
-              // ,context.paymentChannelClient.challengeChannel
             )
           )}
         </tbody>

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -119,11 +119,7 @@ export const ChannelsList: React.FC<UploadInfoProps> = ({torrent, channels, mySi
         state.payer.signingAddress === mySigningAddress ||
         state.beneficiary.signingAddress === mySigningAddress
     )
-    .filter(
-      state =>
-        web3TorrentClient.paymentChannelClient.channelIdToTorrentMap[state.channelId] ==
-        torrent.infoHash
-    )
+    .filter(state => web3TorrentClient.channelIdToTorrentMap[state.channelId] === torrent.infoHash)
     .sort(
       (state1, state2) =>
         statuses.indexOf(state1.status) - statuses.indexOf(state2.status) ||

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import prettier from 'prettier-bytes';
-import React from 'react';
+import React, {useContext} from 'react';
 import {ChannelCache, ChannelState} from '../../../clients/payment-channel-client';
 import './ChannelsList.scss';
 import {prettyPrintWei, prettyPrintBytes} from '../../../utils/calculateWei';
@@ -8,6 +8,7 @@ import {utils} from 'ethers';
 import {TorrentUI} from '../../../types';
 import {Blockie} from 'rimble-ui';
 import {Badge, Avatar, Tooltip} from '@material-ui/core';
+import {Web3TorrentClientContext} from '../../../clients/web3torrent-client';
 
 type UploadInfoProps = {
   torrent: TorrentUI;
@@ -110,6 +111,7 @@ function channelIdToTableRow(
 
 export const ChannelsList: React.FC<UploadInfoProps> = ({torrent, channels, mySigningAddress}) => {
   const statuses = ['running', 'closing', 'proposing', 'closed'];
+  const web3TorrentClient = useContext(Web3TorrentClientContext);
 
   const channelsInfo = _.values(channels)
     .filter(
@@ -117,6 +119,7 @@ export const ChannelsList: React.FC<UploadInfoProps> = ({torrent, channels, mySi
         state.payer.signingAddress === mySigningAddress ||
         state.beneficiary.signingAddress === mySigningAddress
     )
+    .filter(state => web3TorrentClient.paymentChannelClient.channelIdToTorrentMap[state.channelId])
     .sort(
       (state1, state2) =>
         statuses.indexOf(state1.status) - statuses.indexOf(state2.status) ||

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -119,7 +119,11 @@ export const ChannelsList: React.FC<UploadInfoProps> = ({torrent, channels, mySi
         state.payer.signingAddress === mySigningAddress ||
         state.beneficiary.signingAddress === mySigningAddress
     )
-    .filter(state => web3TorrentClient.paymentChannelClient.channelIdToTorrentMap[state.channelId])
+    .filter(
+      state =>
+        web3TorrentClient.paymentChannelClient.channelIdToTorrentMap[state.channelId] ==
+        torrent.infoHash
+    )
     .sort(
       (state1, state2) =>
         statuses.indexOf(state1.status) - statuses.indexOf(state2.status) ||

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -311,6 +311,10 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
       const isLeechingChannel = channelState.channelId === leechingChannelId;
 
       if (isSeedingChannel || isLeechingChannel) {
+        this.paymentChannelClient.channelIdToTorrentMap = {
+          ...this.paymentChannelClient.channelIdToTorrentMap,
+          [channelState.channelId]: torrent.infoHash
+        };
         const isClosed = channelState.status === 'closed';
         if (isClosed) {
           if (isLeechingChannel) {


### PR DESCRIPTION
Fixes https://github.com/statechannels/monorepo/issues/1949.

The goal of the PR is to display the most relevant set of channels for the current torrent. We create an in-memory map of channel id to torrent hash that is updated when a channel is created, joined, or updated. The resulting behavior is:
- After page refresh, no channels are displayed from previous leeching or seeding.
- Only channels for the current file shared are displayed. 