### PR TITLE
Introduce destinationAddress concept

### DIFF
--- a/packages/channel-client/src/channel-client.ts
+++ b/packages/channel-client/src/channel-client.ts
@@ -26,8 +26,8 @@ export class ChannelClient implements ChannelClientInterface {
     return this.provider.signingAddress;
   }
 
-  get selectedAddress(): string | undefined {
-    return this.provider.selectedAddress;
+  get destinationAddress(): string | undefined {
+    return this.provider.destinationAddress;
   }
 
   get walletVersion(): string | undefined {

--- a/packages/channel-client/src/types.ts
+++ b/packages/channel-client/src/types.ts
@@ -27,7 +27,7 @@ export interface ChannelClientInterface {
   channelState: ReplaySubject<ChannelResult>;
   walletVersion?: string;
   signingAddress?: string;
-  selectedAddress?: string;
+  destinationAddress?: string;
 
   /*
     Pushing a message is meant for when the app receives a message from

--- a/packages/channel-client/tests/fakes/fake-channel-provider.ts
+++ b/packages/channel-client/tests/fakes/fake-channel-provider.ts
@@ -49,7 +49,7 @@ const mockDomainBudget = {
  */
 export class FakeChannelProvider implements ChannelProviderInterface {
   public signingAddress?: string;
-  public selectedAddress?: string;
+  public destinationAddress?: string;
   public walletVersion?: string;
 
   private events = new EventEmitter<EventType>();
@@ -68,16 +68,16 @@ export class FakeChannelProvider implements ChannelProviderInterface {
     this.url = url || '';
     this.signingAddress = this.getAddress();
     this.walletVersion = 'FakeChannelProvider@VersionTBD';
-    this.selectedAddress = '0xEthereumSelectedAddress';
+    this.destinationAddress = '0xEthereumAddress';
   }
 
   async enable(): Promise<void> {
-    const {signingAddress, selectedAddress, walletVersion} = await this.send({
+    const {signingAddress, destinationAddress, walletVersion} = await this.send({
       method: 'EnableEthereum',
       params: {}
     });
     this.signingAddress = signingAddress;
-    this.selectedAddress = selectedAddress;
+    this.destinationAddress = destinationAddress;
     this.walletVersion = walletVersion;
   }
 
@@ -93,7 +93,7 @@ export class FakeChannelProvider implements ChannelProviderInterface {
       case 'EnableEthereum':
         return {
           signingAddress: this.getAddress(),
-          selectedAddress: '0xEthereumSelectedAddress',
+          destinationAddress: '0xEthereumAddress',
           walletVersion: 'FakeChannelProvider@VersionTBD'
         };
 

--- a/packages/channel-provider/src/channel-provider.ts
+++ b/packages/channel-provider/src/channel-provider.ts
@@ -32,7 +32,7 @@ class ChannelProvider implements ChannelProviderInterface {
   protected url = '';
 
   public signingAddress?: string;
-  public selectedAddress?: string;
+  public destinationAddress?: string;
   public walletVersion?: string;
 
   constructor() {
@@ -66,22 +66,22 @@ class ChannelProvider implements ChannelProviderInterface {
     logger.info('Waiting for wallet ping...');
     await this.walletReady;
     logger.info('Wallet ready to receive requests');
-    const {signingAddress, selectedAddress, walletVersion} = await this.send({
+    const {signingAddress, destinationAddress, walletVersion} = await this.send({
       method: 'GetWalletInformation',
       params: {}
     });
     this.signingAddress = signingAddress;
-    this.selectedAddress = selectedAddress;
+    this.destinationAddress = destinationAddress;
     this.walletVersion = walletVersion;
   }
 
   async enable() {
-    const {signingAddress, selectedAddress, walletVersion} = await this.send({
+    const {signingAddress, destinationAddress, walletVersion} = await this.send({
       method: 'EnableEthereum',
       params: {}
     });
     this.signingAddress = signingAddress;
-    this.selectedAddress = selectedAddress;
+    this.destinationAddress = destinationAddress;
     this.walletVersion = walletVersion;
   }
 

--- a/packages/channel-provider/src/types.ts
+++ b/packages/channel-provider/src/types.ts
@@ -132,7 +132,7 @@ export type OffType = typeof eventEmitter.off;
 
 export interface ChannelProviderInterface {
   signingAddress?: string;
-  selectedAddress?: string;
+  destinationAddress?: string;
   walletVersion?: string;
   on: OnType;
   off: OffType;

--- a/packages/client-api-docs/source/index.html.md
+++ b/packages/client-api-docs/source/index.html.md
@@ -30,7 +30,7 @@ API between the state channel wallet and application.
 ```
 
 | Parameter      | Type   | Description                                                     |
-| -------------- | ------ | --------------------------------------------------------------- |
+|----------------|--------|-----------------------------------------------------------------|
 | participantId  | String | App allocated id, used for relaying messages to the participant |
 | signingAddress | String | Address used to sign channel updates                            |
 | destination    | String | Address of EOA to receive channel proceeds                      |
@@ -65,7 +65,7 @@ to another participant.
 ```
 
 | Parameter | Type   | Description                                                  |
-| --------- | ------ | ------------------------------------------------------------ |
+|-----------|--------|--------------------------------------------------------------|
 | recipient | String | Identifier of user that the message should be relayed to     |
 | sender    | String | Identifier of user that the message is from                  |
 | data      | String | Message payload. Format defined by wallet and opaque to app. |
@@ -106,7 +106,7 @@ Note: we don't return the state of the channel, as messages are not necessarily 
 ### Errors
 
 | Code | Message           | Meaning                                      |
-| ---- | ----------------- | -------------------------------------------- |
+|------|-------------------|----------------------------------------------|
 | 900  | Wrong Participant | The message is not addressed to this wallet. |
 
 ## EnableEthereum
@@ -130,7 +130,7 @@ Enables the wallet domain against an ethereum provider (e.g., MetaMask). This tr
   "id": 1,
   "result": {
     "signingAddress": "0xabc...",
-    "selectedAddress": "0xabc...",
+    "destinationAddress": "0xabc...",
     "walletVersion": "wallet@0.0.1"
   }
 }
@@ -139,12 +139,12 @@ Enables the wallet domain against an ethereum provider (e.g., MetaMask). This tr
 ### Errors
 
 | Code | Message              | Meaning                                                |
-| ---- | -------------------- | ------------------------------------------------------ |
+|------|----------------------|--------------------------------------------------------|
 | 100  | Ethereum Not Enabled | The wallet approval was rejected by the Web3 provider. |
 
 ## GetWalletInformation
 
-Gets the current data from the wallet on its `signingAddress`, `selectedAddress`, and `walletVersion`. If the wallet has not been enabled relative to a Web3 Provider, `selectedAddress` will be `undefined`.
+Gets the current data from the wallet on its `signingAddress`, `destinationAddress`, and `walletVersion`. If the wallet has not been enabled relative to a Web3 Provider, `destinationAddress` will be `undefined`.
 
 ```json
 {
@@ -163,7 +163,7 @@ Gets the current data from the wallet on its `signingAddress`, `selectedAddress`
   "id": 1,
   "result": {
     "signingAddress": "0xabc...",
-    "selectedAddress": "0xabc...",
+    "destinationAddress": "0xabc...",
     "walletVersion": "wallet@0.0.1"
   }
 }
@@ -245,7 +245,7 @@ Gets the current data from the wallet on its `signingAddress`, `selectedAddress`
 ### Parameters
 
 | Parameter     | Type          | Description                                                       |
-| ------------- | ------------- | ----------------------------------------------------------------- |
+|---------------|---------------|-------------------------------------------------------------------|
 | participants  | Participant[] |                                                                   |
 | allocation    | Allocation    | Starting balances                                                 |
 | appDefinition | Address       | Address of deployed contract that defines the app                 |
@@ -257,7 +257,7 @@ Errors conform to the [JSON-RPC 2.0 error spec](https://www.jsonrpc.org/specific
 Beyond the standard errors from that spec, the following domain-specific errors are possible:
 
 | Code | Message                   | Meaning                                                                                                     |
-| ---- | ------------------------- | ----------------------------------------------------------------------------------------------------------- |
+|------|---------------------------|-------------------------------------------------------------------------------------------------------------|
 | 1000 | Signing address not found | The wallet can't find the signing key corresponding to the first signing address in the participants array. |
 | 1001 | Invalid app definition    | There isn't a contract deployed at the app definition address.                                              |
 | 1002 | Unsupported token         | The wallet doesn't support one or more of the tokens appearing in the allocation.                           |
@@ -318,7 +318,7 @@ Possible response to a `Channel Proposed` event.
 ### Errors
 
 | Code | Message                  | Meaning                                                          |
-| ---- | ------------------------ | ---------------------------------------------------------------- |
+|------|--------------------------|------------------------------------------------------------------|
 | 1100 | Channel not found        | The wallet can't find the channel corresponding to the channelId |
 | 1101 | Invalid State Transition | The wallet contains invalid state data                           |
 
@@ -385,7 +385,7 @@ Possible response to a `Channel Proposed` event.
 ### Errors
 
 | Code | Message            | Meaning                                                                               |
-| ---- | ------------------ | ------------------------------------------------------------------------------------- |
+|------|--------------------|---------------------------------------------------------------------------------------|
 |      | Channel not found  | The wallet can't find the channel corresponding to the channelId                      |
 |      | Invalid app data   | The app data isn't a valid state for the force-move app defined by the app definition |
 |      | Invalid transition | The state transition implied by this state is invalid                                 |
@@ -504,7 +504,7 @@ The channel may later update to `closed` status only when other channel particip
 ### Errors
 
 | Code | Message       | Meaning                                             |
-| ---- | ------------- | --------------------------------------------------- |
+|------|---------------|-----------------------------------------------------|
 | 300  | Not your turn | You cannot close the channel until it is your turn. |
 
 ## Challenge Channel
@@ -560,7 +560,7 @@ The channel may later update to `closed` status only when other channel particip
 ### Errors
 
 | Code | Message           | Meaning                                                          |
-| ---- | ----------------- | ---------------------------------------------------------------- |
+|------|-------------------|------------------------------------------------------------------|
 |      | Channel not found | The wallet can't find the channel corresponding to the channelId |
 
 # Events

--- a/packages/client-api-schema/src/generated-schema.json
+++ b/packages/client-api-schema/src/generated-schema.json
@@ -297,10 +297,10 @@
       "$ref": "#/definitions/JsonRpcError%3C100%2C%22Ethereum%20Not%20Enabled%22%3E"
     },
     "EnableEthereumRequest": {
-      "$ref": "#/definitions/JsonRpcRequest%3C%22EnableEthereum%22%2Cstructure-721393493-223-226-721393493-190-227-721393493-153-228-721393493-0-499%3E"
+      "$ref": "#/definitions/JsonRpcRequest%3C%22EnableEthereum%22%2Cstructure-721393493-223-226-721393493-190-227-721393493-153-228-721393493-0-502%3E"
     },
     "EnableEthereumResponse": {
-      "$ref": "#/definitions/JsonRpcResponse%3Cstructure-721393493-282-365-721393493-265-366-721393493-228-367-721393493-0-499%3E"
+      "$ref": "#/definitions/JsonRpcResponse%3Cstructure-721393493-282-368-721393493-265-369-721393493-228-370-721393493-0-502%3E"
     },
     "ErrorResponse": {
       "anyOf": [
@@ -360,10 +360,10 @@
       "$ref": "#/definitions/JsonRpcResponse%3CChannelResult%3E"
     },
     "GetWalletInformationRequest": {
-      "$ref": "#/definitions/JsonRpcRequest%3C%22GetWalletInformation%22%2Cstructure-825486248-178-181-825486248-139-182-825486248-96-183-825486248-0-336%3E"
+      "$ref": "#/definitions/JsonRpcRequest%3C%22GetWalletInformation%22%2Cstructure-825486248-178-181-825486248-139-182-825486248-96-183-825486248-0-339%3E"
     },
     "GetWalletInformationResponse": {
-      "$ref": "#/definitions/JsonRpcResponse%3Cstructure-825486248-243-333-825486248-226-334-825486248-183-335-825486248-0-336%3E"
+      "$ref": "#/definitions/JsonRpcResponse%3Cstructure-825486248-243-336-825486248-226-337-825486248-183-338-825486248-0-339%3E"
     },
     "JoinChannelParams": {
       "additionalProperties": false,
@@ -1173,7 +1173,7 @@
       ],
       "type": "object"
     },
-    "JsonRpcRequest<\"EnableEthereum\",structure-721393493-223-226-721393493-190-227-721393493-153-228-721393493-0-499>": {
+    "JsonRpcRequest<\"EnableEthereum\",structure-721393493-223-226-721393493-190-227-721393493-153-228-721393493-0-502>": {
       "additionalProperties": false,
       "properties": {
         "id": {
@@ -1309,7 +1309,7 @@
       ],
       "type": "object"
     },
-    "JsonRpcRequest<\"GetWalletInformation\",structure-825486248-178-181-825486248-139-182-825486248-96-183-825486248-0-336>": {
+    "JsonRpcRequest<\"GetWalletInformation\",structure-825486248-178-181-825486248-139-182-825486248-96-183-825486248-0-339>": {
       "additionalProperties": false,
       "properties": {
         "id": {
@@ -1556,7 +1556,7 @@
       ],
       "type": "object"
     },
-    "JsonRpcResponse<structure-721393493-282-365-721393493-265-366-721393493-228-367-721393493-0-499>": {
+    "JsonRpcResponse<structure-721393493-282-368-721393493-265-369-721393493-228-370-721393493-0-502>": {
       "additionalProperties": false,
       "properties": {
         "id": {
@@ -1571,7 +1571,7 @@
         "result": {
           "additionalProperties": false,
           "properties": {
-            "selectedAddress": {
+            "destinationAddress": {
               "$ref": "#/definitions/Address"
             },
             "signingAddress": {
@@ -1583,7 +1583,7 @@
           },
           "required": [
             "signingAddress",
-            "selectedAddress",
+            "destinationAddress",
             "walletVersion"
           ],
           "type": "object"
@@ -1628,7 +1628,7 @@
       ],
       "type": "object"
     },
-    "JsonRpcResponse<structure-825486248-243-333-825486248-226-334-825486248-183-335-825486248-0-336>": {
+    "JsonRpcResponse<structure-825486248-243-336-825486248-226-337-825486248-183-338-825486248-0-339>": {
       "additionalProperties": false,
       "properties": {
         "id": {
@@ -1643,7 +1643,7 @@
         "result": {
           "additionalProperties": false,
           "properties": {
-            "selectedAddress": {
+            "destinationAddress": {
               "anyOf": [
                 {
                   "$ref": "#/definitions/Address"
@@ -1662,7 +1662,7 @@
           },
           "required": [
             "signingAddress",
-            "selectedAddress",
+            "destinationAddress",
             "walletVersion"
           ],
           "type": "object"

--- a/packages/client-api-schema/src/methods/EnableEthereum.ts
+++ b/packages/client-api-schema/src/methods/EnableEthereum.ts
@@ -5,7 +5,7 @@ import {ErrorCodes} from '../error-codes';
 export type EnableEthereumRequest = JsonRpcRequest<'EnableEthereum', {}>;
 export type EnableEthereumResponse = JsonRpcResponse<{
   signingAddress: Address;
-  selectedAddress: Address;
+  destinationAddress: Address;
   walletVersion: string;
 }>;
 

--- a/packages/client-api-schema/src/methods/GetWalletInformation.ts
+++ b/packages/client-api-schema/src/methods/GetWalletInformation.ts
@@ -4,6 +4,6 @@ import {Address} from '../data-types';
 export type GetWalletInformationRequest = JsonRpcRequest<'GetWalletInformation', {}>;
 export type GetWalletInformationResponse = JsonRpcResponse<{
   signingAddress: Address;
-  selectedAddress: Address | null;
+  destinationAddress: Address | null;
   walletVersion: string;
 }>;

--- a/packages/rps/src/redux/game/saga.ts
+++ b/packages/rps/src/redux/game/saga.ts
@@ -74,7 +74,7 @@ function* gameSagaRun(client: RPSChannelClient) {
       yield put(
         a.gotAddressFromWallet(
           window.channelProvider.signingAddress,
-          window.channelProvider.selectedAddress
+          window.channelProvider.destinationAddress
         )
       );
       break;

--- a/packages/rps/src/redux/store.ts
+++ b/packages/rps/src/redux/store.ts
@@ -56,7 +56,7 @@ function* rootSaga() {
     //   [client, 'approveBudgetAndFund'],
     //   tenEth,
     //   tenEth,
-    //   window.channelProvider.selectedAddress,
+    //   window.channelProvider.destinationAddress,
     //   HUB.signingAddress,
     //   HUB.outcomeAddress
     // );

--- a/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
+++ b/packages/rps/src/utils/__tests__/rps-channel-client.test.ts
@@ -104,7 +104,7 @@ class MockChannelClient implements ChannelClientInterface {
   provider = new FakeChannelProvider();
   walletVersion = 'JestMockVersion';
   signingAddress = MOCK_ADDRESS;
-  selectedAddress = MOCK_ADDRESS;
+  destinationAddress = MOCK_ADDRESS;
 
   approveBudgetAndFund = jest.fn(async function(
     playerAmount: string,

--- a/packages/tic-tac-toe/app/services/user.ts
+++ b/packages/tic-tac-toe/app/services/user.ts
@@ -21,7 +21,7 @@ export default class UserService extends Service {
   private async requestAddresses(): Promise<void> {
     await window.channelProvider.enable();
     this.address = window.channelProvider.signingAddress as string;
-    this.outcomeAddress = window.channelProvider.selectedAddress as string;
+    this.outcomeAddress = window.channelProvider.destinationAddress as string;
   }
 }
 

--- a/packages/web3torrent/src/App.tsx
+++ b/packages/web3torrent/src/App.tsx
@@ -28,7 +28,7 @@ const App: React.FC = () => {
           scope.setUser({id: web3TorrentClient.paymentChannelClient.mySigningAddress});
         });
         identify(web3TorrentClient.paymentChannelClient.mySigningAddress, {
-          outcomeAddress: web3TorrentClient.paymentChannelClient.myEthereumSelectedAddress
+          outcomeAddress: web3TorrentClient.paymentChannelClient.myDestinationAddress
         });
       }
     });

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -170,8 +170,8 @@ export class PaymentChannelClient {
     return this.channelClient.signingAddress;
   }
 
-  get myEthereumSelectedAddress(): string | undefined {
-    return this.channelClient.selectedAddress;
+  get myDestinationAddress(): string | undefined {
+    return this.channelClient.destinationAddress;
   }
 
   constructor(readonly channelClient: ChannelClientInterface) {

--- a/packages/web3torrent/src/components/domain-budget/DomainBudget.tsx
+++ b/packages/web3torrent/src/components/domain-budget/DomainBudget.tsx
@@ -134,7 +134,7 @@ export const DomainBudget: React.FC<DomainBudgetProps> = props => {
               />
               <div className="identity">
                 <Tooltip
-                  title={web3torrent.paymentChannelClient.myEthereumSelectedAddress || 'unknown'}
+                  title={web3torrent.paymentChannelClient.myDestinationAddress || 'unknown'}
                   interactive
                   arrow
                   placement="top"
@@ -142,7 +142,7 @@ export const DomainBudget: React.FC<DomainBudgetProps> = props => {
                   <Avatar variant="square">
                     <Blockie
                       opts={{
-                        seed: web3torrent.paymentChannelClient.myEthereumSelectedAddress,
+                        seed: web3torrent.paymentChannelClient.myDestinationAddress,
                         bgcolor: '#3531ff',
                         size: 6,
                         scale: 4,

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -53,7 +53,7 @@ function channelIdToTableRow(
     ? channel.payer.outcomeAddress
     : channel.beneficiary.outcomeAddress;
 
-  const peerSelectedAddress = '0x' + peerOutcomeAddress.slice(26).toLowerCase();
+  const peerDestinationAddress = '0x' + peerOutcomeAddress.slice(26).toLowerCase();
   // For now, this ^ is the ethereum address in my peer's metamask
 
   if (wire) {
@@ -94,11 +94,11 @@ function channelIdToTableRow(
         {/* temporal thing to show the true state instead of a parsed one */}
       </td>
       <td className="peer-id">
-        <Tooltip title={peerSelectedAddress} interactive arrow placement="right">
+        <Tooltip title={peerDestinationAddress} interactive arrow placement="right">
           <Avatar variant="square">
             <Blockie
               opts={{
-                seed: peerSelectedAddress,
+                seed: peerDestinationAddress,
                 bgcolor: '#3531ff',
                 size: 6,
                 scale: 4,

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -58,7 +58,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     if (!this.pseAccount || !this.outcomeAddress) {
       await this.paymentChannelClient.enable();
       this.pseAccount = this.paymentChannelClient.mySigningAddress;
-      this.outcomeAddress = this.paymentChannelClient.myEthereumSelectedAddress;
+      this.outcomeAddress = this.paymentChannelClient.myDestinationAddress;
       this.tracker.getAnnounceOpts = () => ({pseAccount: this.pseAccount});
 
       log.debug({pseAccount: this.pseAccount}, 'PSEAccount set to sc-wallet signing address');
@@ -351,7 +351,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
 
     const seeder = peer(
       this.pseAccount,
-      this.paymentChannelClient.myEthereumSelectedAddress,
+      this.paymentChannelClient.myDestinationAddress,
       hexZeroPad(INITIAL_SEEDER_BALANCE.toHexString(), 32)
     );
     const leecher = peer(

--- a/packages/xstate-wallet/src/integration-tests/approve-budget.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/approve-budget.test.ts
@@ -27,6 +27,7 @@ it('allows for a wallet to approve a budget and fund with the hub', async () => 
 
   hookUpMessaging(playerA, hub);
   await playerA.store.chain.ethereumEnable();
+  await playerA.store.setDestinationAddress(playerA.signingAddress);
   // We need to spawn a create and fund ledger when receiving the objective
   // This should be similar to how the actual hub handles this
   hub.store.objectiveFeed

--- a/packages/xstate-wallet/src/integration-tests/close-withdraw.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/close-withdraw.test.ts
@@ -42,6 +42,7 @@ it('allows for a wallet to close the ledger channel with the hub and withdraw', 
     }
   );
 
+  await playerA.store.setDestinationAddress(playerA.signingAddress);
   await playerA.store.createBudget(budget(BigNumber.from(6), BigNumber.from(4)));
   await hub.store.createBudget(budget(BigNumber.from(6), BigNumber.from(4)));
 

--- a/packages/xstate-wallet/src/messaging.ts
+++ b/packages/xstate-wallet/src/messaging.ts
@@ -165,7 +165,7 @@ export class MessagingService implements MessagingServiceInterface {
       case 'GetWalletInformation':
         await this.sendResponse(requestId, {
           signingAddress: await this.store.getAddress(),
-          selectedAddress: this.store.chain.selectedAddress ?? null,
+          destinationAddress: (await this.store.getDestinationAddress()) ?? null,
           walletVersion: GIT_VERSION
         });
         break;
@@ -173,7 +173,7 @@ export class MessagingService implements MessagingServiceInterface {
         if (this.store.chain.ethereumIsEnabled) {
           await this.sendResponse(requestId, {
             signingAddress: await this.store.getAddress(),
-            selectedAddress: this.store.chain.selectedAddress,
+            destinationAddress: (await this.store.getDestinationAddress()) ?? null,
             walletVersion: GIT_VERSION
           });
         } else {
@@ -246,7 +246,8 @@ async function convertToInternalEvent(
         channelId: request.params.channelId
       };
     case 'CloseAndWithdraw':
-      if (!store.chain.selectedAddress) {
+      const closeAndWithdrawDestination = await store.getDestinationAddress();
+      if (!closeAndWithdrawDestination) {
         throw new Error('No selected destination');
       }
       return {
@@ -255,7 +256,7 @@ async function convertToInternalEvent(
         player: convertToInternalParticipant({
           participantId: request.params.playerParticipantId,
           signingAddress: await store.getAddress(),
-          destination: store.chain.selectedAddress
+          destination: closeAndWithdrawDestination
         }),
         hub: convertToInternalParticipant(request.params.hub),
         domain: domain
@@ -263,7 +264,7 @@ async function convertToInternalEvent(
     case 'ApproveBudgetAndFund':
       const {hub, playerParticipantId} = request.params;
       const signingAddress = await store.getAddress();
-      const destination = store.chain.selectedAddress;
+      const destination = await store.getDestinationAddress();
       if (!destination) {
         throw new Error('No selected destination');
       }

--- a/packages/xstate-wallet/src/store/dexie-backend.ts
+++ b/packages/xstate-wallet/src/store/dexie-backend.ts
@@ -22,7 +22,8 @@ const STORES: ObjectStores[] = [
   ObjectStores.ledgers,
   ObjectStores.nonces,
   ObjectStores.objectives,
-  ObjectStores.privateKeys
+  ObjectStores.privateKeys,
+  ObjectStores.destinationAddress
 ];
 
 // A running, functioning example can be seen and played with here: https://codesandbox.io/s/elastic-kare-m1jp8
@@ -147,7 +148,15 @@ export class Backend implements DBBackend {
     return this.get(ObjectStores.ledgers, key);
   }
 
+  public async getDestinationAddress() {
+    return this.get(ObjectStores.destinationAddress, 0);
+  }
+
   // Individual Setters
+
+  public async setDestinationAddress(address: string) {
+    return this.put(ObjectStores.destinationAddress, address, 0);
+  }
 
   public async setPrivateKey(signingAddress: string, privateKey: string) {
     return this.put(ObjectStores.privateKeys, privateKey, signingAddress);

--- a/packages/xstate-wallet/src/store/memory-backend.ts
+++ b/packages/xstate-wallet/src/store/memory-backend.ts
@@ -8,6 +8,7 @@ export class MemoryBackend implements DBBackend {
   private _channels: Record<string, ChannelStoredData | undefined> = {};
   private _objectives: Objective[] = [];
   private _nonces: Record<string, string | undefined> = {};
+  private _destinationAddress: string | undefined;
   private _privateKeys: Record<string, string | undefined> = {};
   private _ledgers: Record<string, string | undefined> = {};
   private _budgets: Record<string, DomainBudget | undefined> = {};
@@ -66,6 +67,16 @@ export class MemoryBackend implements DBBackend {
   public async deleteBudget(key: string) {
     delete this._budgets[key];
   }
+
+  public async setDestinationAddress(address: string) {
+    this._destinationAddress = address;
+    return address;
+  }
+
+  public async getDestinationAddress() {
+    return this._destinationAddress;
+  }
+
   public async setPrivateKey(key: string, value: string) {
     this._privateKeys[key] = value;
     return value;

--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -113,6 +113,14 @@ export class Store {
     });
   };
 
+  public getDestinationAddress = () => this.backend.getDestinationAddress();
+  public setDestinationAddress = (destinationAddress: string) => {
+    if (!destinationAddress) {
+      logger.error('destinationAddress being set to falsy value', destinationAddress);
+    }
+    return this.backend.setDestinationAddress(destinationAddress);
+  };
+
   public async getBudget(domain: string): Promise<DomainBudget | undefined> {
     return this.backend.getBudget(domain);
   }

--- a/packages/xstate-wallet/src/store/types.ts
+++ b/packages/xstate-wallet/src/store/types.ts
@@ -158,6 +158,9 @@ export interface DBBackend {
   objectives(): Promise<Objective[]>;
   channels(): Promise<Record<string, ChannelStoreEntry | undefined>>;
 
+  setDestinationAddress(destinationAddress: string): Promise<string>;
+  getDestinationAddress(): Promise<string | undefined>;
+
   setPrivateKey(key: string, value: string): Promise<string>;
   getPrivateKey(key: string): Promise<string | undefined>;
 
@@ -217,6 +220,7 @@ export const enum ObjectStores {
   objectives = 'objectives',
   nonces = 'nonces',
   privateKeys = 'privateKeys',
+  destinationAddress = 'destinationAddress',
   ledgers = 'ledgers',
   budgets = 'budgets'
 }


### PR DESCRIPTION
Fixes #2128.

Based on https://github.com/statechannels/monorepo/pull/2143#issuecomment-642811267.

> We discussed this on standup and the plan is to:
> 
> * Rename `selectedAddress` to `idealOutcomeAddress` or something like that which conveys that this is not a selected address but rather an address that, if ETH were sent there, would be easily accessible by the user. It will be set as the selected address in MetaMask the first time any app ever calls `EnableEthereum`.
> * Store `idealOutcomeAddress` in IndexedDB and re-use that as the destination address for all channels in the future instead of checking `ethereum.selectedAddress` each time.
> * Remove `destination` from being a property that can be provided by the application in the call to `CreateChannel`

