### PR TITLE
Add clean-build-folder step to devtools build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "patch-package": "6.2.0"
   },
   "devDependencies": {
-    "@statechannels/devtools": "0.1.3",
+    "@statechannels/devtools": "0.1.4",
     "@types/prettier": "1.19.0",
     "@types/wait-on": "4.0.0",
     "husky": "3.0.7",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -58,7 +58,8 @@
   "private": false,
   "repository": "statechannels/monorepo.git",
   "scripts": {
-    "build:typescript": "tsc -b",
+    "clean-build-folder": "rm -rf ./lib",
+    "build:typescript": "yarn run clean-build-folder && tsc -b",
     "lint:check": "eslint \"*/**/*.ts\" --cache",
     "lint:write": "eslint \"*/**/*.ts\" --fix",
     "precommit": "lint-staged --quiet",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@statechannels/devtools",
   "description": "Scripts used for our team development processes",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": "statechannels",
   "bin": {
     "start-shared-ganache": "lib/src/ganache/start-ganache-script.js"

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@statechannels/channel-provider": "*",
     "@statechannels/client-api-schema": "0.0.1",
-    "@statechannels/devtools": "0.1.3",
+    "@statechannels/devtools": "0.1.4",
     "@types/eslint": "6.1.7",
     "@types/eslint-plugin-prettier": "2.2.0",
     "@types/jest": "25.1.0",

--- a/packages/jest-gas-reporter/package.json
+++ b/packages/jest-gas-reporter/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.2",
   "author": "Alex Gap <alex@magmo.com>",
   "dependencies": {
-    "@statechannels/devtools": "0.1.3",
+    "@statechannels/devtools": "0.1.4",
     "easy-table": "1.1.1",
     "ethers": "4.0.45",
     "path": "0.12.7",

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -10,7 +10,7 @@
     "ethers": "4.0.45"
   },
   "devDependencies": {
-    "@statechannels/devtools": "0.1.3",
+    "@statechannels/devtools": "0.1.4",
     "@types/eslint": "6.1.7",
     "@types/eslint-plugin-prettier": "2.2.0",
     "@types/jest": "25.1.0",

--- a/packages/persistent-seeder/package.json
+++ b/packages/persistent-seeder/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@statechannels/channel-provider": "*",
     "@statechannels/client-api-schema": "0.0.1",
-    "@statechannels/devtools": "0.1.3",
+    "@statechannels/devtools": "0.1.4",
     "@types/eslint": "6.1.7",
     "@types/eslint-plugin-prettier": "2.2.0",
     "@types/node": "13.5.1",

--- a/packages/rps/package.json
+++ b/packages/rps/package.json
@@ -68,7 +68,7 @@
     "@babel/runtime": "7.8.3",
     "@statechannels/channel-provider": "*",
     "@statechannels/client-api-schema": "0.0.1",
-    "@statechannels/devtools": "0.1.3",
+    "@statechannels/devtools": "0.1.4",
     "@statechannels/jest-gas-reporter": "0.0.2",
     "@storybook/react": "5.3.9",
     "@types/autoprefixer": "9.6.1",

--- a/packages/tic-tac-toe/package.json
+++ b/packages/tic-tac-toe/package.json
@@ -52,7 +52,7 @@
     "@glimmer/component": "1.0.0",
     "@glimmer/tracking": "1.0.0",
     "@statechannels/client-api-schema": "0.0.1",
-    "@statechannels/devtools": "0.1.3",
+    "@statechannels/devtools": "0.1.4",
     "@statechannels/jest-gas-reporter": "0.0.2",
     "@types/autoprefixer": "9.6.1",
     "@types/babel__core": "7.1.7",

--- a/packages/web3torrent/package.json
+++ b/packages/web3torrent/package.json
@@ -20,7 +20,7 @@
     "@rimble/connection-banner": "1.2.3",
     "@sentry/browser": "5.15.5",
     "@statechannels/channel-client": "0.0.1",
-    "@statechannels/devtools": "0.1.3",
+    "@statechannels/devtools": "0.1.4",
     "@svgr/webpack": "4.3.2",
     "@typescript-eslint/eslint-plugin": "2.18.0",
     "@typescript-eslint/parser": "2.18.0",

--- a/packages/xstate-wallet/package.json
+++ b/packages/xstate-wallet/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.8.3",
-    "@statechannels/devtools": "0.1.3",
+    "@statechannels/devtools": "0.1.4",
     "@storybook/addon-actions": "5.3.9",
     "@storybook/addon-info": "5.3.9",
     "@storybook/addon-links": "5.3.9",


### PR DESCRIPTION
I think some stale files in the build folder resulted in a broken build 0.1.3

 (https://github.com/statechannels/nitro-tutorial/pull/1 -- evidence being I cleared the build folder, rebuilt, yarn linked and fixed the problem in this pull request). 

