### PR TITLE
Publish wallet-core and client-api-schema

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,10 +200,8 @@ jobs:
       - log_stats:
           file: prepare-stats
       - <<: *restore_dep
-      - <<: *restore_built_artifacts
       - run: yarn --frozen-lockfile
       - <<: *save_dep
-      - <<: *save_built_artifacts
 
       - persist_to_workspace:
           root: /home/circleci/project

--- a/packages/client-api-schema/package.json
+++ b/packages/client-api-schema/package.json
@@ -43,7 +43,7 @@
     "build:typescript": "tsc -b",
     "lint:check": "eslint \"src/**/*.ts\" --cache",
     "lint:write": "eslint \"src/**/*.ts\" --fix",
-    "prepare": "yarn build",
+    "prepare": "rm -rf lib; yarn build",
     "test": "jest",
     "test:ci": "yarn test --ci --runInBand"
   }

--- a/packages/client-api-schema/package.json
+++ b/packages/client-api-schema/package.json
@@ -21,8 +21,7 @@
     "ts-json-schema-generator": "0.60.0"
   },
   "files": [
-    "schema",
-    "types"
+    "lib/src"
   ],
   "keywords": [
     "client api",

--- a/packages/client-api-schema/tsconfig.json
+++ b/packages/client-api-schema/tsconfig.json
@@ -10,5 +10,6 @@
     "target": "es2015",
     "types": ["node", "jest"]
   },
-  "include": ["./src", "./src/generated-schema.json"]
+  "include": ["./src", "./src/generated-schema.json"],
+  "exclude": ["**/*.test.ts", "./src/__tests__"]
 }

--- a/packages/wallet-core/.eslintrc.js
+++ b/packages/wallet-core/.eslintrc.js
@@ -38,12 +38,7 @@ module.exports = {
     ...generalRules,
     ...leftoverTsLintRules,
 
-    'no-restricted-imports': [
-      'error',
-      {
-        patterns: ['**/lib/**', '**/src/**']
-      }
-    ],
+    'no-restricted-imports': ['error', {patterns: ['**/lib', '**/src']}],
     'arrow-body-style': 'error'
   },
 
@@ -51,16 +46,12 @@ module.exports = {
     // process.env allowed in tests
     {
       files: ['*.test.ts'],
-      rules: {
-        'no-process-env': 'off'
-      }
+      rules: {'no-process-env': 'off'}
     },
     // process.env allowed in src/config.js
     {
       files: ['src/config.ts'],
-      rules: {
-        'no-process-env': 'off'
-      }
+      rules: {'no-process-env': 'off'}
     }
   ]
 };

--- a/packages/wallet-core/package.json
+++ b/packages/wallet-core/package.json
@@ -27,7 +27,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "prepare": "yarn build",
+    "prepare": "rm -rf lib; yarn build",
     "build": "yarn tsc -b",
     "build:ci": "yarn build",
     "lint:check": "eslint . --ext .ts --cache",

--- a/packages/wallet-core/package.json
+++ b/packages/wallet-core/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.5",
   "author": "Alex Gap",
   "main": "lib/src/index.js",
