### PR TITLE
Remove mySelectedAddress on ChainWatcher

### DIFF
--- a/packages/xstate-wallet/src/chain.ts
+++ b/packages/xstate-wallet/src/chain.ts
@@ -321,6 +321,9 @@ export class ChainWatcher implements Chain {
   }
 
   public get selectedAddress(): string | null {
+    if (this.mySelectedAddress === null && window && window.ethereum) {
+      this.mySelectedAddress = window.ethereum.selectedAddress ?? null;
+    }
     return this.mySelectedAddress;
   }
 


### PR DESCRIPTION
Sometimes when I load the Web3Torrent app I saw that I would go through the "EnableEthereumWorkflow" again, despite `window.ethereum.selectedAddress` being defined. I manually attempted to load https://xstate-wallet.statechannels.org and, really quickly, inspect `window.ethereum.selectedAddress` which _sometimes_ was `undefined` if I called it fast enough. I suspect what is happening is that there is a race condition between the initialization of `ChainWatcher` and MetaMask injecting `window.ethereum` into the app. This change should fix it.
