### PR TITLE
Reset destinationAddress if selectedAddress exists but IndexedDB destroyed

### DIFF
--- a/packages/xstate-wallet/src/store/store.ts
+++ b/packages/xstate-wallet/src/store/store.ts
@@ -113,7 +113,14 @@ export class Store {
     });
   };
 
-  public getDestinationAddress = () => this.backend.getDestinationAddress();
+  public getDestinationAddress = () => {
+    const destinationAddress = this.backend.getDestinationAddress();
+    if (!destinationAddress && typeof this.chain.selectedAddress === 'string') {
+      return this.backend.setDestinationAddress(this.chain.selectedAddress);
+    }
+    return destinationAddress;
+  };
+
   public setDestinationAddress = (destinationAddress: string) => {
     if (!destinationAddress) {
       logger.error('destinationAddress being set to falsy value', destinationAddress);


### PR DESCRIPTION
This is suboptimal for a couple of reasons, but should get past a blocker on production now. Future fix will remove this field from IndexedDB and instead re-use the value of your destination address in the ledger channel that has been assigned to a particular domain's budget.
