### PR TITLE
Point persistent-seeder at goerli and tweak .env.production-goerli

### DIFF
--- a/.env.persistent-seeder
+++ b/.env.persistent-seeder
@@ -3,17 +3,17 @@ NODE_ENV = 'production'
 LOG_DESTINATION =
 LOG_LEVEL= 'debug'
 ## web3torrent, xstate-wallet, rps, simple-hub
-CHAIN_NETWORK_ID = '3'
+CHAIN_NETWORK_ID = '5'
 
 ## xstate-wallet, e2e-tests
-TARGET_NETWORK = 'ropsten'
+TARGET_NETWORK = 'goerli'
 WEB3TORRENT_URL = 'https://web3torrent.statechannels.org'
 # In Mwei:
 INITIAL_BUDGET_AMOUNT = '10000'
 
 ## e2e-tests
 INFURA_API_KEY = '5cc24072eb7141ada6dd9d3cabf4224d'
-RPC_ENDPOINT = https://ropsten.infura.io/v3/${INFURA_API_KEY}
+RPC_ENDPOINT = https://goerli.infura.io/v3/${INFURA_API_KEY}
 HEADLESS=true
 USE_DAPPETEER=false
 
@@ -22,7 +22,7 @@ WALLET_URL = 'https://xstate-wallet.statechannels.org'
 
 ## web3torrent
 FIREBASE_API_KEY = 'AIzaSyAOvhDzJir_El3O6SJ2xQlrpOisnObq6zw'
-FIREBASE_PREFIX = 'netlify-ropsten'
+FIREBASE_PREFIX = 'netlify-goerli'
 FIREBASE_PROJECT = 'rock-paper-scissors-production'
 
 FUNDING_STRATEGY = 'Virtual'

--- a/.env.production-goerli
+++ b/.env.production-goerli
@@ -39,7 +39,7 @@ HUB_CHAIN_PK = '<override this on private heroku dashboard>'
 HUB_PARTICIPANT_ID = 'firebase:simple-hub'
 
 ## xstate-wallet
-# hub address is from Heroku which specifies a funded account on Ropsten (kept secret here)
+# hub address is from Heroku which specifies a funded account on Goerli (kept secret here)
 HUB_DESTINATION = '0x0000000000000000000000004F72D4213411Faa1b1b7bf43f9F36667A98B973A'
 USE_INDEXED_DB = 'true'
 


### PR DESCRIPTION
PSA: Have switched the hub SC_ENV to the goerli one via heroku dashboard 🤞 .

I wonder if we should bring the persistent-seeder environment config in line with the simple-hub? i.e. remove `.env.persistent-seeder` and the baked-in references to it, and simply pass `.env.production-goerli` in the heroku dashboard?