### PR TITLE
Reload window after deleting database

### DIFF
--- a/packages/xstate-wallet/src/ui/factory-reset.tsx
+++ b/packages/xstate-wallet/src/ui/factory-reset.tsx
@@ -24,5 +24,6 @@ const destroyStore = async (store: Store) => {
   if (confirm('Are you sure you want to delete your store?')) {
     logger.error({store: await (store as any).backend.dump()}, 'Wallet destroyed');
     await Dexie.delete(DB_NAME);
+    window.location.reload();
   }
 };


### PR DESCRIPTION
Otherwise, the second factory reset fails:
```
Unhandled Rejection (DatabaseClosedError): DatabaseClosedError Database has been closed
```