### PR TITLE
Add webtorrent logs

### DIFF
--- a/.env.circle-integration-w3t-with-hub
+++ b/.env.circle-integration-w3t-with-hub
@@ -21,6 +21,7 @@ TARGET_NETWORK = 'localhost'
 WEB3TORRENT_URL = 'http://localhost:3000'
 SCREENSHOT_DIR = 'screenshots'
 CLOSE_BROWSERS = 'true'
+DEBUG_FILTER = 'bittorrent-protocol'
 
 ## simple-hub
 SIMPLE_HUB_DEPLOYER_ACCOUNT_INDEX = '1'

--- a/packages/e2e-tests/puppeteer/constants.ts
+++ b/packages/e2e-tests/puppeteer/constants.ts
@@ -17,6 +17,7 @@ export const CHAIN_NETWORK_ID = process.env.CHAIN_NETWORK_ID;
 export const RPC_ENDPOINT = process.env.RPC_ENDPOINT;
 export const CLOSE_BROWSERS = process.env.CLOSE_BROWSERS ? getEnvBool('CLOSE_BROWSERS') : true;
 export const SHOW_DEVTOOLS = process.env.SHOW_DEVTOOLS ? getEnvBool('SHOW_DEVTOOLS') : null;
+export const DEBUG_FILTER = process.env.DEBUG_FILTER;
 
 export const SCREENSHOT_DIR = process.env.SCREENSHOT_DIR;
 

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -95,8 +95,10 @@ export async function setupLogging(
   const isChannelProviderLog = isPinoLog('channel-provider');
   const isBittorrentProtocolLog = isDebugLog('bittorrent-protocol');
 
+  const browserId = ganacheAccountIndex;
+
   const withGanacheIndex = (text: string): string =>
-    JSON.stringify({...JSON.parse(text), browserId: ganacheAccountIndex}) + '\n';
+    JSON.stringify({...JSON.parse(text), browserId}) + '\n';
 
   page.on('console', msg => {
     if (msg.type() === 'error' && !ignoreConsoleError) {
@@ -113,11 +115,11 @@ export async function setupLogging(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       Promise.all(msg.args().map(arg => arg.jsonValue())).then((args: any) => {
         const [logLine, ...values] = args;
-        const line = {time, ...parseBittorrentLog(logLine, ...values)};
+        const line = {time, browserId, ...parseBittorrentLog(logLine, ...values)};
         pinoLog.write(JSON.stringify(line) + '\n');
       });
     } else {
-      browserConsoleLog.write(`Browser ${ganacheAccountIndex} logged ${text}` + '\n');
+      browserConsoleLog.write(`Browser ${browserId} logged ${text}` + '\n');
     }
   });
 }

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -12,7 +12,8 @@ import {
   CHAIN_NETWORK_ID,
   LOG_DESTINATION,
   USING_EXTERNAL_CHAIN,
-  SHOW_DEVTOOLS
+  SHOW_DEVTOOLS,
+  DEBUG_FILTER
 } from './constants';
 import {ETHERLIME_ACCOUNTS} from '@statechannels/devtools';
 import {promisify} from 'util';
@@ -57,6 +58,12 @@ export async function setupLogging(
   page.on('pageerror', error => {
     throw error;
   });
+
+  if (DEBUG_FILTER) {
+    console.log(`Setting DEBUG filter for ${ganacheAccountIndex}`);
+    await page.goto('http://localhost:3000'); // Can be any page
+    await page.evaluate(`localStorage.setItem('debug', '${DEBUG_FILTER}')`);
+  }
 
   const filename = `${logPrefix}.${ganacheAccountIndex}`;
 

--- a/packages/e2e-tests/puppeteer/helpers.ts
+++ b/packages/e2e-tests/puppeteer/helpers.ts
@@ -115,7 +115,8 @@ export async function setupLogging(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       Promise.all(msg.args().map(arg => arg.jsonValue())).then((args: any) => {
         const [logLine, ...values] = args;
-        const line = {time, browserId, ...parseBittorrentLog(logLine, ...values)};
+        const TRACE = 10;
+        const line = {time, browserId, level: TRACE, ...parseBittorrentLog(logLine, ...values)};
         pinoLog.write(JSON.stringify(line) + '\n');
       });
     } else {

--- a/packages/e2e-tests/puppeteer/parseBittorrentProtocolLogs.ts
+++ b/packages/e2e-tests/puppeteer/parseBittorrentProtocolLogs.ts
@@ -1,0 +1,89 @@
+/**
+ // Example:
+ const first = '%cbittorrent-protocol %c[5e0cb699] handshake i=%s p=%s exts=%o%c +11s';
+ const args = [
+   'color: #9900CC',
+   'color: inherit',
+   '2045f638f8d12ad7d95c4876b2ebd851664e7579',
+   '2d5757303030372d31485472334634724c586b62',
+   {dht: false},
+   'color: #9900CC'
+ ];
+ parseBittorrentLog(first, ...args)
+ ```
+ {"time":1592443875126,"msg":"handshake +11s","name":"bittorrent-protocol","wireId":"5e0cb699","params":{"i":"2045f638f8d12ad7d95c4876b2ebd851664e7579","p":"2d5757303030372d31485472334634724c586b62","exts":{"dht":false}}}
+ ```
+*/
+export const parseBittorrentLog = (
+  logLine: string,
+  ...values: (string | object | number)[]
+): any => {
+  // Webtorrent uses debug.
+  // Debug makes calls to console.log with format arguments
+  // See
+  // https://github.com/webtorrent/bittorrent-protocol/blob/master/index.js#L4
+  // https://github.com/webtorrent/bittorrent-protocol/blob/master/index.js#L729-L732
+  // Examples:
+  // bittorrent-protocol [95adde64] new wire +0ms
+  // bittorrent-protocol [5e0cb699] handshake i=2045f638f8d12ad7d95c4876b2ebd851664e7579 p=2d5757303030372d31485472334634724c586b62 exts={dht: false} +11s
+
+  /**
+   * ----- Remove these things from the log line
+   * %s → Formats the value as a string
+   * %i or %d → Formats the value as an integer
+   * %f → Formats the value as a floating point value
+   * %o → Formats the value as an expandable DOM element. As seen in the Elements panel
+   * %O → Formats the value as an expandable JavaScript object
+   * %c → Applies CSS style rules to the output string as specified by the second parameter
+   */
+  let idx = -1;
+  const replacer = (match: '%s' | '%i' | '%d' | '%f' | '%o' | '%O' | '%c'): string => {
+    idx++;
+    switch (match) {
+      case '%c':
+        // Remove colours
+        return '';
+      case '%o':
+      case '%O':
+        // Serialize objects
+        return JSON.stringify(values[idx]);
+      case '%d':
+      case '%i':
+      case '%f':
+        // Convert numbers
+        return values[idx].toString();
+      case '%s':
+        // Replace strings
+        return values[idx] as string;
+    }
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const formatted = logLine.replace(/%(s|i|d|f|o|O|c)/g, replacer as any);
+
+  const [tag, id, ...rest] = formatted.split(' ');
+
+  // This is specific to bittorrent-protocol's use of debug:
+  // it uses key=val to log things like "index=3" or "ext={dht: true}"
+  const isParam = (item: string): boolean => item.includes('=');
+
+  const msg = rest.filter(s => !isParam(s)).join(' ');
+  const wireId = id.slice(1, id.length - 1);
+
+  const baseLog: Record<string, string | number> = {msg, name: tag, wireId};
+
+  return formatted
+    .split(' ')
+    .filter(isParam)
+    .reduce((result, param) => {
+      const [key, val] = param.split('=');
+      try {
+        // If it's an object, deserialize it
+        result[key] = JSON.parse(val);
+      } catch (e) {
+        // else it's a string
+        result[key] = val;
+      }
+
+      return result;
+    }, baseLog);
+};

--- a/packages/e2e-tests/puppeteer/parseBittorrentProtocolLogs.ts
+++ b/packages/e2e-tests/puppeteer/parseBittorrentProtocolLogs.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 /**
  // Example:
  const first = '%cbittorrent-protocol %c[5e0cb699] handshake i=%s p=%s exts=%o%c +11s';
@@ -57,7 +59,6 @@ export const parseBittorrentLog = (
         return values[idx] as string;
     }
   };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const formatted = logLine.replace(/%(s|i|d|f|o|O|c)/g, replacer as any);
 
   const [tag, id, ...rest] = formatted.split(' ');


### PR DESCRIPTION
This lets us know what's going on with wires.

I promised @kerzhner  I would look at some logs to see if wires were being dropped. There wasn't a way to see if wires were being dropped, so I decided to make those logs. Then I realized that webtorrent already logs lots of things, if you set `window.localStorage.debug = 'bittorrent-protocol'`, I just have to capture those and pino log them!


... this is what `debug` calls `console.log` with:
```
 [
   '%cbittorrent-protocol %c[5e0cb699] handshake i=%s p=%s exts=%o%c +11s',
   'color: #9900CC',
   'color: inherit',
   '2045f638f8d12ad7d95c4876b2ebd851664e7579',
   '2d5757303030372d31485472334634724c586b62',
   {dht: false},
   'color: #9900CC'
 ];
```

... after an hour, I managed to pino log it!
```
 {"time":1592443875126,"msg":"handshake +11s","name":"bittorrent-protocol","wireId":"5e0cb699","params":{"i":"2045f638f8d12ad7d95c4876b2ebd851664e7579","p":"2d5757303030372d31485472334634724c586b62","exts":{"dht":false}}}
```

... then I decided
> I probably shouldn't put this [parsing code](https://github.com/statechannels/monorepo/pull/2228/commits/09b6031ab6cdde8decc7664efa703553d03add92#diff-6c01f9ba873c01526dc284885db74e76) in web3torrent

... after a few hours, I managed to get the e2e tests to parse it!

```
{"time":1592450706183,"browserId":0,"level":10,"msg":"use +8ms","name":"bittorrent-protocol","wireId":"387b2f90","extension.name":"paidStreamingExtension"}
{"time":1592450706184,"browserId":0,"level":10,"msg":"setKeepAlive true +1ms","name":"bittorrent-protocol","wireId":"387b2f90"}
{"time":1592450706184,"browserId":0,"level":10,"msg":"setTimeout +1ms","name":"bittorrent-protocol","wireId":"387b2f90","ms":65000,"unref":"undefined"}
{"time":1592450706186,"browserId":0,"level":10,"msg":"extended +3ms","name":"bittorrent-protocol","wireId":"387b2f90","ext":0}
{"time":1592450706187,"browserId":0,"level":10,"msg":"bitfield +2ms","name":"bittorrent-protocol","wireId":"387b2f90"}
{"time":1592450706170,"browserId":0,"level":10,"msg":"got handshake +5ms","name":"bittorrent-protocol","wireId":"387b2f90","i":"76bfbfe85cd60ffb992945458de72c31a438cc3d","p":"2d5757303030372d584a4474576176724d775241","exts":{"dht":false,"extended":true}}
{"time":1592450706188,"browserId":0,"level":10,"msg":"got extended handshake +2ms","name":"bittorrent-protocol","wireId":"387b2f90"}
{"time":1592450706207,"browserId":0,"level":10,"msg":"extended +17ms","name":"bittorrent-protocol","wireId":"387b2f90","ext":"ut_metadata"}
{"time":1592450706207,"browserId":0,"level":10,"msg":"got extended message +1ms","name":"bittorrent-protocol","wireId":"387b2f90","ext":"ut_metadata"}
{"time":1592450706214,"browserId":0,"level":10,"msg":"got bitfield +8ms","name":"bittorrent-protocol","wireId":"387b2f90"}
{"time":1592450706219,"browserId":0,"level":10,"msg":"got interested +4ms","name":"bittorrent-protocol","wireId":"387b2f90"}
{"time":1592450706219,"browserId":0,"level":10,"msg":"unchoke +1ms","name":"bittorrent-protocol","wireId":"387b2f90"}
```

(pretty):
```
[1592450706183] TRACE (bittorrent-protocol): use +8ms
    browserId: 0
    wireId: "387b2f90"
    extension.name: "paidStreamingExtension"
[1592450706184] TRACE (bittorrent-protocol): setKeepAlive true +1ms
    browserId: 0
    wireId: "387b2f90"
[1592450706184] TRACE (bittorrent-protocol): setTimeout +1ms
    browserId: 0
    wireId: "387b2f90"
    ms: 65000
    unref: "undefined"
[1592450706186] TRACE (bittorrent-protocol): extended +3ms
    browserId: 0
    wireId: "387b2f90"
    ext: 0
[1592450706187] TRACE (bittorrent-protocol): bitfield +2ms
    browserId: 0
    wireId: "387b2f90"
[1592450706170] TRACE (bittorrent-protocol): got handshake +5ms
    browserId: 0
    wireId: "387b2f90"
    i: "76bfbfe85cd60ffb992945458de72c31a438cc3d"
    p: "2d5757303030372d584a4474576176724d775241"
    exts: {
      "dht": false,
      "extended": true
    }
[1592450706188] TRACE (bittorrent-protocol): got extended handshake +2ms
    browserId: 0
    wireId: "387b2f90"
[1592450706207] TRACE (bittorrent-protocol): extended +17ms
    browserId: 0
    wireId: "387b2f90"
    ext: "ut_metadata"
[1592450706207] TRACE (bittorrent-protocol): got extended message +1ms
    browserId: 0
    wireId: "387b2f90"
    ext: "ut_metadata"
[1592450706214] TRACE (bittorrent-protocol): got bitfield +8ms
    browserId: 0
    wireId: "387b2f90"
[1592450706219] TRACE (bittorrent-protocol): got interested +4ms
    browserId: 0
    wireId: "387b2f90"
[1592450706219] TRACE (bittorrent-protocol): unchoke +1ms
    browserId: 0
    wireId: "387b2f90"
```