### PR TITLE
[nitro-docs] Add section on indirect (de)funding

### DIFF
--- a/packages/nitro-protocol/docs/wallet-dev-tutorial/execute-state-transitions.md
+++ b/packages/nitro-protocol/docs/wallet-dev-tutorial/execute-state-transitions.md
@@ -133,6 +133,8 @@ function validTransition(a, b) <=>
      b.app.validTransition(a, b)
 ```
 
+### Application logic
+
 Note the use of `app.ValidTransition`. This function should be written by third party DApp developers. We provide a `TrivialApp` contract which always returns `true`, to aid in testing:
 
 ```typescript
@@ -167,6 +169,14 @@ expect(
   )
 ).toBe(true);
 ```
+
+### Setup states
+
+If `n` is the number of participants, then states with turn numbers 0 through `n-1` (inclusive) are known as "pre fund setup" states. They signal each participant's intention to join the channel with a particular outcome specified.
+
+Once a pre fund setup state with turn number `n-1` is supported, it is safe for the channel to be funded.
+
+States with turn numbers `n` through `2n-1` (inclusive) are known as "post fund setup" states. They signal each participant's agreement that the channel is fully funded. Once a post fund setup state with turn number `2n-1` is supported, the state channel can begin execution in earnest (updating the `appData` and `outcome`).
 
 ## Support a state in several different ways
 

--- a/packages/nitro-protocol/docs/wallet-dev-tutorial/execute-state-transitions.md
+++ b/packages/nitro-protocol/docs/wallet-dev-tutorial/execute-state-transitions.md
@@ -172,7 +172,7 @@ expect(
 
 ### Setup states
 
-If `n` is the number of participants, then states with turn numbers 0 through `n-1` (inclusive) are known as "pre fund setup" states. They signal each participant's intention to join the channel with a particular outcome specified.
+If `n` is the number of participants, then states with turn numbers `0` through `n-1` (inclusive) are known as "pre fund setup" states. They signal each participant's intention to join the channel with a particular outcome specified.
 
 Once a pre fund setup state with turn number `n-1` is supported, it is safe for the channel to be funded.
 

--- a/packages/nitro-protocol/docs/wallet-dev-tutorial/finalize-a-channel-happy.md
+++ b/packages/nitro-protocol/docs/wallet-dev-tutorial/finalize-a-channel-happy.md
@@ -3,11 +3,15 @@ id: finalize-a-channel-happy
 title: Finalize a channel (happy)
 ---
 
-Finalization of a state channel is a necessary step before defunding it (i.e. releasing the assets that were deposited on chain, in the case of direct funding). In the so-called 'happy' case, all participants cooperate to achieve this.
+Finalization of a state channel is a necessary step before defunding it. In the so-called 'happy' case, all participants cooperate to achieve this.
 
-A participant wishing to end the state channel will sign a state with `isFinal = true`. Then, the other participants support that state. Once a full set of `n` such signatures exists \(this set is known as a **finalization proof**\) anyone in possession may use it to finalize the `outcome` on-chain. They would do this by calling `conclude` on the adjudicator.
+A participant wishing to end the state channel will sign a state with `isFinal = true`. Then, the other participants may support that state. Once a full set of `n` such signatures exists \(this set is known as a **finalization proof**\) the channel is said to be 'closed' or 'finalized'.
+
+In most cases, the channel would be finalized and defunded off chain, and no contract calls are necessary.
 
 ## Call `conclude`
+
+In the case where assets were deposited against the channel on chain (the case of direct funding), anyone in possession of a finalization proof may use it to finalize the `outcome` on-chain. They would do this by calling `conclude` on the adjudicator. This enables [assets to be released](./release-assets).
 
 The conclude method allows anyone with sufficient off-chain state to immediately finalize an outcome for a channel without having to wait for a challenge to expire (more on that later).
 

--- a/packages/nitro-protocol/docs/wallet-dev-tutorial/finalize-a-channel-happy.md
+++ b/packages/nitro-protocol/docs/wallet-dev-tutorial/finalize-a-channel-happy.md
@@ -5,9 +5,9 @@ title: Finalize a channel (happy)
 
 Finalization of a state channel is a necessary step before defunding it. In the so-called 'happy' case, all participants cooperate to achieve this.
 
-A participant wishing to end the state channel will sign a state with `isFinal = true`. Then, the other participants may support that state. Once a full set of `n` such signatures exists \(this set is known as a **finalization proof**\) the channel is said to be 'closed' or 'finalized'.
+A participant wishing to end the state channel will sign a state with `isFinal = true`. Then, the other participants may support that state. Once a full set of `n` such signatures exists (this set is known as a **finalization proof**) the channel is said to be 'closed' or 'finalized'.
 
-In most cases, the channel would be finalized and defunded off chain, and no contract calls are necessary.
+In most cases, the channel would be finalized and defunded [off chain](./fund-and-defund-off-chain), and no contract calls are necessary.
 
 ## Call `conclude`
 

--- a/packages/nitro-protocol/docs/wallet-dev-tutorial/finalize-a-channel-happy.md
+++ b/packages/nitro-protocol/docs/wallet-dev-tutorial/finalize-a-channel-happy.md
@@ -7,7 +7,7 @@ Finalization of a state channel is a necessary step before defunding it. In the 
 
 A participant wishing to end the state channel will sign a state with `isFinal = true`. Then, the other participants may support that state. Once a full set of `n` such signatures exists (this set is known as a **finalization proof**) the channel is said to be 'closed' or 'finalized'.
 
-In most cases, the channel would be finalized and defunded [off chain](./fund-and-defund-off-chain), and no contract calls are necessary.
+In most cases, the channel would be finalized and defunded [off chain](./off-chain-funding), and no contract calls are necessary.
 
 ## Call `conclude`
 

--- a/packages/nitro-protocol/docs/wallet-dev-tutorial/finalize-a-channel-sad.md
+++ b/packages/nitro-protocol/docs/wallet-dev-tutorial/finalize-a-channel-sad.md
@@ -3,7 +3,7 @@ id: finalize-a-channel-sad
 title: Finalize a channel (sad)
 ---
 
-When cooperation breaks down, it is possible to finalize a state channel without requiring on-demand cooperation of all participants. This is the so-called 'sad' path to finalizing a channel, and it requires a supported (but `isFinal = false`) state(s) being submitted.
+When cooperation breaks down, it is possible to finalize a state channel without requiring on-demand cooperation of all participants. This is the so-called 'sad' path to finalizing a channel, and it requires a supported (but `isFinal = false`) state(s) being submitted to the chain.
 
 The `forceMove` function allows anyone holding the appropriate off-chain state to register a challenge on chain. It is designed to ensure that a state channel can progress or be finalized in the event of inactivity on behalf of a participant (e.g. the current mover).
 

--- a/packages/nitro-protocol/docs/wallet-dev-tutorial/fund-and-defund-off-chain.md
+++ b/packages/nitro-protocol/docs/wallet-dev-tutorial/fund-and-defund-off-chain.md
@@ -296,6 +296,7 @@ linkStyle 3,4 opacity:0.2;
 classDef external fill:#f96
 classDef defunded opacity:0.2;
 </div>
+The defunded channel A1 can now safely be discarded.
 
 ### Challenging with a deep funding tree
 

--- a/packages/nitro-protocol/docs/wallet-dev-tutorial/fund-and-defund-off-chain.md
+++ b/packages/nitro-protocol/docs/wallet-dev-tutorial/fund-and-defund-off-chain.md
@@ -169,7 +169,7 @@ const threeEachAndSixForTheApp: State = {
   appDefinition: AddressZero,
   appData: HashZero,
   challengeDuration: 1,
-  turnNum: 1,
+  turnNum: 4,
 };
 
 // Construct the "post fund setup" state for the application channel
@@ -271,7 +271,7 @@ const nineForMe3ForTheHub: State = {
   appDefinition: AddressZero,
   appData: HashZero,
   challengeDuration: 1,
-  turnNum: 1,
+  turnNum: 5,
 };
 ```
 

