### PR TITLE
[e2e] add SHOW_DEVTOOLS configuration

### DIFF
--- a/.env.virtual-funding
+++ b/.env.virtual-funding
@@ -14,6 +14,7 @@ LOG_LEVEL= 'debug'
 HEADLESS = 'true'
 USE_DAPPETEER = 'false'
 CLOSE_BROWSERS = 'true'
+SHOW_DEVTOOLS = 'false'
 
 ## simple-hub
 SIMPLE_HUB_DEPLOYER_ACCOUNT_INDEX = '1'

--- a/packages/e2e-tests/puppeteer/constants.ts
+++ b/packages/e2e-tests/puppeteer/constants.ts
@@ -16,6 +16,7 @@ export const TX_WAIT_TIMEOUT = USING_EXTERNAL_CHAIN ? 180_000 : 30000;
 export const CHAIN_NETWORK_ID = process.env.CHAIN_NETWORK_ID;
 export const RPC_ENDPOINT = process.env.RPC_ENDPOINT;
 export const CLOSE_BROWSERS = process.env.CLOSE_BROWSERS ? getEnvBool('CLOSE_BROWSERS') : true;
+export const SHOW_DEVTOOLS = process.env.SHOW_DEVTOOLS ? getEnvBool('SHOW_DEVTOOLS') : null;
 
 export const SCREENSHOT_DIR = process.env.SCREENSHOT_DIR;
 

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -11,7 +11,8 @@ import {
   RPC_ENDPOINT,
   CHAIN_NETWORK_ID,
   LOG_DESTINATION,
-  USING_EXTERNAL_CHAIN
+  USING_EXTERNAL_CHAIN,
+  SHOW_DEVTOOLS
 } from './constants';
 import {ETHERLIME_ACCOUNTS} from '@statechannels/devtools';
 import {promisify} from 'util';
@@ -174,7 +175,7 @@ export async function setUpBrowser(
       headless,
       slowMo,
       pipe: usePipe,
-      devtools: !headless,
+      devtools: SHOW_DEVTOOLS === null ? !headless : SHOW_DEVTOOLS,
       // Keep code here for convenience... if you want to use redux-dev-tools
       // then download and unzip the release from Github and specify the location.
       // Github URL: https://github.com/zalmoxisus/redux-devtools-extension/releases


### PR DESCRIPTION
When running the multiple-leecher test locally, I find it hard to visually inspect the clients as devtools takes up much of the screen real estate.

<img width="2550" alt="Screen Shot 2020-06-12 at 11 49 27 AM" src="https://user-images.githubusercontent.com/1062379/84536962-bedca780-aca3-11ea-9e6d-f16844aa0f40.png">

With this PR, setting `SHOW_DEVTOOLS` to `false` helps.

<img width="2546" alt="Screen Shot 2020-06-12 at 11 54 18 AM" src="https://user-images.githubusercontent.com/1062379/84537027-dae04900-aca3-11ea-8109-cce885c3aa7f.png">
