### PR TITLE
Permanent stop

### DIFF
--- a/packages/web3torrent/src/library/paid-streaming-extension.ts
+++ b/packages/web3torrent/src/library/paid-streaming-extension.ts
@@ -106,6 +106,14 @@ export abstract class PaidStreamingExtension implements Extension {
     this.executeExtensionCommand(PaidStreamingExtensionNotices.STOP, this.seedingChannelId);
   }
 
+  permanentStop() {
+    this.isForceChoking = true;
+    this.executeExtensionCommand(
+      PaidStreamingExtensionNotices.PERMANENT_STOP,
+      this.seedingChannelId
+    );
+  }
+
   start() {
     if (this.isForceChoking) {
       this.isForceChoking = false;

--- a/packages/web3torrent/src/library/types.ts
+++ b/packages/web3torrent/src/library/types.ts
@@ -53,6 +53,7 @@ export enum PaidStreamingExtensionNotices {
   MESSAGE = 'message',
   START = 'start',
   STOP = 'stop',
+  PERMANENT_STOP = 'permanent-stop',
   ACK = 'ack'
 }
 

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -148,6 +148,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
     // https://github.com/webtorrent/webtorrent/blob/master/lib/torrent.js#L82-L84
     (torrent as any)._rechokeNumSlots = 0;
     (torrent as any)._rechoke();
+    torrent.wires.forEach(w => w.paidStreamingExtension.permanentStop());
   }
 
   /**
@@ -441,6 +442,9 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
           break;
         case PaidStreamingExtensionNotices.START: // "okay, now you can continue asking for data" request
           this.jumpStart(torrent, wire);
+          break;
+        case PaidStreamingExtensionNotices.PERMANENT_STOP: // "okay, now you can continue asking for data" request
+          this.closeChannel(wire, wire.paidStreamingExtension.leechingChannelId);
           break;
         case PaidStreamingExtensionNotices.MESSAGE: // general use message
           log.info({data}, 'Message received');

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -443,8 +443,10 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
         case PaidStreamingExtensionNotices.START: // "okay, now you can continue asking for data" request
           this.jumpStart(torrent, wire);
           break;
-        case PaidStreamingExtensionNotices.PERMANENT_STOP: // "okay, now you can continue asking for data" request
-          this.closeChannel(wire, wire.paidStreamingExtension.leechingChannelId);
+        case PaidStreamingExtensionNotices.PERMANENT_STOP: // "no more data ever"
+          if (wire.paidStreamingExtension.leechingChannelId) {
+            await this.closeChannel(wire, wire.paidStreamingExtension.leechingChannelId);
+          }
           break;
         case PaidStreamingExtensionNotices.MESSAGE: // general use message
           log.info({data}, 'Message received');


### PR DESCRIPTION
Currently we have the problem that when seeder stops seeding, they choke, so no more requests are sent. They then might have to wait for the “no-progress timeout” for leecher to close the channel.

This PR adds a `PERMANENT_STOP` message, that the seeder sends to the leecher, which prompts them to close the channel.