### PR TITLE
Increase test timeout

### DIFF
--- a/packages/web3torrent/src/library/client-seeding.test.ts
+++ b/packages/web3torrent/src/library/client-seeding.test.ts
@@ -84,7 +84,7 @@ describe('Seeding and Leeching', () => {
         done();
       });
     });
-  }, 10000);
+  });
 
   it('should reach a ready-for-leeching, choked state', done => {
     seeder.seed(defaultFile as File, defaultSeedingOptions(), seededTorrent => {
@@ -96,7 +96,7 @@ describe('Seeding and Leeching', () => {
       });
       leecherA.add(seededTorrent.magnetURI, {store: MemoryChunkStore});
     });
-  }, 10000);
+  });
 
   it('should be able to unchoke and finish a download', async done => {
     seeder.seed(defaultFile as File, defaultSeedingOptions(), seededTorrent => {
@@ -118,7 +118,7 @@ describe('Seeding and Leeching', () => {
 
       leecherA.add(seededTorrent.magnetURI, {store: MemoryChunkStore});
     });
-  }, 10000);
+  });
 
   it('should support multiple leechers finishing their downloads', async done => {
     const knownPeers = new Set();
@@ -145,7 +145,7 @@ describe('Seeding and Leeching', () => {
 
     leecherA.once(ClientEvents.TORRENT_DONE, downloadFinished);
     leecherB.once(ClientEvents.TORRENT_DONE, downloadFinished);
-  }, 10000);
+  });
 
   afterEach(() => {
     seeder.destroy();

--- a/packages/web3torrent/src/library/client-seeding.test.ts
+++ b/packages/web3torrent/src/library/client-seeding.test.ts
@@ -11,6 +11,8 @@ import WebTorrentPaidStreamingClient, {ClientEvents, PaidStreamingTorrent} from 
 import {PaymentChannelClient} from '../clients/payment-channel-client';
 import {ChannelClient, FakeChannelProvider} from '@statechannels/channel-client';
 
+jest.setTimeout(20_000);
+
 async function defaultClient(): Promise<WebTorrentPaidStreamingClient> {
   const client = new WebTorrentPaidStreamingClient({
     dht: false,


### PR DESCRIPTION
Fixes #2178 (hopefully)

Doubles the timeout for the client seeding test as we're occasionally seeing timeouts there.