### PR TITLE
Redeploy contracts to goerli and verify

### DIFF
--- a/.env.local-goerli
+++ b/.env.local-goerli
@@ -29,8 +29,11 @@ WALLET_URL = 'http://localhost:3055'
 
 ## simple-hub, xstate-wallet
 CONSENSUS_APP_ADDRESS = '0xdb7accd228222ea0035cb3da82f09eb6fde4f7ae'
-ETH_ASSET_HOLDER_ADDRESS = '0xff0c71bfe3edbae5f3c2330e78ddce960403166d'
-NITRO_ADJUDICATOR_ADDRESS = '0x6cf0c4ab3f1e66913c0983dc0bb1202d958abb8f'
+
+### NitroAdjudicator and ETHAssetHolder deployed by George Knee, by uploading files to https://remix.ethereum.org/ and using compiler 0.6.10+commit.00c0fcaf, optimization ON. Source code verified on https://goerli.etherscan.io/ .
+NITRO_ADJUDICATOR_ADDRESS = '0xedae380e8da298979848337d7527f441071e68cf'
+ETH_ASSET_HOLDER_ADDRESS = '0x8e409FB551fC96f5129cb41e7194e8F8CB9df0a0'
+
 TRIVIAL_APP_ADDRESS = '0x93ae13bd37021cc4e17685578851bcf152ee28d5'
 
 ## simple-hub

--- a/.env.production-goerli
+++ b/.env.production-goerli
@@ -29,8 +29,11 @@ WALLET_URL = 'https://xstate-wallet.statechannels.org'
 
 ## simple-hub, xstate-wallet
 CONSENSUS_APP_ADDRESS = '0xdb7accd228222ea0035cb3da82f09eb6fde4f7ae'
-ETH_ASSET_HOLDER_ADDRESS = '0xff0c71bfe3edbae5f3c2330e78ddce960403166d'
-NITRO_ADJUDICATOR_ADDRESS = '0x6cf0c4ab3f1e66913c0983dc0bb1202d958abb8f'
+
+### NitroAdjudicator and ETHAssetHolder deployed by George Knee, both using compiler 0.6.10+commit.00c0fcaf, optimization ON. Source code verified on https://goerli.etherscan.io/ .
+NITRO_ADJUDICATOR_ADDRESS = '0xedae380e8da298979848337d7527f441071e68cf'
+ETH_ASSET_HOLDER_ADDRESS = '0x8e409FB551fC96f5129cb41e7194e8F8CB9df0a0'
+
 TRIVIAL_APP_ADDRESS = '0x93ae13bd37021cc4e17685578851bcf152ee28d5'
 
 ## simple-hub

--- a/.env.production-goerli
+++ b/.env.production-goerli
@@ -30,7 +30,7 @@ WALLET_URL = 'https://xstate-wallet.statechannels.org'
 ## simple-hub, xstate-wallet
 CONSENSUS_APP_ADDRESS = '0xdb7accd228222ea0035cb3da82f09eb6fde4f7ae'
 
-### NitroAdjudicator and ETHAssetHolder deployed by George Knee, both using compiler 0.6.10+commit.00c0fcaf, optimization ON. Source code verified on https://goerli.etherscan.io/ .
+### NitroAdjudicator and ETHAssetHolder deployed by George Knee, by uploading files to https://remix.ethereum.org/ and using compiler 0.6.10+commit.00c0fcaf, optimization ON. Source code verified on https://goerli.etherscan.io/ .
 NITRO_ADJUDICATOR_ADDRESS = '0xedae380e8da298979848337d7527f441071e68cf'
 ETH_ASSET_HOLDER_ADDRESS = '0x8e409FB551fC96f5129cb41e7194e8F8CB9df0a0'
 


### PR DESCRIPTION
Fixes #2175 .

I gave up trying different compiler versions etc to try and match the bytecode that was already deployed. 

I redeployed the contracts, noted the compiler version and method, and verified on etherscan. This PR would point our apps __at the newly deployed contract addresses__.
