### PR TITLE
Reload page on address change

### DIFF
--- a/packages/channel-provider/src/channel-provider.ts
+++ b/packages/channel-provider/src/channel-provider.ts
@@ -27,7 +27,8 @@ class ChannelProvider implements ChannelProviderInterface {
     ChannelClosed: [],
     BudgetUpdated: [],
     MessageQueued: [],
-    UIUpdate: []
+    UIUpdate: [],
+    ReloadPage: []
   };
   protected url = '';
 
@@ -127,11 +128,11 @@ class ChannelProvider implements ChannelProviderInterface {
       const notificationMethod = message.method;
       const notificationParams = message.params;
       this.events.emit(notificationMethod, notificationParams);
+      if (notificationMethod === 'ReloadPage') {
+        logger.warn('Received page reload request from the wallet. Reloading page.');
+        window.location.reload();
+      }
       if (notificationMethod === 'UIUpdate') {
-        if (message.params.reloadPage) {
-          logger.warn('Received page reload request from the wallet. Reloading page.');
-          window.location.reload();
-        }
         this.ui.setVisibility(message.params.showWallet);
       } else {
         this.subscriptions[notificationMethod].forEach(id => {

--- a/packages/channel-provider/src/channel-provider.ts
+++ b/packages/channel-provider/src/channel-provider.ts
@@ -128,6 +128,10 @@ class ChannelProvider implements ChannelProviderInterface {
       const notificationParams = message.params;
       this.events.emit(notificationMethod, notificationParams);
       if (notificationMethod === 'UIUpdate') {
+        if (message.params.reloadPage) {
+          logger.warn('Received page reload request from the wallet. Reloading page.');
+          window.location.reload();
+        }
         this.ui.setVisibility(message.params.showWallet);
       } else {
         this.subscriptions[notificationMethod].forEach(id => {

--- a/packages/channel-provider/src/types.ts
+++ b/packages/channel-provider/src/types.ts
@@ -85,6 +85,7 @@ export type MethodResponseType = {
   GetBudget: GetBudgetResponse['result'];
   CloseAndWithdraw: any; // TODO: Add types
   GetChannels: GetChannelsResponse['result'];
+  ReloadPage: any;
 };
 
 type Method =
@@ -100,7 +101,8 @@ type Method =
   | 'ApproveBudgetAndFund'
   | 'GetBudget'
   | 'CloseAndWithdraw'
-  | 'GetChannels';
+  | 'GetChannels'
+  | 'ReloadPage';
 
 type Request = {params: RequestParams['params']}; // Replace with union type
 type Call<K extends Method, T extends Request> = {
@@ -121,7 +123,8 @@ export type MethodRequestType =
   | Call<'ApproveBudgetAndFund', ApproveBudgetAndFundRequest>
   | Call<'GetBudget', GetBudgetRequest>
   | Call<'CloseAndWithdraw', any>
-  | Call<'GetChannels', GetChannelsRequest>;
+  | Call<'GetChannels', GetChannelsRequest>
+  | Call<'ReloadPage', any>;
 
 export interface EventType extends NotificationType {
   [id: string]: [unknown]; // guid

--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -979,7 +979,7 @@
       ],
       "type": "object"
     },
-    "JsonRpcNotification<\"UIUpdate\",structure-683137520-780-802-683137520-748-803-683137520-719-804-683137520-0-1196>": {
+    "JsonRpcNotification<\"UIUpdate\",structure-683137520-783-829-683137520-748-831-683137520-719-832-683137520-0-1224>": {
       "additionalProperties": false,
       "properties": {
         "jsonrpc": {
@@ -997,6 +997,9 @@
         "params": {
           "additionalProperties": false,
           "properties": {
+            "reloadPage": {
+              "type": "boolean"
+            },
             "showWallet": {
               "type": "boolean"
             }
@@ -1871,7 +1874,7 @@
       "type": "object"
     },
     "UiNotification": {
-      "$ref": "#/definitions/JsonRpcNotification%3C%22UIUpdate%22%2Cstructure-683137520-780-802-683137520-748-803-683137520-719-804-683137520-0-1196%3E"
+      "$ref": "#/definitions/JsonRpcNotification%3C%22UIUpdate%22%2Cstructure-683137520-783-829-683137520-748-831-683137520-719-832-683137520-0-1224%3E"
     },
     "Uint256": {
       "description": "Uint256",

--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -979,7 +979,32 @@
       ],
       "type": "object"
     },
-    "JsonRpcNotification<\"UIUpdate\",structure-683137520-783-829-683137520-748-831-683137520-719-832-683137520-0-1224>": {
+    "JsonRpcNotification<\"ReloadPage\",any>": {
+      "additionalProperties": false,
+      "properties": {
+        "jsonrpc": {
+          "enum": [
+            "2.0"
+          ],
+          "type": "string"
+        },
+        "method": {
+          "enum": [
+            "ReloadPage"
+          ],
+          "type": "string"
+        },
+        "params": {
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "JsonRpcNotification<\"UIUpdate\",structure-683137520-783-829-683137520-748-831-683137520-719-832-683137520-0-1391>": {
       "additionalProperties": false,
       "properties": {
         "jsonrpc": {
@@ -1719,6 +1744,9 @@
         },
         {
           "$ref": "#/definitions/UiNotification"
+        },
+        {
+          "$ref": "#/definitions/ReloadPageNotification"
         }
       ]
     },
@@ -1759,6 +1787,9 @@
         "success"
       ],
       "type": "object"
+    },
+    "ReloadPageNotification": {
+      "$ref": "#/definitions/JsonRpcNotification%3C%22ReloadPage%22%2Cany%3E"
     },
     "Request": {
       "anyOf": [
@@ -1874,7 +1905,7 @@
       "type": "object"
     },
     "UiNotification": {
-      "$ref": "#/definitions/JsonRpcNotification%3C%22UIUpdate%22%2Cstructure-683137520-783-829-683137520-748-831-683137520-719-832-683137520-0-1224%3E"
+      "$ref": "#/definitions/JsonRpcNotification%3C%22UIUpdate%22%2Cstructure-683137520-783-829-683137520-748-831-683137520-719-832-683137520-0-1391%3E"
     },
     "Uint256": {
       "description": "Uint256",

--- a/packages/client-api-schema/src/notifications.ts
+++ b/packages/client-api-schema/src/notifications.ts
@@ -13,6 +13,8 @@ export type UiNotification = JsonRpcNotification<
   'UIUpdate',
   {showWallet: boolean; reloadPage?: boolean}
 >;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ReloadPageNotification = JsonRpcNotification<'ReloadPage', any>;
 
 export type Notification =
   | ChannelProposedNotification
@@ -20,7 +22,8 @@ export type Notification =
   | ChannelClosingNotification
   | BudgetUpdatedNotification
   | MessageQueuedNotification
-  | UiNotification;
+  | UiNotification
+  | ReloadPageNotification;
 
 type FilterByMethod<T, Method> = T extends {method: Method} ? T : never;
 

--- a/packages/client-api-schema/src/notifications.ts
+++ b/packages/client-api-schema/src/notifications.ts
@@ -9,7 +9,10 @@ export type ChannelUpdatedNotification = JsonRpcNotification<'ChannelUpdated', C
 export type ChannelClosingNotification = JsonRpcNotification<'ChannelClosed', ChannelResult>;
 export type MessageQueuedNotification = JsonRpcNotification<'MessageQueued', Message>;
 export type BudgetUpdatedNotification = JsonRpcNotification<'BudgetUpdated', DomainBudget>;
-export type UiNotification = JsonRpcNotification<'UIUpdate', {showWallet: boolean}>;
+export type UiNotification = JsonRpcNotification<
+  'UIUpdate',
+  {showWallet: boolean; reloadPage?: boolean}
+>;
 
 export type Notification =
   | ChannelProposedNotification

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -141,7 +141,7 @@ export async function setupFakeWeb3(page: Page, ganacheAccountIndex: number): Pr
 
     window.ethereum = window.web3.currentProvider;
     ${TARGET_NETWORK === 'ropsten' ? 'window.ethereum.mockingInfuraProvider = true;' : ''}
-
+    window.ethereum.fake = true;
     window.ethereum.enable = () => new Promise(r => {
       console.log("[puppeteer] window.ethereum.enable() was called");
       web3.eth.getAccounts().then(lst => {
@@ -157,6 +157,7 @@ export async function setupFakeWeb3(page: Page, ganacheAccountIndex: number): Pr
     });
     window.ethereum.networkVersion = ${CHAIN_NETWORK_ID};
     window.ethereum.on = () => {};
+
   `);
 }
 

--- a/packages/web3torrent/src/App.tsx
+++ b/packages/web3torrent/src/App.tsx
@@ -5,16 +5,13 @@ import {Route, Switch, BrowserRouter} from 'react-router-dom';
 import './App.scss';
 import {LayoutFooter, LayoutHeader} from './components/layout';
 import Welcome from './pages/welcome/Welcome';
-import {Flash, Link} from 'rimble-ui';
 import File from './pages/file/File';
 import Upload from './pages/upload/Upload';
 import {RoutePath} from './routes';
-import {requiredNetwork, INITIAL_BUDGET_AMOUNT} from './constants';
+import {requiredNetwork} from './constants';
 import {Budgets} from './pages/budgets/Budgets';
 import {web3TorrentClient} from './clients/web3torrent-client';
 import {identify} from './analytics';
-import {providers} from 'ethers';
-import {utils} from 'ethers';
 
 const App: React.FC = () => {
   const [currentNetwork, setCurrentNetwork] = useState(
@@ -36,38 +33,19 @@ const App: React.FC = () => {
       }
     });
   }, [initialized]);
-  const [selectedAddressState, setSelectedAddressState] = useState(undefined);
 
   useEffect(() => {
     if (window.ethereum && typeof window.ethereum.on === 'function') {
       const networkChangeListener = chainId => setCurrentNetwork(Number(chainId));
-      const addressChangeListener = accounts => setSelectedAddressState(accounts[0]);
-
       window.ethereum.on('networkChanged', networkChangeListener);
-      window.ethereum.on('accountsChanged', addressChangeListener);
       return () => {
         window.ethereum.removeListener('networkChanged', networkChangeListener);
-        window.ethereum.removeListener('accountsChanged', addressChangeListener);
       };
     }
     return () => ({});
   }, []);
 
   const ready = currentNetwork === requiredNetwork && initialized;
-
-  const [balance, setBalance] = useState(undefined);
-  useEffect(() => {
-    const getBalance = async () => {
-      const selectedAddress = selectedAddressState ?? window.ethereum?.selectedAddress;
-      if (ready && selectedAddress) {
-        const provider = new providers.Web3Provider(window.ethereum);
-        const balance = await provider.getBalance(selectedAddress);
-        setBalance(balance);
-      }
-    };
-
-    getBalance();
-  }, [ready, selectedAddressState]);
 
   return (
     <BrowserRouter>
@@ -77,16 +55,7 @@ const App: React.FC = () => {
           requiredNetwork={requiredNetwork}
           onWeb3Fallback={!('ethereum' in window)}
         />
-        {ready && balance && balance.lt(INITIAL_BUDGET_AMOUNT) && (
-          <Flash my={3} variant="warning">
-            You currently have {utils.formatEther(balance)} ETH in your wallet. You'll need at least{' '}
-            {utils.formatEther(INITIAL_BUDGET_AMOUNT)} ETH in your wallet to fund Web3Torrent. You
-            can get more ETH{' '}
-            <Link target="_blank" href={`https://faucet.ropsten.be/`}>
-              here.
-            </Link>
-          </Flash>
-        )}
+
         <Route path={RoutePath.Root}>
           <LayoutHeader />
         </Route>

--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -9,7 +9,7 @@ import {
 import {Contract, Wallet, BigNumber, BigNumberish} from 'ethers';
 
 import {Observable, fromEvent, from, merge} from 'rxjs';
-import {filter, map, flatMap} from 'rxjs/operators';
+import {filter, map, flatMap, distinctUntilChanged} from 'rxjs/operators';
 import {One, Zero} from '@ethersproject/constants';
 import {hexZeroPad} from '@ethersproject/bytes';
 import {TransactionRequest} from '@ethersproject/providers';
@@ -52,6 +52,7 @@ export interface Chain {
   challenge: (support: SignedState[], privateKey: string) => Promise<string | undefined>;
   finalizeAndWithdraw: (finalizationProof: SignedState[]) => Promise<string | undefined>;
   getChainInfo: (channelId: string) => Promise<ChannelChainInfo>;
+  balanceUpdatedFeed(address: string): Observable<BigNumber>;
 }
 
 type Updated = ChannelChainInfo & {channelId: string};
@@ -199,11 +200,18 @@ export class FakeChain implements Chain {
 
     return merge(first, updates);
   }
-
+  public balanceUpdatedFeed(): Observable<BigNumber> {
+    // You're rich!
+    return from([BigNumber.from('0x999999999999')]);
+  }
   public challengeRegisteredFeed(channelId: string): Observable<ChallengeRegistered> {
     const updates = fromEvent(this.eventEmitter, 'challengeRegistered').pipe(
       filter((event: ChallengeRegistered) => event.channelId === channelId),
-      map(({challengeState, challengeExpiry}) => ({channelId, challengeState, challengeExpiry}))
+      map(({challengeState, challengeExpiry}) => ({
+        channelId,
+        challengeState,
+        challengeExpiry
+      }))
     );
 
     return merge(
@@ -406,6 +414,15 @@ export class ChainWatcher implements Chain {
       finalized: finalizesAt.gt(0) && finalizesAt.lte(blockNum),
       blockNum
     };
+  }
+
+  public balanceUpdatedFeed(address: string): Observable<BigNumber> {
+    const first = from(this.provider.getBalance(address));
+    const updates = fromEvent<BigNumber>(this.provider, 'block').pipe(
+      flatMap(() => this.provider.getBalance(address))
+    );
+
+    return merge(first, updates).pipe(distinctUntilChanged((a, b) => a.eq(b)));
   }
 
   public chainUpdatedFeed(channelId: string): Observable<ChannelChainInfo> {

--- a/packages/xstate-wallet/src/index.ts
+++ b/packages/xstate-wallet/src/index.ts
@@ -31,7 +31,14 @@ const log = logger.trace.bind(logger);
   const store = new Store(chain, backend);
 
   await store.initialize([], CLEAR_STORAGE_ON_START);
+
   const messagingService = new MessagingService(store);
+
+  chain.accountChangedFeed.subscribe(() => {
+    logger.warn('Detected address change, sending message to parent to reload page');
+    messagingService.sendReloadMessage();
+  });
+
   const channelWallet = new ChannelWallet(store, messagingService);
 
   if (NODE_ENV === 'production') {

--- a/packages/xstate-wallet/src/index.ts
+++ b/packages/xstate-wallet/src/index.ts
@@ -34,7 +34,7 @@ const log = logger.trace.bind(logger);
 
   const messagingService = new MessagingService(store);
 
-  chain.accountChangedFeed.subscribe(() => {
+  chain.accountChangedFeed().subscribe(() => {
     logger.warn('Detected address change, sending message to parent to reload page');
     messagingService.sendReloadMessage();
   });

--- a/packages/xstate-wallet/src/messaging.ts
+++ b/packages/xstate-wallet/src/messaging.ts
@@ -157,6 +157,15 @@ export class MessagingService implements MessagingServiceInterface {
     this.eventEmitter.emit('SendMessage', notification);
   }
 
+  public sendReloadMessage() {
+    const notification: Notification = {
+      jsonrpc: '2.0',
+      method: 'UIUpdate',
+      params: {showWallet: false, reloadPage: true}
+    };
+    this.eventEmitter.emit('SendMessage', notification);
+  }
+
   public async receiveRequest(jsonRpcRequest: Request, fromDomain: string) {
     const request = parseRequest(jsonRpcRequest);
     const {id: requestId} = request;

--- a/packages/xstate-wallet/src/messaging.ts
+++ b/packages/xstate-wallet/src/messaging.ts
@@ -160,8 +160,8 @@ export class MessagingService implements MessagingServiceInterface {
   public sendReloadMessage() {
     const notification: Notification = {
       jsonrpc: '2.0',
-      method: 'UIUpdate',
-      params: {showWallet: false, reloadPage: true}
+      method: 'ReloadPage',
+      params: {}
     };
     this.eventEmitter.emit('SendMessage', notification);
   }

--- a/packages/xstate-wallet/src/ui/approve-budget-and-fund-workflow.tsx
+++ b/packages/xstate-wallet/src/ui/approve-budget-and-fund-workflow.tsx
@@ -7,7 +7,7 @@ import {formatEther} from '@ethersproject/units';
 import {Button, Heading, Flex, Text, Box, Link} from 'rimble-ui';
 import {getAmountsFromBudget} from './selectors';
 import {ETH_ASSET_HOLDER_ADDRESS} from '../config';
-
+import {utils} from 'ethers';
 interface Props {
   service: ApproveBudgetAndFundService;
 }
@@ -17,7 +17,7 @@ export const ApproveBudgetAndFund = (props: Props) => {
   const {budget} = current.context;
   const {playerAmount, hubAmount} = getAmountsFromBudget(budget);
 
-  // Sets a timer that expires after 5 minutes
+  // Sets a timer that expires after 1.5 minutes
   // Used to determine if we've timed out waiting for the hub
   let stateTimer;
   const [stateTimerExpired, setStateTimerExpired] = useState(false);
@@ -29,6 +29,31 @@ export const ApproveBudgetAndFund = (props: Props) => {
     };
   }, [current]);
 
+  const waitForSufficientFundsInit = (
+    <Flex alignItems="center" flexDirection="column">
+      <Heading>App Budget</Heading>
+
+      <Text textAlign="center">Querying blockchain</Text>
+    </Flex>
+  );
+
+  const waitForSufficientFunds = (
+    <Flex alignItems="left" flexDirection="column">
+      <Heading textAlign="center" mb={2}>
+        App Budget
+      </Heading>
+      <Text pb={3} fontSize={1}>
+        You don&#39;t have enough ETH in your wallet!
+      </Text>
+      <Text pb={3} fontSize={1}>
+        You&#39;ll need at least {utils.formatEther(playerAmount)} ETH in your wallet to fund the
+        channel. You can get more ETH{' '}
+        <Link target="_blank" href={`https://faucet.ropsten.be/`}>
+          here.
+        </Link>
+      </Text>
+    </Flex>
+  );
   const waitForUserApproval = ({waiting}: {waiting: boolean} = {waiting: false}) => (
     <Flex alignItems="left" flexDirection="column">
       <Heading textAlign="center" mb={2}>
@@ -176,8 +201,12 @@ export const ApproveBudgetAndFund = (props: Props) => {
 
   if (current.matches('waitForUserApproval')) {
     return waitForUserApproval();
+  } else if (current.matches({waitForSufficientFunds: 'init'})) {
+    return waitForSufficientFundsInit;
+  } else if (current.matches({waitForSufficientFunds: 'waitForFunds'})) {
+    return waitForSufficientFunds;
   } else if (current.matches('createLedger')) {
-    return waitForUserApproval({waiting: true});
+    return waitForSufficientFunds;
   } else if (current.matches('waitForPreFS')) {
     return waitForPreFS;
   } else if (current.matches({deposit: 'init'})) {

--- a/packages/xstate-wallet/src/workflows/tests/approve-budget-and-fund.test.ts
+++ b/packages/xstate-wallet/src/workflows/tests/approve-budget-and-fund.test.ts
@@ -41,6 +41,7 @@ let messagingService: MessagingServiceInterface;
 
 beforeEach(async () => {
   chain = new FakeChain();
+  await chain.ethereumEnable();
   playerStore = new TestStore(chain);
   messagingService = new MessagingService(playerStore);
 


### PR DESCRIPTION
Reloads web3torrent when the address changes.

Since the  `accountsChanged` event will only get fired from the wallet iFrame (due to `window.ethereum.enable` only being called from the wallet iframe) the wallet has to be the one responsible for detecting the account change event.

Due to the fact that our iframe has a different domain than the main window, web3torrent needs to be responsible for reloading the whole page.

To accomplish this the wallet now sends a reload message to the main frame where the channel provider handles it and reloads the page.