### PR TITLE
Change destination address to be signingAddress

### DIFF
--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -114,16 +114,16 @@ const arrangePeers = ({beneficiary, payer}: Peers): [Peer, Peer] => {
   return peers;
 };
 
-const formatParticipant = ({signingAddress, outcomeAddress}: Peer): Participant => ({
+const formatParticipant = ({signingAddress /*, outcomeAddress */}: Peer): Participant => ({
   participantId: signingAddress,
   signingAddress,
-  destination: outcomeAddress
+  destination: signingAddress // Using signingAddress for destination allows user to switch MetaMask accounts
 });
 const formatParticipants = (peers: Peers) => arrangePeers(peers).map(formatParticipant);
 
 const formatItem = (p: Peer): AllocationItem => ({
   amount: hexZeroPad(bigNumberify(p.balance).toHexString(), 32),
-  destination: p.outcomeAddress
+  destination: p.signingAddress // Using signingAddress for destination allows user to switch MetaMask accounts
 });
 const formatAllocations = (peers: Peers): Allocations => [
   {token: AddressZero, allocationItems: arrangePeers(peers).map(formatItem)}

--- a/packages/xstate-wallet/src/messaging.ts
+++ b/packages/xstate-wallet/src/messaging.ts
@@ -263,7 +263,7 @@ async function convertToInternalEvent(
     case 'ApproveBudgetAndFund':
       const {hub, playerParticipantId} = request.params;
       const signingAddress = await store.getAddress();
-      const destination = store.chain.selectedAddress;
+      const destination = signingAddress; // Using signingAddress for destination allows user to switch MetaMask accounts
       if (!destination) {
         throw new Error('No selected destination');
       }


### PR DESCRIPTION
Fixes #2128.

This makes it so that Web3Torrent provides the _signingAddress_ of its peer and wallet as the destination when creating a channel. Similarly, the wallet uses the signing address in the `ApproveBudgetAndFund` call which then sets up the ledger channel as appropriate. This small changes allows the user of Web3Torrent to use the app, close tabs and switch accounts, and return to the app and use it again.

When withdrawing, the selected address is actually used, so withdrawing works as expected. This change only really becomes slightly confusing if you _challenge_ a channel, but even then it is not that confusing.

It's worth considering whether or not it makes sense for the app to even be providing a destination value to the wallet.
