### PR TITLE
Make closeChannel more robust

### DIFF
--- a/.env.circle-integration-w3t-with-hub
+++ b/.env.circle-integration-w3t-with-hub
@@ -15,13 +15,12 @@ USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 
 # For e2e-test
 BROWSER_LOG_DESTINATION = 'browser.log'
-HEADLESS = 'false'
+HEADLESS = 'true'
 USE_DAPPETEER = 'false'
 TARGET_NETWORK = 'localhost'
 WEB3TORRENT_URL = 'http://localhost:3000'
 SCREENSHOT_DIR = 'screenshots'
-CLOSE_BROWSERS = 'false'
-SHOW_DEVTOOLS = 'false'
+CLOSE_BROWSERS = 'true'
 
 ## simple-hub
 SIMPLE_HUB_DEPLOYER_ACCOUNT_INDEX = '1'

--- a/.env.circle-integration-w3t-with-hub
+++ b/.env.circle-integration-w3t-with-hub
@@ -15,12 +15,13 @@ USE_GANACHE_DEPLOYMENT_CACHE = 'true'
 
 # For e2e-test
 BROWSER_LOG_DESTINATION = 'browser.log'
-HEADLESS = 'true'
+HEADLESS = 'false'
 USE_DAPPETEER = 'false'
 TARGET_NETWORK = 'localhost'
 WEB3TORRENT_URL = 'http://localhost:3000'
 SCREENSHOT_DIR = 'screenshots'
-CLOSE_BROWSERS = 'true'
+CLOSE_BROWSERS = 'false'
+SHOW_DEVTOOLS = 'false'
 
 ## simple-hub
 SIMPLE_HUB_DEPLOYER_ACCOUNT_INDEX = '1'

--- a/packages/web3torrent/src/clients/payment-channel-client.ts
+++ b/packages/web3torrent/src/clients/payment-channel-client.ts
@@ -29,6 +29,7 @@ import {map, filter, first, tap, take} from 'rxjs/operators';
 import {logger} from '../logger';
 import {concat, of, Observable} from 'rxjs';
 import _ from 'lodash';
+import {safeUnsubscribeFromFunction} from '../utils/react-utls';
 
 const log = logger.child({module: 'payment-channel-client'});
 const hexZeroPad = utils.hexZeroPad;
@@ -285,7 +286,7 @@ export class PaymentChannelClient {
     this.insertIntoChannelCache(convertToChannelState(channelResult));
   }
 
-  async closeChannel(channelId: string): Promise<ChannelState> {
+  closeChannel(channelId: string): Promise<ChannelState> {
     const MAX_CLOSE_ATTEMPTS = 5;
     const {unsubscribe} = this.channelState(channelId)
       .pipe(
@@ -318,7 +319,7 @@ export class PaymentChannelClient {
     return this.channelState(channelId)
       .pipe(
         first(cs => cs.status === 'closed'),
-        tap(unsubscribe)
+        tap(safeUnsubscribeFromFunction(unsubscribe, log))
       )
       .toPromise();
   }

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -141,6 +141,15 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     }
   }
 
+  stopUploading(infoHash: string) {
+    const torrent = this.torrents.find(t => t.infoHash === infoHash);
+    // there isn't a method on the torrent to stop seeding once you have started
+    // setting _rechokeNumSlots = 0 has the same effect as setting upload: false initially
+    // https://github.com/webtorrent/webtorrent/blob/master/lib/torrent.js#L82-L84
+    (torrent as any)._rechokeNumSlots = 0;
+    (torrent as any)._rechoke();
+  }
+
   /**
    * Cancels a Torrent (closes all channels, destroys the torrent from memory).
    *
@@ -155,7 +164,9 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
       // If I don't pause the torrent, then I will continue to make payments, meaning the call to
       // this.closeChannels would race the `makePayment` function, and one of them would fail with a
       // "Not my turn" error.
-      torrent.pause();
+      torrent.pause(); // prevents connections to new peers
+      (torrent as any).maxWebConns = 0; // don't start downloading from existing upload peers
+
       await this.closeTorrentChannels(torrent, true);
       torrent.destroy(() => this.emitTorrentUpdated(infoHash, 'destroy'));
     } else {

--- a/packages/web3torrent/src/utils/react-utls.ts
+++ b/packages/web3torrent/src/utils/react-utls.ts
@@ -11,6 +11,6 @@ export const safeUnsubscribeFromFunction = (unsubscribe: () => void, log: P.Logg
   try {
     unsubscribe();
   } catch (error) {
-    log.warn('Unable to unsubscribe');
+    log.warn({error}, 'Unable to unsubscribe');
   }
 };


### PR DESCRIPTION
Instead of trying to win the "who can update first" five times, we instead obtain an unfair advantage by attempting to close before the app is notified, when the channel is updated.

Note: includes #2211 