### PR TITLE
Fix create budget from budget screen

### DIFF
--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -162,7 +162,10 @@ if (process.env.FAKE_CHANNEL_PROVIDER === 'true') {
 export class PaymentChannelClient {
   channelCache: Record<string, ChannelState | undefined> = {};
   budgetCache?: DomainBudget;
-
+  _enabled = false;
+  get enabled(): boolean {
+    return this._enabled;
+  }
   get mySigningAddress(): string | undefined {
     return this.channelClient.signingAddress;
   }
@@ -201,6 +204,7 @@ export class PaymentChannelClient {
       log.debug('Virtual Funding - Creating Budget');
       await this.createBudget(INITIAL_BUDGET_AMOUNT);
     }
+    this._enabled = true;
   }
 
   private initializeHubComms() {

--- a/packages/web3torrent/src/hooks/use-budget.ts
+++ b/packages/web3torrent/src/hooks/use-budget.ts
@@ -21,7 +21,13 @@ export function useBudget({ready}: {ready: boolean}) {
 
   const createBudget = async () => {
     setLoading(true);
-    await paymentChannelClient.createBudget(INITIAL_BUDGET_AMOUNT);
+    if (paymentChannelClient.enabled) {
+      await paymentChannelClient.createBudget(INITIAL_BUDGET_AMOUNT);
+    } else {
+      // enable will call create budget so we don't need to explicitly call it
+      await paymentChannelClient.enable();
+    }
+
     setBudget(paymentChannelClient.budgetCache);
     setLoading(false);
   };


### PR DESCRIPTION
Fixes #2130 

The budget screen would call `createBudget` which would fail if the `etheuremEnable` workflow hadn't been run.

This PR changes `createBudget` to call `enable` if the `paymentChannelClient` hasn't been enabled.