### PR TITLE
[web3torrent] enable the payment client only once

### DIFF
--- a/packages/web3torrent/src/App.tsx
+++ b/packages/web3torrent/src/App.tsx
@@ -32,7 +32,7 @@ const App: React.FC = () => {
         });
       }
     });
-  }, [initialized]);
+  }, []);
 
   useEffect(() => {
     if (window.ethereum && typeof window.ethereum.on === 'function') {


### PR DESCRIPTION
A `useEffect` hook is run every time a dependency in the dependency array changes. This hook will run twice before this PR: once when the App component is initially mounted and `initialized === false` and once when `initialized` is set to `true` by the hook.