### PR TITLE
Button emphasis

### DIFF
--- a/packages/web3torrent/src/pages/welcome/Welcome.scss
+++ b/packages/web3torrent/src/pages/welcome/Welcome.scss
@@ -58,7 +58,7 @@ div.subtitle {
   display: block;
   cursor: pointer;
   box-shadow: $c-orange;
-  animation: pulse 1.5s infinite;
+  animation: pulse 5s infinite;
 }
 .thick-border {
   border: 2px #ea692b solid;
@@ -75,7 +75,7 @@ div.subtitle {
     -webkit-box-shadow: 0 0 0 3px $c-orangealt;
   }
   100% {
-    -webkit-box-shadow: 0 0 0 0 $c-orangealt;
+    -webkit-box-shadow: 0 0 0 0 $c-orange;
   }
 }
 @keyframes pulse {
@@ -83,12 +83,24 @@ div.subtitle {
     -moz-box-shadow: 0 0 0 0 $c-orange;
     box-shadow: 0 0 0 0 $c-orange;
   }
-  70% {
+  5% {
     -moz-box-shadow: 0 0 0 3px $c-orangealt;
     box-shadow: 0 0 0 3px $c-orangealt;
   }
+  20% {
+    -moz-box-shadow: 0 0 0 0 $c-orange;
+    box-shadow: 0 0 0 0 $c-orange;
+  }
+  25% {
+    -moz-box-shadow: 0 0 0 3px $c-orangealt;
+    box-shadow: 0 0 0 3px $c-orangealt;
+  }
+  40% {
+    -moz-box-shadow: 0 0 0 0 $c-orange;
+    box-shadow: 0 0 0 0 $c-orange;
+  }
   100% {
-    -moz-box-shadow: 0 0 0 0 $c-orangealt;
-    box-shadow: 0 0 0 0 $c-orangealt;
+    -moz-box-shadow: 0 0 0 0 $c-orange;
+    box-shadow: 0 0 0 0 $c-orange;
   }
 }

--- a/packages/web3torrent/src/pages/welcome/Welcome.scss
+++ b/packages/web3torrent/src/pages/welcome/Welcome.scss
@@ -60,8 +60,8 @@ div.subtitle {
   box-shadow: $c-orange;
   animation: pulse 5s infinite;
 }
-.thick-border {
-  border: 2px #ea692b solid;
+.shadow {
+  box-shadow: 0 0 0 3px $c-orangealt;
 }
 .pulse:hover {
   animation: none;

--- a/packages/web3torrent/src/pages/welcome/Welcome.scss
+++ b/packages/web3torrent/src/pages/welcome/Welcome.scss
@@ -60,6 +60,9 @@ div.subtitle {
   box-shadow: $c-orange;
   animation: pulse 1.5s infinite;
 }
+.thick-border {
+  border: 2px #ea692b solid;
+}
 .pulse:hover {
   animation: none;
 }

--- a/packages/web3torrent/src/pages/welcome/Welcome.tsx
+++ b/packages/web3torrent/src/pages/welcome/Welcome.tsx
@@ -23,7 +23,7 @@ const Welcome: React.FC<Props> = () => {
         <p>
           <div className="actions-container">
             <FormButton
-              className="button pulse"
+              className="button thick-border"
               name="download"
               onClick={() => history.push(generateURL(preseededTorrentsUI[0]))}
             >

--- a/packages/web3torrent/src/pages/welcome/Welcome.tsx
+++ b/packages/web3torrent/src/pages/welcome/Welcome.tsx
@@ -23,7 +23,7 @@ const Welcome: React.FC<Props> = () => {
         <p>
           <div className="actions-container">
             <FormButton
-              className="button thick-border"
+              className="button pulse"
               name="download"
               onClick={() => history.push(generateURL(preseededTorrentsUI[0]))}
             >

--- a/packages/web3torrent/src/pages/welcome/Welcome.tsx
+++ b/packages/web3torrent/src/pages/welcome/Welcome.tsx
@@ -23,7 +23,7 @@ const Welcome: React.FC<Props> = () => {
         <p>
           <div className="actions-container">
             <FormButton
-              className="button pulse"
+              className="button shadow"
               name="download"
               onClick={() => history.push(generateURL(preseededTorrentsUI[0]))}
             >


### PR DESCRIPTION
~![Jun-18-2020 16-57-04](https://user-images.githubusercontent.com/1833419/85043844-c230d100-b184-11ea-80dd-ae948f20a350.gif)~


~Double pulse, 5 seconds of nothing, repeat.~

~Still seductive, but hopefully not _too_ seductive?~ Prefer box shadow option, below. 

Whatever we end up using here, we can roll out to other key moments in the user story. For example, I just finished the download: the "share link" button could pulse this way to nudge me into exploring that.