### PR TITLE
Enforce lower casing in blockie calculation

### DIFF
--- a/packages/web3torrent/src/components/domain-budget/DomainBudget.tsx
+++ b/packages/web3torrent/src/components/domain-budget/DomainBudget.tsx
@@ -142,7 +142,7 @@ export const DomainBudget: React.FC<DomainBudgetProps> = props => {
                   <Avatar variant="square">
                     <Blockie
                       opts={{
-                        seed: web3torrent.paymentChannelClient.myDestinationAddress,
+                        seed: web3torrent.paymentChannelClient.myDestinationAddress.toLowerCase(),
                         bgcolor: '#3531ff',
                         size: 6,
                         scale: 4,

--- a/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
+++ b/packages/web3torrent/src/components/torrent-info/channels-list/ChannelsList.tsx
@@ -78,7 +78,7 @@ function channelIdToTableRow(
           <Avatar variant="square">
             <Blockie
               opts={{
-                seed: peerDestinationAddress,
+                seed: peerDestinationAddress.toLowerCase(),
                 bgcolor: '#3531ff',
                 size: 6,
                 scale: 4,


### PR DESCRIPTION
This ensures consistency across the two components even if the convention on lower casing is broken upstream of the UI. 