--- a/packages/nitro-protocol/docs/wallet-dev-tutorial/fund-and-defund-off-chain.md
+++ b/packages/nitro-protocol/docs/wallet-dev-tutorial/fund-and-defund-off-chain.md
@@ -34,7 +34,7 @@ const sixEachStatePreFS: State = {
   channel: ledgerChannel,
   outcome: [
     {
-      assetHolderAddress: process.env.ETH_ASSET_HOLDER_ADDRESS,
+      assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS,
       allocationItems: [
         {destination: me, amount: parseUnits('6', 'wei').toHexString()},
         {destination: hub, amount: parseUnits('6', 'wei').toHexString()},
@@ -102,7 +102,7 @@ const threeEachStatePreFS: State = {
   channel: applicationChannel1,
   outcome: [
     {
-      assetHolderAddress: process.env.ETH_ASSET_HOLDER_ADDRESS,
+      assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS,
       allocationItems: [
         {destination: me, amount: parseUnits('3', 'wei').toHexString()},
         {destination: hub, amount: parseUnits('3', 'wei').toHexString()},
@@ -155,7 +155,7 @@ const threeEachAndSixForTheApp: State = {
   channel: ledgerChannel,
   outcome: [
     {
-      assetHolderAddress: process.env.ETH_ASSET_HOLDER_ADDRESS,
+      assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS,
       allocationItems: [
         {destination: me, amount: parseUnits('3', 'wei').toHexString()},
         {destination: hub, amount: parseUnits('3', 'wei').toHexString()},
@@ -218,7 +218,7 @@ const threeEachStatePreFS: State = {
   channel: applicationChannel1,
   outcome: [
     {
-      assetHolderAddress: process.env.ETH_ASSET_HOLDER_ADDRESS,
+      assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS,
       allocationItems: [{destination: me, amount: parseUnits('6', 'wei').toHexString()}],
     },
   ],
@@ -246,9 +246,10 @@ ledger-->|3|hub;
 ledger-->|6|app
 app((A1))
 app-->|6|me;
-app-->|0|hub;
 classDef external fill:#f96
 </div>
+
+---
 
 Now
 
@@ -261,7 +262,7 @@ const nineForMe3ForTheHub: State = {
   channel: ledgerChannel,
   outcome: [
     {
-      assetHolderAddress: process.env.ETH_ASSET_HOLDER_ADDRESS,
+      assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS,
       allocationItems: [
         {destination: me, amount: parseUnits('9', 'wei').toHexString()},
         {destination: hub, amount: parseUnits('3', 'wei').toHexString()},
@@ -291,8 +292,7 @@ ledger-->|9|me;
 ledger-->|3|hub;
 app((A1)):::defunded
 app-->|6|me;
-app-->|0|hub;
-linkStyle 3,4 opacity:0.2;
+linkStyle 3 opacity:0.2;
 classDef external fill:#f96
 classDef defunded opacity:0.2;
 </div>

--- a/packages/nitro-protocol/docs/wallet-dev-tutorial/fund-and-defund-off-chain.md
+++ b/packages/nitro-protocol/docs/wallet-dev-tutorial/fund-and-defund-off-chain.md
@@ -1,0 +1,302 @@
+---
+id: fund-and-defund-off-chain
+title: Off-chain funding
+---
+
+This advanced section of the tutorial covers funding and defunding channels by redistributing assets off chain. This has the great advantage of removing the need for most on-chain transactions.
+
+## Indirect funding
+
+Let's introduce one level of indirection by setting up a ledger channel with a counterparty which we'll call "the hub". We will fund this in the same way as we have done earlier in the tutorial. A ledger channel is a special channel that runs the "null app" (meaning that all transitions are considered invalid), and whose sole purpose is to reallocate its funding to other channels and/or state channel participants.
+
+Now imagine that we want to play Rock Paper Scissors (or run some other state channel application) with that same participant. We'll open a new channel for that.
+
+Instead of funding it on chain, let's just divert some money from our existing ledger channel.
+
+```typescript
+// Construct a ledger channel with the hub
+const me = ethers.Wallet.createRandom().address;
+const hub = ethers.Wallet.createRandom().address;
+const participants = [me, hub];
+const chainId = '0x1234';
+const ledgerChannel: Channel = {
+  chainId,
+  channelNonce: bigNumberify(0).toHexString(),
+  participants,
+};
+const ledgerChannelId = getChannelId(ledgerChannel);
+
+// Construct a state for that allocates 6 wei to each of us, and has turn numer n - 1
+// This is called the "pre fund setup" state
+
+const sixEachStatePreFS: State = {
+  isFinal: false,
+  channel: ledgerChannel,
+  outcome: [
+    {
+      assetHolderAddress: process.env.ETH_ASSET_HOLDER_ADDRESS,
+      allocationItems: [
+        {destination: me, amount: parseUnits('6', 'wei').toHexString()},
+        {destination: hub, amount: parseUnits('6', 'wei').toHexString()},
+      ],
+    },
+  ],
+  appDefinition: AddressZero,
+  appData: HashZero,
+  challengeDuration: 1,
+  turnNum: 1,
+};
+
+// Support this state by providing a signature on it
+
+// Desposit plenty of funds ON CHAIN
+const amount = parseUnits('12', 'wei');
+const destination = ledgerChannelId;
+const expectedHeld = 0;
+const tx0 = ETHAssetHolder.deposit(destination, expectedHeld, amount, {
+  value: amount,
+});
+await(await tx0).wait();
+
+// Construct a state that allocates 6 wei to each of us, but with turn number 2n - 1
+// This is called the "post fund setup" state
+
+const sixEachStatePostFS: State = {...sixEachStatePreFS, turnNum: 3};
+
+// Support this state by providing a signature on it
+```
+
+So far, so standard. We have directly funded a channel, but this time we are calling it a ledger channel, L. The funding graph looks like this:
+
+<div class="mermaid" align="center">
+graph LR;
+linkStyle default interpolate basis;
+chain( )
+ledger((L))
+me(( )):::external
+hub(( )):::external
+chain-->|12|ledger;
+ledger-->|6|me;
+ledger-->|6|hub;
+classDef external fill:#f96
+</div>
+
+---
+
+Let's create the application channel:
+
+```typescript
+// Construct an application channel with the hub
+const applicationChannel1: Channel = {
+  chainId,
+  channelNonce: bigNumberify(1).toHexString(),
+  participants,
+};
+const applicationChannel1Id = getChannelId(applicationChannel1);
+
+// Construct a state that allocates 3 wei to each of us, and has turn numer n - 1
+// This is the "pre fund setup" state for the our first application channel
+
+const threeEachStatePreFS: State = {
+  isFinal: false,
+  channel: applicationChannel1,
+  outcome: [
+    {
+      assetHolderAddress: process.env.ETH_ASSET_HOLDER_ADDRESS,
+      allocationItems: [
+        {destination: me, amount: parseUnits('3', 'wei').toHexString()},
+        {destination: hub, amount: parseUnits('3', 'wei').toHexString()},
+      ],
+    },
+  ],
+  appDefinition: ROCK_PAPER_SCISSORS_ADDRESS,
+  appData: HashZero,
+  challengeDuration: 1,
+  turnNum: 1,
+};
+
+// Support this state by providing a signature on it
+```
+
+We are now in the following situation:
+
+<div class="mermaid" align="center">
+graph LR;
+linkStyle default interpolate basis;
+chain( )
+ledger((L))
+me(( )):::external
+hub(( )):::external
+me(( )):::external
+hub(( )):::external
+chain-->|12|ledger;
+ledger-->|6|me;
+ledger-->|6|hub;
+app((A1)):::defunded
+app-->|3|me;
+app-->|3|hub;
+linkStyle 3,4 opacity:0.2;
+classDef external fill:#f96
+classDef defunded opacity:0.2;
+</div>
+
+The application channel A1 exists, but it is not yet funded.
+
+---
+
+Now we proceed to divert the funds:
+
+```typescript
+// Fund our first application channel OFF CHAIN
+// simply by collecting a support proof for a state such as this:
+
+const threeEachAndSixForTheApp: State = {
+  isFinal: false,
+  channel: ledgerChannel,
+  outcome: [
+    {
+      assetHolderAddress: process.env.ETH_ASSET_HOLDER_ADDRESS,
+      allocationItems: [
+        {destination: me, amount: parseUnits('3', 'wei').toHexString()},
+        {destination: hub, amount: parseUnits('3', 'wei').toHexString()},
+        {
+          destination: applicationChannel1Id,
+          amount: parseUnits('6', 'wei').toHexString(),
+        },
+      ],
+    },
+  ],
+  appDefinition: AddressZero,
+  appData: HashZero,
+  challengeDuration: 1,
+  turnNum: 1,
+};
+
+// Construct the "post fund setup" state for the application channel
+
+const threeEachStatePostFS: State = {
+  ...threeEachStatePreFS,
+  turnNum: 3,
+};
+
+// Support this state by providing a signature on it
+```
+
+Finally, we have our indirectly funded channel
+
+<div class="mermaid" align="center">
+graph LR;
+linkStyle default interpolate basis;
+chain( )
+ledger((L))
+me(( )):::external
+hub(( )):::external
+me(( )):::external
+hub(( )):::external
+chain-->|12|ledger;
+ledger-->|3|me;
+ledger-->|3|hub;
+ledger-->|6|app
+app((A1))
+app-->|3|me;
+app-->|3|hub;
+classDef external fill:#f96
+</div>
+
+We could fund more application channels from the same ledger channel in the same way, if we wanted to.
+
+## Indirect defunding
+
+Let's say application A1 finished and between me and the hub, we finalize it off chain with an outcome that allocates all the funds to me. To defund it off chain, we just agree to get the funds back into the ledger channel in a manner that preserves each of our balances in the funding graph.
+
+```typescript
+// Construct a state that allocates 6 wei to me
+// This is the "pre fund setup" state for the our first application channel
+
+const threeEachStatePreFS: State = {
+  isFinal: true,
+  channel: applicationChannel1,
+  outcome: [
+    {
+      assetHolderAddress: process.env.ETH_ASSET_HOLDER_ADDRESS,
+      allocationItems: [{destination: me, amount: parseUnits('6', 'wei').toHexString()}],
+    },
+  ],
+  appDefinition: ROCK_PAPER_SCISSORS_ADDRESS,
+  appData: HashZero,
+  challengeDuration: 1,
+  turnNum: 100,
+};
+
+// Support this state by providing a signature on it
+```
+
+<div class="mermaid" align="center">
+graph LR;
+linkStyle default interpolate basis;
+chain( )
+ledger((L))
+me(( )):::external
+hub(( )):::external
+me(( )):::external
+hub(( )):::external
+chain-->|12|ledger;
+ledger-->|3|me;
+ledger-->|3|hub;
+ledger-->|6|app
+app((A1))
+app-->|6|me;
+app-->|0|hub;
+classDef external fill:#f96
+</div>
+
+Now
+
+```typescript
+// Fund our first application channel OFF CHAIN
+// simply by collecting a support proof for a state such as this:
+
+const nineForMe3ForTheHub: State = {
+  isFinal: false,
+  channel: ledgerChannel,
+  outcome: [
+    {
+      assetHolderAddress: process.env.ETH_ASSET_HOLDER_ADDRESS,
+      allocationItems: [
+        {destination: me, amount: parseUnits('9', 'wei').toHexString()},
+        {destination: hub, amount: parseUnits('3', 'wei').toHexString()},
+      ],
+    },
+  ],
+  appDefinition: AddressZero,
+  appData: HashZero,
+  challengeDuration: 1,
+  turnNum: 1,
+};
+```
+
+and the funding graph now looks like this:
+
+<div class="mermaid" align="center">
+graph LR;
+linkStyle default interpolate basis;
+chain( )
+ledger((L))
+me(( )):::external
+hub(( )):::external
+me(( )):::external
+hub(( )):::external
+chain-->|12|ledger;
+ledger-->|9|me;
+ledger-->|3|hub;
+app((A1)):::defunded
+app-->|6|me;
+app-->|0|hub;
+linkStyle 3,4 opacity:0.2;
+classDef external fill:#f96
+classDef defunded opacity:0.2;
+</div>
+
+### Challenging with a deep funding tree
+
+If the hub goes AWOL, in the worst-case scenario we would need to finalize the ledger channel as well as _all_ of the channels funded by that ledger channel, in order to recover our on chain deposit. See the section on [sad-path finalization](./finalize-a-dchannel-sad).

--- a/packages/nitro-protocol/docs/wallet-dev-tutorial/fund-and-defund-off-chain.md
+++ b/packages/nitro-protocol/docs/wallet-dev-tutorial/fund-and-defund-off-chain.md
@@ -71,11 +71,11 @@ So far, so standard. We have directly funded a channel, but this time we are cal
 <div class="mermaid" align="center">
 graph LR;
 linkStyle default interpolate basis;
-chain( )
+ETHAssetHolder( )
 ledger((L))
 me(( )):::external
 hub(( )):::external
-chain-->|12|ledger;
+ETHAssetHolder-->|12|ledger;
 ledger-->|6|me;
 ledger-->|6|hub;
 classDef external fill:#f96
@@ -123,13 +123,13 @@ We are now in the following situation:
 <div class="mermaid" align="center">
 graph LR;
 linkStyle default interpolate basis;
-chain( )
+ETHAssetHolder( )
 ledger((L))
 me(( )):::external
 hub(( )):::external
 me(( )):::external
 hub(( )):::external
-chain-->|12|ledger;
+ETHAssetHolder-->|12|ledger;
 ledger-->|6|me;
 ledger-->|6|hub;
 app((A1)):::defunded
@@ -187,13 +187,13 @@ Finally, we have our indirectly funded channel
 <div class="mermaid" align="center">
 graph LR;
 linkStyle default interpolate basis;
-chain( )
+ETHAssetHolder( )
 ledger((L))
 me(( )):::external
 hub(( )):::external
 me(( )):::external
 hub(( )):::external
-chain-->|12|ledger;
+ETHAssetHolder-->|12|ledger;
 ledger-->|3|me;
 ledger-->|3|hub;
 ledger-->|6|app
@@ -234,13 +234,13 @@ const threeEachStatePreFS: State = {
 <div class="mermaid" align="center">
 graph LR;
 linkStyle default interpolate basis;
-chain( )
+ETHAssetHolder( )
 ledger((L))
 me(( )):::external
 hub(( )):::external
 me(( )):::external
 hub(( )):::external
-chain-->|12|ledger;
+ETHAssetHolder-->|12|ledger;
 ledger-->|3|me;
 ledger-->|3|hub;
 ledger-->|6|app
@@ -281,13 +281,13 @@ and the funding graph now looks like this:
 <div class="mermaid" align="center">
 graph LR;
 linkStyle default interpolate basis;
-chain( )
+ETHAssetHolder( )
 ledger((L))
 me(( )):::external
 hub(( )):::external
 me(( )):::external
 hub(( )):::external
-chain-->|12|ledger;
+ETHAssetHolder-->|12|ledger;
 ledger-->|9|me;
 ledger-->|3|hub;
 app((A1)):::defunded

--- a/packages/nitro-protocol/docs/wallet-dev-tutorial/off-chain-funding.md
+++ b/packages/nitro-protocol/docs/wallet-dev-tutorial/off-chain-funding.md
@@ -1,5 +1,5 @@
 ---
-id: fund-and-defund-off-chain
+id: off-chain-funding
 title: Off-chain funding
 ---
 

--- a/packages/nitro-protocol/docs/wallet-dev-tutorial/off-chain-funding.md
+++ b/packages/nitro-protocol/docs/wallet-dev-tutorial/off-chain-funding.md
@@ -7,9 +7,11 @@ This advanced section of the tutorial covers funding and defunding channels by r
 
 ## Indirect funding
 
-Let's introduce one level of indirection by setting up a ledger channel with a counterparty which we'll call "the hub". We will fund this in the same way as we have done earlier in the tutorial. A ledger channel is a special channel that runs the "null app" (meaning that all transitions are considered invalid), and whose sole purpose is to reallocate its funding to other channels and/or state channel participants.
+Let's introduce one level of indirection between the chain and the state channel we want to fund. We will first set up a ledger channel (L) with a counterparty (we'll call this counterparty "the hub"). We will fund the ledger channel "directly" -- in the same way as we have done [earlier in the tutorial](./deposit-assets).
 
-Now imagine that we want to play Rock Paper Scissors (or run some other state channel application) with that same participant. We'll open a new channel for that.
+A ledger channel is a special channel that runs the "null app" (meaning that all transitions are considered invalid, and the channel may only be updated by a state being supported by all participants signing it). The sole purpose of this ledger channel is to reallocate some or all of its funding to other channels and/or state channel participants.
+
+Now imagine that we want to play Rock Paper Scissors (or run some other state channel application) with that same participant. We'll open a new channel (A1) for that.
 
 Instead of funding it on chain, let's just divert some money from our existing ledger channel.
 
@@ -95,7 +97,7 @@ const applicationChannel1: Channel = {
 const applicationChannel1Id = getChannelId(applicationChannel1);
 
 // Construct a state that allocates 3 wei to each of us, and has turn numer n - 1
-// This is the "pre fund setup" state for the our first application channel
+// This is the "pre fund setup" state for our application channel A1
 
 const threeEachStatePreFS: State = {
   isFinal: false,
@@ -211,7 +213,6 @@ Let's say application A1 finished and between me and the hub, we finalize it off
 
 ```typescript
 // Construct a state that allocates 6 wei to me
-// This is the "pre fund setup" state for the our first application channel
 
 const threeEachStatePreFS: State = {
   isFinal: true,

--- a/packages/nitro-protocol/docs/wallet-dev-tutorial/outcomes.md
+++ b/packages/nitro-protocol/docs/wallet-dev-tutorial/outcomes.md
@@ -8,39 +8,13 @@ So far during this tutorial we have not concerned ourselves with specifying mean
 The time has come to tackle this issue!
 Nitro protocol is an extension of ForceMove protocol that we have dealt with so far. ForceMove specifies only that a state should have a default `outcome` but does not specify the format of that `outcome`, and simply treats it as an unstructured `bytes` field. In this section we look at the outcome formats needed for Nitro.
 
-## Outcomes that allocate
-
-The following table illustrates an example data structure for an outcome, which features an _allocation_ asset outcome. (For those interested, the giveaway is the `0` in the `AssetOutcome` property. Guarantee asset outcomes, which we will get to shortly, have a `1` there).
-
 :::tip
 Nitro supports multiple different assets (e.g. ETH and one or more ERC20s) being held in the same channel.
 :::
 
-| >                                                                                               | 0xETHAssetHolder                                 | 0                                                                                                     | 0xDestA     | 5      | 0xDestB     | 2      | 0xDAIAssetHolder | ... |
-| ----------------------------------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ----------- | ------ | ----------- | ------ | ---------------- | --- |
-|                                                                                                 |                                                  |                                                                                                       | Destination | Amount | Destination | Amount |                  |     |
-|                                                                                                 |                                                  | <td colspan="2" align="center">AllocationItem</td> <td colspan="2" align="center">AllocationItem</td> |             |        |
-|                                                                                                 |                                                  | <td colspan="4" align="center">Allocation</td>                                                        |             |        |
-|                                                                                                 | <td colspan="5" align="center">AssetOutcome</td> |                                                                                                       |             |
-| <td colspan="6" align="center">OutcomeItem</td> <td colspan="6" align="center">OutcomeItem</td> |
-| <td colspan="8" align="center">Outcome</td>                                                     |
+## Outcomes that allocate
 
-```
-0xETHAssetHolderAddress00xDestinationA50xDestinationB2
-                                                     ^  Amount
-                                       ^^^^^^^^^^^^^^   Destination
-                                      ^                 Amount
-                        ^^^^^^^^^^^^^^                  Destination
-                                       ^^^^^^^^^^^^^^^  AllocationItem
-                        ^^^^^^^^^^^^^^^                 AllocationItem
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  Allocation
-                       ^                                Outcome type
-                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  AssetOutcome
-^^^^^^^^^^^^^^^^^^^^^^^                                 Asset Holder Address
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  OutcomeItem
-```
-
-Such an outcome specifies
+An Allocation outcome specifies
 
 - at least one asset holder (which in turn is tied to a specific asset type such as ETH or an ERC20 token)
 - for each asset holder, an array of (destination, amount) pairs known as an `Allocation`, and indicating a payout of amount tokens to destination.
@@ -80,16 +54,6 @@ expect(decodeOutcome(encodedOutcome)).toEqual(outcome);
 ## Outcomes that guarantee
 
 Guarantee Asset Outcomes are similar to Allocation Asset Outcomes, only they not have any amounts. Their purpose is to simply express an ordering of destinations for a given asset holder (say, a given token).
-
-The following table illustrates an example data structure for an outcome, which features an _guarantee_ asset outcome. (This time the giveaway is the `1` in the `AssetOutcome` property).
-
-| >                                                                                               | 0xETHAssetHolder                                 | 1                                             | 0xchannelA                                                       | 0xBob | 0xAlice | 0xDAIAssetHolder | ... |
-| ----------------------------------------------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------- | ---------------------------------------------------------------- | ----- | ------- | ---------------- | --- |
-|                                                                                                 |                                                  |                                               | TargetChannelId <td colspan="2" align="center">Destinations</td> |       |         |
-|                                                                                                 |                                                  | <td colspan="3" align="center">Guarantee</td> |                                                                  |       |
-|                                                                                                 | <td colspan="4" align="center">AssetOutcome</td> |                                               |                                                                  |
-| <td colspan="5" align="center">OutcomeItem</td> <td colspan="5" align="center">OutcomeItem</td> |
-| <td colspan="7" align="center">Outcome</td>                                                     |
 
 A channel that has a guarantee outcome is said to be a guarantor channel.
 

--- a/packages/nitro-protocol/docs/wallet-dev-tutorial/outcomes.md
+++ b/packages/nitro-protocol/docs/wallet-dev-tutorial/outcomes.md
@@ -25,6 +25,21 @@ Nitro supports multiple different assets (e.g. ETH and one or more ERC20s) being
 | <td colspan="6" align="center">OutcomeItem</td> <td colspan="6" align="center">OutcomeItem</td> |
 | <td colspan="8" align="center">Outcome</td>                                                     |
 
+```
+0xETHAssetHolderAddress00xDestinationA50xDestinationB2
+                                                     ^  Amount
+                                       ^^^^^^^^^^^^^^   Destination
+                                      ^                 Amount
+                        ^^^^^^^^^^^^^^                  Destination
+                                       ^^^^^^^^^^^^^^^  AllocationItem
+                        ^^^^^^^^^^^^^^^                 AllocationItem
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  Allocation
+                       ^                                Outcome type
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  AssetOutcome
+^^^^^^^^^^^^^^^^^^^^^^^                                 Asset Holder Address
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  OutcomeItem
+```
+
 Such an outcome specifies
 
 - at least one asset holder (which in turn is tied to a specific asset type such as ETH or an ERC20 token)

--- a/packages/nitro-protocol/docs/wallet-dev-tutorial/outcomes.md
+++ b/packages/nitro-protocol/docs/wallet-dev-tutorial/outcomes.md
@@ -19,7 +19,7 @@ An Allocation outcome specifies
 - at least one asset holder (which in turn is tied to a specific asset type such as ETH or an ERC20 token)
 - for each asset holder, an array of (destination, amount) pairs known as an `Allocation`, and indicating a payout of amount tokens to destination.
 
-The destination here might be an external destination (which means the assets will get paid out to an ethereum address) or a channelId.
+The destination here might be an external destination (which means the assets will get paid out to an ethereum address) or a channelId. In the code snippet below, we import `convertAddressToBytes32` to convert an ethereum address to an external destination.
 
 :::tip
 In nitro protocol, channels can allocate funds to other channels!
@@ -30,7 +30,15 @@ To construct an outcome, you can import the `Outcome` type to ensure you're gett
 ```typescript
 // In lesson11.test.ts
 
-import { AllocationAssetOutcome, Outcome, encodeOutcome, decodeOutcome } from '@statechannels/nitro-protocol';
+import {
+  AllocationAssetOutcome,
+  Outcome,
+  encodeOutcome,
+  decodeOutcome,
+  convertAddressToBytes32
+  } from '@statechannels/nitro-protocol';
+
+const externalDestination(convertAddressToBytes32(AddressZero));
 
 const assetOutcome: AllocationAssetOutcome = {
   assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS

--- a/packages/nitro-protocol/docs/wallet-dev-tutorial/release-assets.md
+++ b/packages/nitro-protocol/docs/wallet-dev-tutorial/release-assets.md
@@ -3,6 +3,8 @@ id: release-assets
 title: Release assets
 ---
 
+If a channel has been finalized on chain, the adjudicator contract knows about the final outcome. This tutorial section covers pushing that outcome to the asset holder contract(s), which is a necessary step to releasing the assets.
+
 ## Using `pushOutcome`
 
 A finalized outcome is stored in two places on chain: first, as a single hash in the adjudicator contract; second, in multiple hashes across multiple asset holder contracts.

--- a/packages/nitro-protocol/website/sidebars.json
+++ b/packages/nitro-protocol/website/sidebars.json
@@ -16,7 +16,7 @@
       "wallet-dev-tutorial/clear-a-challenge",
       "wallet-dev-tutorial/outcomes",
       "wallet-dev-tutorial/release-assets",
-      "wallet-dev-tutorial/fund-and-defund-off-chain"
+      "wallet-dev-tutorial/off-chain-funding"
     ],
     "Contract Developers": [
       "contract-devs/contract-devs-intro",

--- a/packages/nitro-protocol/website/sidebars.json
+++ b/packages/nitro-protocol/website/sidebars.json
@@ -15,7 +15,8 @@
       "wallet-dev-tutorial/understand-channel-storage",
       "wallet-dev-tutorial/clear-a-challenge",
       "wallet-dev-tutorial/outcomes",
-      "wallet-dev-tutorial/release-assets"
+      "wallet-dev-tutorial/release-assets",
+      "wallet-dev-tutorial/fund-and-defund-off-chain"
     ],
     "Contract Developers": [
       "contract-devs/contract-devs-intro",


### PR DESCRIPTION
- removes tables from the outcomes section
- adds (long) section on indirect (d)efunding
- adds a passage about setup states

TODO 
- [x] write a tutorial in the nitro-tutorial repo to accompany this page
- [ ] extend to virtual (de)funding (wontfix?)