### PR TITLE
[web3torrent] for leecher, do not set seeding channel id to null blindly

### DIFF
--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -619,7 +619,7 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
         wire.paidStreamingExtension.leechingChannelId = null;
         log.info(`Leechning channel ${channelId} set to null`);
       }
-      if (channelId === wire.paidStreamingExtension.leechingChannelId) {
+      if (channelId === wire.paidStreamingExtension.seedingChannelId) {
         wire.paidStreamingExtension.seedingChannelId = null;
         log.info(`Seeding channel ${channelId} set to null`);
       }

--- a/packages/web3torrent/src/library/web3torrent-lib.ts
+++ b/packages/web3torrent/src/library/web3torrent-lib.ts
@@ -335,8 +335,10 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
         if (isClosed) {
           if (isLeechingChannel) {
             wire.paidStreamingExtension.leechingChannelId = null;
+            log.info(`Leechning channel ${channelState.channelId} set to null`);
           } else {
             wire.paidStreamingExtension.seedingChannelId = null;
+            log.info(`Seeding channel ${channelState.channelId} set to null`);
           }
           log.info(`Account ${peerAccount} - ChannelId ${channelState.channelId} Channel Closed`);
         }
@@ -611,12 +613,15 @@ export default class WebTorrentPaidStreamingClient extends WebTorrent {
   private async closeChannel(wire: PaidStreamingWire, channelId: string): Promise<string> {
     try {
       await this.paymentChannelClient.closeChannel(channelId);
+      // Note: it is possible that onChannelUpdated already set the wire.paidStreamingExtention leeching or seeding id to null
+      // while we were awaiting the above promise
       if (channelId === wire.paidStreamingExtension.leechingChannelId) {
         wire.paidStreamingExtension.leechingChannelId = null;
-        log.info(`Payment Channel closed: ${channelId}`);
-      } else {
+        log.info(`Leechning channel ${channelId} set to null`);
+      }
+      if (channelId === wire.paidStreamingExtension.leechingChannelId) {
         wire.paidStreamingExtension.seedingChannelId = null;
-        log.info(`Paying Channel closed: ${channelId}`);
+        log.info(`Seeding channel ${channelId} set to null`);
       }
     } catch (error) {
       log.error({error}, 'Error closing channel');


### PR DESCRIPTION
In my testing, the following is the usual sequence of events when the leecher cancels download from one seeder:
1. Leeching channel id is set to null in `onChannelUpdated`.
1. Seeding channel id is set to null incorrectly in `closeChannel`.

This race condition might impact wires that are both seed and leech wires.