+  "types": "lib/src/index.d.ts",
   "dependencies": {
     "@statechannels/nitro-protocol": "0.1.4",
     "@statechannels/wire-format": "0.0.4",

--- a/packages/wallet-core/package.json
+++ b/packages/wallet-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@statechannels/wallet-core",
   "description": "State channel wallet components.",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": "Alex Gap",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/wallet-core/package.json
+++ b/packages/wallet-core/package.json
@@ -6,7 +6,7 @@
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
   "files": [
-    "lib"
+    "lib/src"
   ],
   "dependencies": {
     "@statechannels/nitro-protocol": "0.1.4",

--- a/packages/wallet-core/package.json
+++ b/packages/wallet-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@statechannels/wallet-core",
   "description": "State channel wallet components.",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": "Alex Gap",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/wallet-core/package.json
+++ b/packages/wallet-core/package.json
@@ -5,6 +5,9 @@
   "author": "Alex Gap",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@statechannels/nitro-protocol": "0.1.4",
     "@statechannels/wire-format": "0.0.4",

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -1,5 +1,5 @@
 import {BigNumber} from 'ethers';
-import {FundingStrategy} from '@statechannels/client-api-schema/src';
+import {FundingStrategy} from '@statechannels/client-api-schema';
 
 export interface DomainBudget {
   domain: string;

--- a/packages/wallet-core/tsconfig.json
+++ b/packages/wallet-core/tsconfig.json
@@ -20,6 +20,7 @@
     "types": ["jest", "node"]
   },
   "include": ["./src"],
+  "exclude": ["**/*.test.ts"],
   "references": [
     {"path": "../nitro-protocol"},
     {"path": "../devtools"},

--- a/packages/xstate-wallet/.eslintrc.js
+++ b/packages/xstate-wallet/.eslintrc.js
@@ -38,7 +38,7 @@ module.exports = {
     ...generalRules,
     ...leftoverTsLintRules,
 
-    'no-restricted-imports': ['error', {patterns: ['**/lib/**', '**/src/**']}],
+    'no-restricted-imports': ['error', {patterns: ['**/lib', '**/src']}],
     'arrow-body-style': 'error',
     'import/order': [
       'error',

--- a/packages/xstate-wallet/package.json
+++ b/packages/xstate-wallet/package.json
@@ -26,7 +26,7 @@
     "@rimble/utils": "1.2.3",
     "@sentry/browser": "5.15.5",
     "@statechannels/client-api-schema": "0.0.1",
-    "@statechannels/wallet-core": "0.0.5",
+    "@statechannels/wallet-core": "0.0.7",
     "@statechannels/nitro-protocol": "0.1.4",
     "@statechannels/wire-format": "0.0.4",
     "@xstate/react": "1.0.0-rc.3",

--- a/packages/xstate-wallet/src/integration-tests/approve-budget.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/approve-budget.test.ts
@@ -2,7 +2,7 @@ import {filter, map, first} from 'rxjs/operators';
 import {FundLedger, assertSimpleEthAllocation} from '@statechannels/wallet-core';
 
 import {hexZeroPad} from '@ethersproject/bytes';
-import {ApproveBudgetAndFundResponse} from '@statechannels/client-api-schema/src';
+import {ApproveBudgetAndFundResponse} from '@statechannels/client-api-schema';
 import {BigNumber} from 'ethers';
 import {FakeChain} from '../chain';
 import {TEST_APP_DOMAIN} from '../workflows/tests/data';

--- a/packages/xstate-wallet/src/integration-tests/running.test.ts
+++ b/packages/xstate-wallet/src/integration-tests/running.test.ts
@@ -1,6 +1,6 @@
 import {simpleEthAllocation} from '@statechannels/wallet-core';
 import {BigNumber, constants} from 'ethers';
-import {ErrorResponse, ErrorCodes} from '@statechannels/client-api-schema/src';
+import {ErrorResponse, ErrorCodes} from '@statechannels/client-api-schema';
 import {FakeChain} from '../chain';
 import {CHAIN_NETWORK_ID} from '../config';
 import {Player, hookUpMessaging, generatePlayerUpdate} from './helpers';


### PR DESCRIPTION
This PR prepares the `wallet-core` package and `client-api-schema` package for publishing:
- updating their `package.json` files so that they publish the right things (up-to-date, compiled typescript files)
- updating their `tsconfig.json` files so that they compile the right things (no tests)

I've taken the liberty of publishing these two packages as of 2c7f551. You can explore the files that got published:
- https://www.npmjs.com/package/@statechannels/wallet-core
- https://www.npmjs.com/package/@statechannels/client-api-schema
(The "Explore" tab will let you browse the files.)