### PR TITLE
[simple-hub] reduce hub gas price from 1000 to 15 gwei

### DIFF
--- a/packages/simple-hub/src/blockchain/eth-asset-holder.ts
+++ b/packages/simple-hub/src/blockchain/eth-asset-holder.ts
@@ -58,7 +58,7 @@ async function fund(channelID: string, value: BigNumber): Promise<void> {
       expectedHeld.toHexString(),
       value,
       {
-        gasPrice: utils.parseUnits('1000', 'gwei'),
+        gasPrice: utils.parseUnits('15', 'gwei'),
         value: value.sub(expectedHeld)
       }
     );


### PR DESCRIPTION
Originally, we pushed gas price to 1000 gwei as a last resort to speed up Ropsten transactions. Now that production runs on Goerli, 15 gwei should be sufficient.

1000 gwei for a gas price results in the hub spending ~0.05 eth per deposit transaction, which drains the hub funds fairly quickly.