### PR TITLE
Only allow withdrawal when no active torrent

### DIFF
--- a/packages/e2e-tests/puppeteer/__tests__/web3torrent/withdraw.test.ts
+++ b/packages/e2e-tests/puppeteer/__tests__/web3torrent/withdraw.test.ts
@@ -8,7 +8,8 @@ import {
   waitForEmptyBudget,
   setupLogging,
   setupFakeWeb3,
-  takeScreenshot
+  takeScreenshot,
+  waitForAndClickButton
 } from '../../helpers';
 import {
   JEST_TIMEOUT,
@@ -55,6 +56,7 @@ describe('withdrawal from a ledger channel', () => {
 
     await waitForBudgetEntry(web3tTabA);
 
+    await waitForAndClickButton(web3tTabA, web3tTabA.frames()[0], '#cancel-download-button');
     await withdrawAndWait(web3tTabA, metamask);
 
     await waitForEmptyBudget(web3tTabA);

--- a/packages/web3torrent/src/components/domain-budget/DomainBudget.scss
+++ b/packages/web3torrent/src/components/domain-budget/DomainBudget.scss
@@ -15,6 +15,18 @@
   border: 1px solid $c-orange;
   margin: 15px auto 15px;
   padding: 3px 6px;
+
+  &:not(:disabled) {
+    &:hover {
+      border-color: $c-orangealt;
+      color: $c-orangealt;
+    }
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.28;
+  }
 }
 
 svg.budget-pie-chart {

--- a/packages/web3torrent/src/components/domain-budget/DomainBudget.tsx
+++ b/packages/web3torrent/src/components/domain-budget/DomainBudget.tsx
@@ -92,6 +92,10 @@ export const DomainBudget: React.FC<DomainBudgetProps> = props => {
   ] = [myBalanceFree, myBalanceLocked, hubBalanceFree, hubBalanceLocked].map(percentageOfTotal);
 
   const colors = ['#ea692b', '#ea692b', '#d5dbe3', '#d5dbe3'];
+
+  const withdrawalTooltipText = !props.allowWithdrawal
+    ? 'Your torrent is still active! You need to click "Stop Torrenting" first before withdrawing.'
+    : '';
   return (
     <table>
       <tbody>
@@ -188,22 +192,27 @@ export const DomainBudget: React.FC<DomainBudgetProps> = props => {
         </tr>
         <tr>
           <td className="budget-button-container" colSpan={1}>
-            <button
-              className={'budget-button'}
-              disabled={!props.allowWithdrawal}
-              id="budget-withdraw"
-              onClick={() => {
-                track('Withdraw Initiated', {
-                  myBalanceFree,
-                  myBalanceLocked,
-                  hubBalanceFree,
-                  hubBalanceLocked
-                });
-                withdraw();
-              }}
-            >
-              Withdraw
-            </button>
+            <Tooltip title={withdrawalTooltipText} placement="top">
+              <span style={{width: '100%'}}>
+                <button
+                  className={'budget-button'}
+                  style={!props.allowWithdrawal ? {pointerEvents: 'none'} : {}}
+                  disabled={!props.allowWithdrawal}
+                  id="budget-withdraw"
+                  onClick={() => {
+                    track('Withdraw Initiated', {
+                      myBalanceFree,
+                      myBalanceLocked,
+                      hubBalanceFree,
+                      hubBalanceLocked
+                    });
+                    withdraw();
+                  }}
+                >
+                  Withdraw
+                </button>
+              </span>
+            </Tooltip>
           </td>
         </tr>
       </tbody>

--- a/packages/web3torrent/src/components/domain-budget/DomainBudget.tsx
+++ b/packages/web3torrent/src/components/domain-budget/DomainBudget.tsx
@@ -26,6 +26,7 @@ export type DomainBudgetProps = {
   budgetCache: DomainBudgetType;
   mySigningAddress: string;
   withdraw: () => void;
+  allowWithdrawal: boolean;
 };
 
 export const DomainBudget: React.FC<DomainBudgetProps> = props => {
@@ -189,6 +190,7 @@ export const DomainBudget: React.FC<DomainBudgetProps> = props => {
           <td className="budget-button-container" colSpan={1}>
             <button
               className={'budget-button'}
+              disabled={!props.allowWithdrawal}
               id="budget-withdraw"
               onClick={() => {
                 track('Withdraw Initiated', {

--- a/packages/web3torrent/src/hooks/use-budget.ts
+++ b/packages/web3torrent/src/hooks/use-budget.ts
@@ -45,10 +45,6 @@ export function useBudget({ready}: {ready: boolean}) {
 
   const closeBudget = async () => {
     setLoading(true);
-    // Cancel all existing torrents
-    await Promise.all(
-      web3TorrentClient.torrents.map(torrent => web3TorrentClient.cancel(torrent.infoHash))
-    );
     await paymentChannelClient.closeAndWithdraw();
     setBudget(paymentChannelClient.budgetCache);
     setLoading(false);

--- a/packages/web3torrent/src/hooks/use-budget.ts
+++ b/packages/web3torrent/src/hooks/use-budget.ts
@@ -45,6 +45,10 @@ export function useBudget({ready}: {ready: boolean}) {
 
   const closeBudget = async () => {
     setLoading(true);
+    // Cancel all existing torrents
+    await Promise.all(
+      web3TorrentClient.torrents.map(torrent => web3TorrentClient.cancel(torrent.infoHash))
+    );
     await paymentChannelClient.closeAndWithdraw();
     setBudget(paymentChannelClient.budgetCache);
     setLoading(false);

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -56,8 +56,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     this.pseAccount = opts.pseAccount;
     this.paymentChannelClient = opts.paymentChannelClient;
     this.outcomeAddress = opts.outcomeAddress;
-    this.canWithdrawSubject = new rxjs.Subject();
-    this.enableWithdrawal();
+    this.canWithdrawSubject = new rxjs.BehaviorSubject(true);
   }
 
   /** Enable the client capabilities to seed or leech torrents, enabling the paymentChannelClient

--- a/packages/web3torrent/src/pages/budgets/Budgets.tsx
+++ b/packages/web3torrent/src/pages/budgets/Budgets.tsx
@@ -43,6 +43,7 @@ const CurrentBudget: React.FC<Props> = props => {
           channelCache={channelCache}
           mySigningAddress={me}
           withdraw={closeBudget}
+          allowWithdrawal={true}
         />
       )}
       {!loading && !budgetExists && (

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -57,7 +57,7 @@ const File: React.FC<Props> = props => {
   const torrentName = queryParams.get('name');
   const torrentLength = Number(queryParams.get('length'));
 
-  const [canWithdraw, setCanWithdraw] = useState(false);
+  const [canWithdraw, setCanWithdraw] = useState(true);
   useEffect(() => {
     const subscription = web3TorrentClient.canWithdrawFeed.subscribe(setCanWithdraw);
     return safeUnsubscribe(subscription, log);

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -57,6 +57,12 @@ const File: React.FC<Props> = props => {
   const torrentName = queryParams.get('name');
   const torrentLength = Number(queryParams.get('length'));
 
+  const [canWithdraw, setCanWithdraw] = useState(false);
+  useEffect(() => {
+    const subscription = web3TorrentClient.canWithdrawFeed.subscribe(setCanWithdraw);
+    return safeUnsubscribe(subscription, log);
+  }, [web3TorrentClient.canWithdrawFeed]);
+
   const [torrent, setTorrent] = useState<TorrentUI>(() =>
     getTorrentUI(web3TorrentClient, {
       infoHash,
@@ -115,10 +121,6 @@ const File: React.FC<Props> = props => {
   let warning = warningState;
   let buttonEnabled = true;
 
-  // torrent.ready will be false whenever the torrent is active in any way
-  // This means the user will have to hit stop seeding/downloading before withdrawal
-  const withdrawalEnabled = !torrent.ready;
-
   if (showBudget) {
     if (
       (torrent.status === Status.Seeding || torrent.status === Status.Downloading) &&
@@ -155,7 +157,7 @@ const File: React.FC<Props> = props => {
           channelCache={channels}
           mySigningAddress={me}
           withdraw={closeBudget}
-          allowWithdrawal={withdrawalEnabled}
+          allowWithdrawal={canWithdraw}
         />
       )}
       {(torrent.status === Status.Idle || torrent.status === Status.Paused) && (

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -113,6 +113,7 @@ const File: React.FC<Props> = props => {
 
   let warning = warningState;
   let buttonEnabled = true;
+  let withdrawalEnabled = false;
   if (showBudget) {
     if (
       (torrent.status === Status.Seeding || torrent.status === Status.Downloading) &&
@@ -126,6 +127,10 @@ const File: React.FC<Props> = props => {
     ) {
       warning = 'You do not have enough funds in your budget to download this file.';
       buttonEnabled = false;
+    }
+
+    if (torrent.status === Status.Idle || torrent.status === Status.Completed) {
+      withdrawalEnabled = true;
     }
   }
 
@@ -149,6 +154,7 @@ const File: React.FC<Props> = props => {
           channelCache={channels}
           mySigningAddress={me}
           withdraw={closeBudget}
+          allowWithdrawal={withdrawalEnabled}
         />
       )}
       {(torrent.status === Status.Idle || torrent.status === Status.Paused) && (

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -115,7 +115,9 @@ const File: React.FC<Props> = props => {
   let warning = warningState;
   let buttonEnabled = true;
 
-  const withdrawalEnabled = !torrent || torrent.done;
+  // torrent.ready will be false whenever the torrent is active in any way
+  // This means the user will have to hit stop seeding/downloading before withdrawal
+  const withdrawalEnabled = !torrent.ready;
 
   if (showBudget) {
     if (

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -115,7 +115,7 @@ const File: React.FC<Props> = props => {
   let warning = warningState;
   let buttonEnabled = true;
 
-  const withdrawalEnabled = _.values(channels).every(cs => cs.status === 'closed');
+  const withdrawalEnabled = !torrent || torrent.done;
 
   if (showBudget) {
     if (

--- a/packages/web3torrent/src/pages/file/File.tsx
+++ b/packages/web3torrent/src/pages/file/File.tsx
@@ -129,7 +129,11 @@ const File: React.FC<Props> = props => {
       buttonEnabled = false;
     }
 
-    if (torrent.status === Status.Idle || torrent.status === Status.Completed) {
+    if (
+      torrent.status === Status.Idle ||
+      torrent.status === Status.Completed ||
+      torrent.status === Status.Seeding
+    ) {
       withdrawalEnabled = true;
     }
   }

--- a/packages/xstate-wallet/src/workflows/application.ts
+++ b/packages/xstate-wallet/src/workflows/application.ts
@@ -180,11 +180,11 @@ const generateConfig = (
           channelId: ctx.channelId,
           funding: ctx.fundingStrategy
         }),
-        onDone: 'running'
+        onDone: {target: 'running', actions: [actions.hideUi]}
       }
     },
     running: {
-      entry: [actions.hideUi, actions.spawnObservers],
+      entry: [actions.spawnObservers],
       on: {
         // TODO: It would be nice to get rid of this event, which is used
         // in testing when starting the workflow in the 'running' state.


### PR DESCRIPTION
Adds a `canWithdrawFeed` to the web3 torrent client that is used to notify the file component when the user should be allowed to withdraw.

The withdrawal button is disabled with a tooltip when there is an active torrent.

![image](https://user-images.githubusercontent.com/1620336/84939144-bebd1d00-b092-11ea-94cb-939429cc11c6.png)

