### PR TITLE
Add BigNumber utility class

### DIFF
--- a/packages/wallet-core/package.json
+++ b/packages/wallet-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@statechannels/wallet-core",
   "description": "State channel wallet components.",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "author": "Alex Gap",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/wallet-core/src/bignumber.ts
+++ b/packages/wallet-core/src/bignumber.ts
@@ -3,7 +3,10 @@ import {Uint256} from './types';
 
 type T = BigNumberish;
 
-const binaryOperator = (name: keyof EthersBigNumber) => (a: T, b: T): Uint256 => {
+const binaryOperator = <S extends any = Uint256>(name: keyof EthersBigNumber) => (
+  a: T,
+  b: T
+): S => {
   if (typeof EthersBigNumber.from(a)[name] !== 'function') throw Error(`Invalid method ${name}`);
 
   const result = (EthersBigNumber.from(a)[name] as any)(b);
@@ -28,11 +31,11 @@ const unaryOperator = <S extends any = Uint256>(name: keyof EthersBigNumber) => 
  */
 
 export class BN {
-  static eq = binaryOperator('eq');
-  static lt = binaryOperator('lt');
-  static gt = binaryOperator('gt');
-  static lte = binaryOperator('lte');
-  static gte = binaryOperator('gte');
+  static eq = binaryOperator<boolean>('eq');
+  static lt = binaryOperator<boolean>('lt');
+  static gt = binaryOperator<boolean>('gt');
+  static lte = binaryOperator<boolean>('lte');
+  static gte = binaryOperator<boolean>('gte');
   static add = binaryOperator('add');
   static sub = binaryOperator('sub');
   static mul = binaryOperator('mul');

--- a/packages/wallet-core/src/bignumber.ts
+++ b/packages/wallet-core/src/bignumber.ts
@@ -1,0 +1,52 @@
+import {BigNumber as EthersBigNumber, BigNumberish} from 'ethers';
+import {Uint256} from './types';
+
+type T = BigNumberish;
+
+const binaryOperator = (name: keyof EthersBigNumber) => (a: T, b: T): Uint256 => {
+  if (typeof EthersBigNumber.from(a)[name] !== 'function') throw Error(`Invalid method ${name}`);
+
+  const result = (EthersBigNumber.from(a)[name] as any)(b);
+
+  return EthersBigNumber.isBigNumber(result) ? result.toHexString() : result;
+};
+
+const unaryOperator = <S extends any = Uint256>(name: keyof EthersBigNumber) => (a: T): S => {
+  if (typeof EthersBigNumber.from(a)[name] !== 'function') throw Error(`Invalid method ${name}`);
+
+  const result = (EthersBigNumber.from(a)[name] as any)();
+  return EthersBigNumber.isBigNumber(result) ? result.toHexString() : result;
+};
+
+/**
+ * This is a convenience class that looks like instances of ether's BigNumber class.
+ * This way, people can call
+ * ```
+ * BN.eq(2, '3') // false
+ * BN.add('0x123', 4) // '0x661'
+ * BN.add('0xabc', 10) // '0xac6'
+ */
+
+export class BigNumber {
+  static eq = binaryOperator('eq');
+  static lt = binaryOperator('lt');
+  static gt = binaryOperator('gt');
+  static lte = binaryOperator('lte');
+  static gte = binaryOperator('gte');
+  static add = binaryOperator('add');
+  static sub = binaryOperator('sub');
+  static mul = binaryOperator('mul');
+  static div = binaryOperator('div');
+  static mod = binaryOperator('mod');
+  static pow = binaryOperator('pow');
+  static abs = unaryOperator('abs');
+  static isNegative = unaryOperator<boolean>('isNegative');
+  static isZero = unaryOperator<boolean>('isZero');
+  static toNumber = unaryOperator<number>('toNumber');
+  static toHexString = unaryOperator('toHexString');
+
+  static from = (n: BigNumberish): Uint256 => EthersBigNumber.from(n).toHexString() as Uint256;
+  static isBigNumber = val => typeof val === 'string' && !!val.match(/^0x[0-9A-Fa-f]{0,64}$/);
+}
+
+export const Zero = BigNumber.from(0);

--- a/packages/wallet-core/src/bignumber.ts
+++ b/packages/wallet-core/src/bignumber.ts
@@ -27,7 +27,7 @@ const unaryOperator = <S extends any = Uint256>(name: keyof EthersBigNumber) => 
  * BN.add('0xabc', 10) // '0xac6'
  */
 
-export class BigNumber {
+export class BN {
   static eq = binaryOperator('eq');
   static lt = binaryOperator('lt');
   static gt = binaryOperator('gt');
@@ -49,4 +49,4 @@ export class BigNumber {
   static isBigNumber = val => typeof val === 'string' && !!val.match(/^0x[0-9A-Fa-f]{0,64}$/);
 }
 
-export const Zero = BigNumber.from(0);
+export const Zero = BN.from(0);

--- a/packages/wallet-core/src/index.ts
+++ b/packages/wallet-core/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './state-utils';
 export * from './utils';
+export * from './bignumber';

--- a/packages/wallet-core/src/serde/app-messages/deserialize.ts
+++ b/packages/wallet-core/src/serde/app-messages/deserialize.ts
@@ -7,7 +7,7 @@ import {
 } from '@statechannels/client-api-schema';
 import {Allocation, AllocationItem, SimpleAllocation, DomainBudget, AssetBudget} from '../../types';
 import {ETH_ASSET_HOLDER_ADDRESS} from '../../config';
-import {BigNumber} from 'ethers';
+import {BigNumber} from '../../bignumber';
 import {AddressZero} from '@ethersproject/constants';
 import {makeDestination, assetHolderAddress} from '../../utils';
 

--- a/packages/wallet-core/src/serde/app-messages/deserialize.ts
+++ b/packages/wallet-core/src/serde/app-messages/deserialize.ts
@@ -7,7 +7,7 @@ import {
 } from '@statechannels/client-api-schema';
 import {Allocation, AllocationItem, SimpleAllocation, DomainBudget, AssetBudget} from '../../types';
 import {ETH_ASSET_HOLDER_ADDRESS} from '../../config';
-import {BigNumber} from '../../bignumber';
+import {BN} from '../../bignumber';
 import {AddressZero} from '@ethersproject/constants';
 import {makeDestination, assetHolderAddress} from '../../utils';
 
@@ -17,8 +17,8 @@ export function deserializeBudgetRequest(
 ): DomainBudget {
   const assetBudget: AssetBudget = {
     assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS,
-    availableSendCapacity: BigNumber.from(budgetRequest.requestedSendCapacity),
-    availableReceiveCapacity: BigNumber.from(budgetRequest.requestedReceiveCapacity),
+    availableSendCapacity: BN.from(budgetRequest.requestedSendCapacity),
+    availableReceiveCapacity: BN.from(budgetRequest.requestedReceiveCapacity),
     channels: {}
   };
   return {
@@ -31,10 +31,10 @@ export function deserializeBudgetRequest(
 export function deserializeDomainBudget(DomainBudget: AppDomainBudget): DomainBudget {
   const assetBudgets: AssetBudget[] = DomainBudget.budgets.map(b => ({
     assetHolderAddress: assetHolderAddress(b.token) || AddressZero,
-    availableReceiveCapacity: BigNumber.from(b.availableReceiveCapacity),
-    availableSendCapacity: BigNumber.from(b.availableSendCapacity),
+    availableReceiveCapacity: BN.from(b.availableReceiveCapacity),
+    availableSendCapacity: BN.from(b.availableSendCapacity),
     channels: b.channels.reduce((record, item) => {
-      record[item.channelId] = {amount: BigNumber.from(item.amount)};
+      record[item.channelId] = {amount: BN.from(item.amount)};
       return record;
     }, {})
   }));
@@ -80,6 +80,6 @@ function deserializeAllocation(allocation: AppAllocation): SimpleAllocation {
 function deserializeAllocationItem(allocationItem: AppAllocationItem): AllocationItem {
   return {
     destination: makeDestination(allocationItem.destination),
-    amount: BigNumber.from(allocationItem.amount)
+    amount: BN.from(allocationItem.amount)
   };
 }

--- a/packages/wallet-core/src/serde/app-messages/example.ts
+++ b/packages/wallet-core/src/serde/app-messages/example.ts
@@ -4,7 +4,7 @@ import {hexZeroPad} from '@ethersproject/bytes';
 import {ETH_ASSET_HOLDER_ADDRESS} from '../../config';
 import {makeDestination} from '../../utils';
 import {ETH_TOKEN} from '../../constants';
-import {BigNumber} from '../../bignumber';
+import {BN} from '../../bignumber';
 
 export const externalEthAllocation: Allocations = [
   {
@@ -29,11 +29,11 @@ export const internalEthAllocation: SimpleAllocation = {
   assetHolderAddress: ETH_ASSET_HOLDER_ADDRESS,
   allocationItems: [
     {
-      amount: BigNumber.from(hexZeroPad('0x5', 32)),
+      amount: BN.from(hexZeroPad('0x5', 32)),
       destination: makeDestination('0xA5C9d076B3FC5910d67b073CBF75C4e13a5AC6E5')
     },
     {
-      amount: BigNumber.from(hexZeroPad('0x5', 32)),
+      amount: BN.from(hexZeroPad('0x5', 32)),
       destination: makeDestination('0xBAF5D86514365D487ea69B7D7c85913E5dF51648')
     }
   ],
@@ -69,11 +69,11 @@ export const internalMixedAllocation: MixedAllocation = {
       assetHolderAddress: '0x1111111111111111111111111111111111111111',
       allocationItems: [
         {
-          amount: BigNumber.from(hexZeroPad('0x1', 32)),
+          amount: BN.from(hexZeroPad('0x1', 32)),
           destination: makeDestination('0xA5C9d076B3FC5910d67b073CBF75C4e13a5AC6E5')
         },
         {
-          amount: BigNumber.from(hexZeroPad('0x1', 32)),
+          amount: BN.from(hexZeroPad('0x1', 32)),
           destination: makeDestination('0xBAF5D86514365D487ea69B7D7c85913E5dF51648')
         }
       ]

--- a/packages/wallet-core/src/serde/app-messages/example.ts
+++ b/packages/wallet-core/src/serde/app-messages/example.ts
@@ -4,7 +4,7 @@ import {hexZeroPad} from '@ethersproject/bytes';
 import {ETH_ASSET_HOLDER_ADDRESS} from '../../config';
 import {makeDestination} from '../../utils';
 import {ETH_TOKEN} from '../../constants';
-import {BigNumber} from 'ethers';
+import {BigNumber} from '../../bignumber';
 
 export const externalEthAllocation: Allocations = [
   {

--- a/packages/wallet-core/src/serde/app-messages/serialize.ts
+++ b/packages/wallet-core/src/serde/app-messages/serialize.ts
@@ -20,14 +20,14 @@ import {
 
 import {AddressZero} from '@ethersproject/constants';
 import {checkThat, exists, formatAmount, tokenAddress} from '../../utils';
-import {BigNumber} from '../../bignumber';
+import {BN} from '../../bignumber';
 
 export function serializeDomainBudget(budget: DomainBudget): AppDomainBudget {
   const budgets: TokenBudget[] = Object.keys(budget.forAsset).map(assetHolderAddress => {
     const assetBudget = checkThat<AssetBudget>(budget.forAsset[assetHolderAddress], exists);
     const channels = Object.keys(assetBudget.channels).map(channelId => ({
       channelId,
-      amount: formatAmount(BigNumber.from(assetBudget.channels[channelId].amount))
+      amount: formatAmount(BN.from(assetBudget.channels[channelId].amount))
     }));
     return {
       token: tokenAddress(assetHolderAddress) || AddressZero,

--- a/packages/wallet-core/src/serde/app-messages/serialize.ts
+++ b/packages/wallet-core/src/serde/app-messages/serialize.ts
@@ -20,7 +20,7 @@ import {
 
 import {AddressZero} from '@ethersproject/constants';
 import {checkThat, exists, formatAmount, tokenAddress} from '../../utils';
-import {BigNumber} from 'ethers';
+import {BigNumber} from '../../bignumber';
 
 export function serializeDomainBudget(budget: DomainBudget): AppDomainBudget {
   const budgets: TokenBudget[] = Object.keys(budget.forAsset).map(assetHolderAddress => {

--- a/packages/wallet-core/src/serde/wire-format/deserialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/deserialize.ts
@@ -17,7 +17,7 @@ import {
   Objective,
   Participant
 } from '../../types';
-import {BigNumber} from 'ethers';
+import {BigNumber} from '../../bignumber';
 import {makeDestination} from '../../utils';
 import {getSignerAddress} from '../../state-utils';
 

--- a/packages/wallet-core/src/serde/wire-format/deserialize.ts
+++ b/packages/wallet-core/src/serde/wire-format/deserialize.ts
@@ -17,7 +17,7 @@ import {
   Objective,
   Participant
 } from '../../types';
-import {BigNumber} from '../../bignumber';
+import {BN} from '../../bignumber';
 import {makeDestination} from '../../utils';
 import {getSignerAddress} from '../../state-utils';
 
@@ -109,5 +109,5 @@ function deserializeAllocation(allocation: AllocationWire): SimpleAllocation {
 
 function deserializeAllocationItem(allocationItem: AllocationItemWire): AllocationItem {
   const {amount, destination} = allocationItem;
-  return {destination: makeDestination(destination), amount: BigNumber.from(amount)};
+  return {destination: makeDestination(destination), amount: BN.from(amount)};
 }

--- a/packages/wallet-core/src/serde/wire-format/example.ts
+++ b/packages/wallet-core/src/serde/wire-format/example.ts
@@ -1,4 +1,4 @@
-import {BigNumber} from 'ethers';
+import {BigNumber} from '../../bignumber';
 import {Message, SignedState} from '../../types';
 import {Message as WireMessage, SignedState as WireState} from '@statechannels/wire-format';
 import {makeDestination} from '../../utils';

--- a/packages/wallet-core/src/serde/wire-format/example.ts
+++ b/packages/wallet-core/src/serde/wire-format/example.ts
@@ -1,4 +1,4 @@
-import {BigNumber} from '../../bignumber';
+import {BN} from '../../bignumber';
 import {Message, SignedState} from '../../types';
 import {Message as WireMessage, SignedState as WireState} from '@statechannels/wire-format';
 import {makeDestination} from '../../utils';
@@ -85,17 +85,13 @@ export const internalStateFormat: SignedState = {
     assetHolderAddress: '0x4ad3F07BEFDC54511449A1f553E36A653c82eA57',
     allocationItems: [
       {
-        amount: BigNumber.from(
-          '0x00000000000000000000000000000000000000000000000006f05b59d3b20000'
-        ),
+        amount: BN.from('0x00000000000000000000000000000000000000000000000006f05b59d3b20000'),
         destination: makeDestination(
           '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7'
         )
       },
       {
-        amount: BigNumber.from(
-          '0x00000000000000000000000000000000000000000000000006f05b59d3b20000'
-        ),
+        amount: BN.from('0x00000000000000000000000000000000000000000000000006f05b59d3b20000'),
         destination: makeDestination(
           '0x00000000000000000000000063e3fb11830c01ac7c9c64091c14bb6cbaac9ac7'
         )

--- a/packages/wallet-core/src/state-utils.ts
+++ b/packages/wallet-core/src/state-utils.ts
@@ -23,7 +23,7 @@ import {
 import {joinSignature, splitSignature} from '@ethersproject/bytes';
 import _ from 'lodash';
 import {Wallet} from 'ethers';
-import {BigNumber} from './bignumber';
+import {BN} from './bignumber';
 
 function toNitroState(state: State): NitroState {
   const {channelNonce, participants, chainId} = state;
@@ -105,7 +105,7 @@ function simpleAllocationsEqual(left: SimpleAllocation, right: SimpleAllocation)
       left.allocationItems,
       (value, index) =>
         value.destination === right.allocationItems[index].destination &&
-        BigNumber.eq(value.amount, right.allocationItems[index].amount)
+        BN.eq(value.amount, right.allocationItems[index].amount)
     )
   );
 }
@@ -154,7 +154,7 @@ function convertToNitroAllocationItems(allocationItems: AllocationItem[]): Nitro
 
 function convertFromNitroAllocationItems(allocationItems: NitroAllocationItem[]): AllocationItem[] {
   return allocationItems.map(a => ({
-    amount: BigNumber.from(a.amount),
+    amount: BN.from(a.amount),
     destination:
       a.destination.substr(2, 22) === '00000000000000000000'
         ? (convertBytes32ToAddress(a.destination) as Destination)

--- a/packages/wallet-core/src/state-utils.ts
+++ b/packages/wallet-core/src/state-utils.ts
@@ -22,7 +22,8 @@ import {
 } from '@statechannels/nitro-protocol';
 import {joinSignature, splitSignature} from '@ethersproject/bytes';
 import _ from 'lodash';
-import {Wallet, BigNumber} from 'ethers';
+import {Wallet} from 'ethers';
+import {BigNumber} from './bignumber';
 
 function toNitroState(state: State): NitroState {
   const {channelNonce, participants, chainId} = state;
@@ -104,7 +105,7 @@ function simpleAllocationsEqual(left: SimpleAllocation, right: SimpleAllocation)
       left.allocationItems,
       (value, index) =>
         value.destination === right.allocationItems[index].destination &&
-        value.amount.eq(right.allocationItems[index].amount)
+        BigNumber.eq(value.amount, right.allocationItems[index].amount)
     )
   );
 }
@@ -145,7 +146,7 @@ export const firstState = (
 
 function convertToNitroAllocationItems(allocationItems: AllocationItem[]): NitroAllocationItem[] {
   return allocationItems.map(a => ({
-    amount: a.amount.toHexString(),
+    amount: a.amount,
     destination:
       a.destination.length === 42 ? convertAddressToBytes32(a.destination) : a.destination
   }));

--- a/packages/wallet-core/src/tests/outcomes-equal.test.ts
+++ b/packages/wallet-core/src/tests/outcomes-equal.test.ts
@@ -1,18 +1,18 @@
 import {outcomesEqual} from '../state-utils';
 import {SimpleAllocation, Destination} from '../types';
 import {AddressZero, HashZero} from '@ethersproject/constants';
-import {BigNumber} from '../bignumber';
+import {BN} from '../bignumber';
 
 const simpleAllocation1: SimpleAllocation = {
   type: 'SimpleAllocation',
   assetHolderAddress: AddressZero,
-  allocationItems: [{destination: HashZero as Destination, amount: BigNumber.from('0x2')}]
+  allocationItems: [{destination: HashZero as Destination, amount: BN.from('0x2')}]
 };
 
 const simpleAllocation2: SimpleAllocation = {
   type: 'SimpleAllocation',
   assetHolderAddress: AddressZero,
-  allocationItems: [{destination: HashZero as Destination, amount: BigNumber.from('0x02')}]
+  allocationItems: [{destination: HashZero as Destination, amount: BN.from('0x02')}]
 };
 
 describe('outcomesEqual', () => {

--- a/packages/wallet-core/src/tests/outcomes-equal.test.ts
+++ b/packages/wallet-core/src/tests/outcomes-equal.test.ts
@@ -1,7 +1,7 @@
 import {outcomesEqual} from '../state-utils';
 import {SimpleAllocation, Destination} from '../types';
 import {AddressZero, HashZero} from '@ethersproject/constants';
-import {BigNumber} from 'ethers';
+import {BigNumber} from '../bignumber';
 
 const simpleAllocation1: SimpleAllocation = {
   type: 'SimpleAllocation',

--- a/packages/wallet-core/src/types.ts
+++ b/packages/wallet-core/src/types.ts
@@ -1,5 +1,10 @@
-import {BigNumber} from 'ethers';
 import {FundingStrategy} from '@statechannels/client-api-schema';
+
+export type Uint256 = string & {_isUint256: void};
+// These "integers" have "type-safe" addition:
+// const a: Uint256 = '0xa' as Uint256;
+// const b: Uint256 = '0xb' as Uint256;
+// const s: Uint256 = a + b; // Type error: Type 'string' is not assignable to type 'Uint256'
 
 export interface DomainBudget {
   domain: string;
@@ -8,12 +13,12 @@ export interface DomainBudget {
 }
 
 interface ChannelBudgetEntry {
-  amount: BigNumber;
+  amount: Uint256;
 }
 export interface AssetBudget {
   assetHolderAddress: string;
-  availableReceiveCapacity: BigNumber;
-  availableSendCapacity: BigNumber;
+  availableReceiveCapacity: Uint256;
+  availableSendCapacity: Uint256;
   channels: Record<string, ChannelBudgetEntry>;
 }
 export interface Participant {
@@ -33,7 +38,7 @@ export type StateVariablesWithHash = StateVariables & Hashed;
 export type Destination = string & {_isDestination: void};
 export interface AllocationItem {
   destination: Destination;
-  amount: BigNumber;
+  amount: Uint256;
 }
 export interface SimpleAllocation {
   type: 'SimpleAllocation';
@@ -69,10 +74,10 @@ export interface ChannelConstants {
 
 export interface State extends ChannelConstants, StateVariables {}
 
-interface Signed {
+export interface Signed {
   signatures: SignatureEntry[];
 }
-interface Hashed {
+export interface Hashed {
   stateHash: string;
 }
 export type SignedState = State & Signed;

--- a/packages/wallet-core/src/utils/allocate-to-target.test.ts
+++ b/packages/wallet-core/src/utils/allocate-to-target.test.ts
@@ -1,4 +1,4 @@
-import {BigNumber} from '../bignumber';
+import {BN} from '../bignumber';
 
 import {AllocationItem} from '../types';
 
@@ -10,9 +10,9 @@ import {
   makeDestination
 } from '.';
 
-const one = BigNumber.from(1);
-const two = BigNumber.from(2);
-const three = BigNumber.from(3);
+const one = BN.from(1);
+const two = BN.from(2);
+const three = BN.from(3);
 
 const left = makeDestination('0x0000000000000000000000000000000000000001');
 const right = makeDestination('0x0000000000000000000000000000000000000002');

--- a/packages/wallet-core/src/utils/allocate-to-target.test.ts
+++ b/packages/wallet-core/src/utils/allocate-to-target.test.ts
@@ -1,4 +1,4 @@
-import {BigNumber} from 'ethers';
+import {BigNumber} from '../bignumber';
 
 import {AllocationItem} from '../types';
 

--- a/packages/wallet-core/src/utils/contract-utils.ts
+++ b/packages/wallet-core/src/utils/contract-utils.ts
@@ -1,11 +1,9 @@
-
-import {ETH_ASSET_HOLDER_ADDRESS, } from '../config';
+import {ETH_ASSET_HOLDER_ADDRESS} from '../config';
 import {MOCK_TOKEN, MOCK_ASSET_HOLDER_ADDRESS, ETH_TOKEN} from '../constants';
-import {BigNumber, } from 'ethers';
-
+import {BigNumber} from '../bignumber';
 
 export function assetHolderAddress(tokenAddress: string): string | undefined {
-  if (BigNumber.from(tokenAddress).isZero()) return ETH_ASSET_HOLDER_ADDRESS;
+  if (BigNumber.isZero(tokenAddress)) return ETH_ASSET_HOLDER_ADDRESS;
   else if (tokenAddress === MOCK_TOKEN) return MOCK_ASSET_HOLDER_ADDRESS;
 
   throw 'AssetHolderAddress not found';
@@ -17,4 +15,3 @@ export function tokenAddress(assetHolderAddress: string): string | undefined {
 
   throw 'TokenAddress not found';
 }
-

--- a/packages/wallet-core/src/utils/contract-utils.ts
+++ b/packages/wallet-core/src/utils/contract-utils.ts
@@ -1,9 +1,9 @@
 import {ETH_ASSET_HOLDER_ADDRESS} from '../config';
 import {MOCK_TOKEN, MOCK_ASSET_HOLDER_ADDRESS, ETH_TOKEN} from '../constants';
-import {BigNumber} from '../bignumber';
+import {BN} from '../bignumber';
 
 export function assetHolderAddress(tokenAddress: string): string | undefined {
-  if (BigNumber.isZero(tokenAddress)) return ETH_ASSET_HOLDER_ADDRESS;
+  if (BN.isZero(tokenAddress)) return ETH_ASSET_HOLDER_ADDRESS;
   else if (tokenAddress === MOCK_TOKEN) return MOCK_ASSET_HOLDER_ADDRESS;
 
   throw 'AssetHolderAddress not found';

--- a/packages/wallet-core/src/utils/helpers.ts
+++ b/packages/wallet-core/src/utils/helpers.ts
@@ -1,5 +1,6 @@
 import {hexZeroPad} from '@ethersproject/bytes';
-import {BigNumber} from 'ethers';
+import {BigNumber} from '../bignumber';
+import {Uint256} from '../types';
 export function unreachable(x: never) {
   return x;
 }
@@ -23,8 +24,8 @@ export function createDestination(address: string): string {
   return hexZeroPad(address, 32);
 }
 
-export function formatAmount(amount: BigNumber): string {
-  return hexZeroPad(BigNumber.from(amount).toHexString(), 32);
+export function formatAmount(amount: Uint256): Uint256 {
+  return hexZeroPad(BigNumber.from(amount), 32) as Uint256;
 }
 
 export function arrayToRecord<T, K extends keyof T>(

--- a/packages/wallet-core/src/utils/helpers.ts
+++ b/packages/wallet-core/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 import {hexZeroPad} from '@ethersproject/bytes';
-import {BigNumber} from '../bignumber';
+import {BN} from '../bignumber';
 import {Uint256} from '../types';
 export function unreachable(x: never) {
   return x;
@@ -25,7 +25,7 @@ export function createDestination(address: string): string {
 }
 
 export function formatAmount(amount: Uint256): Uint256 {
-  return hexZeroPad(BigNumber.from(amount), 32) as Uint256;
+  return hexZeroPad(BN.from(amount), 32) as Uint256;
 }
 
 export function arrayToRecord<T, K extends keyof T>(

--- a/packages/wallet-core/src/utils/index.ts
+++ b/packages/wallet-core/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from './outcome';
 export * from './budget-utils';
 export * from './contract-utils';
 export * from './math-utils';
+export * from './messages';

--- a/packages/wallet-core/src/utils/messages.ts
+++ b/packages/wallet-core/src/utils/messages.ts
@@ -1,0 +1,13 @@
+import {Participant} from '../types';
+import {makeDestination} from '.';
+
+export function convertToParticipant(participant: {
+  destination: string;
+  signingAddress: string;
+  participantId: string;
+}): Participant {
+  return {
+    ...participant,
+    destination: makeDestination(participant.destination)
+  };
+}

--- a/packages/wallet-core/src/utils/outcome.ts
+++ b/packages/wallet-core/src/utils/outcome.ts
@@ -10,7 +10,7 @@ import {ETH_ASSET_HOLDER_ADDRESS} from '../config';
 import _ from 'lodash';
 import {ethers} from 'ethers';
 import {checkThat} from './helpers';
-import {BigNumber, Zero} from '../bignumber';
+import {BN, Zero} from '../bignumber';
 
 export function isSimpleEthAllocation(outcome: Outcome): outcome is SimpleAllocation {
   return (
@@ -73,14 +73,14 @@ export function allocateToTarget(
       throw new Error(Errors.DestinationMissing);
     }
 
-    total = BigNumber.add(total, targetItem.amount);
-    ledgerItem.amount = BigNumber.sub(ledgerItem.amount, targetItem.amount);
+    total = BN.add(total, targetItem.amount);
+    ledgerItem.amount = BN.sub(ledgerItem.amount, targetItem.amount);
 
-    if (BigNumber.lt(ledgerItem.amount, 0)) throw new Error(Errors.InsufficientFunds);
+    if (BN.lt(ledgerItem.amount, 0)) throw new Error(Errors.InsufficientFunds);
   });
 
   currentItems.push({destination: makeDestination(targetChannelId), amount: total});
-  currentItems = currentItems.filter(i => BigNumber.gt(i.amount, 0));
+  currentItems = currentItems.filter(i => BN.gt(i.amount, 0));
 
   currentOutcome.allocationItems = currentItems;
   return currentOutcome;

--- a/packages/wallet-core/src/utils/outcome.ts
+++ b/packages/wallet-core/src/utils/outcome.ts
@@ -9,8 +9,8 @@ import {
 import {ETH_ASSET_HOLDER_ADDRESS} from '../config';
 import _ from 'lodash';
 import {ethers} from 'ethers';
-import {Zero} from '@ethersproject/constants';
 import {checkThat} from './helpers';
+import {BigNumber, Zero} from '../bignumber';
 
 export function isSimpleEthAllocation(outcome: Outcome): outcome is SimpleAllocation {
   return (
@@ -73,14 +73,14 @@ export function allocateToTarget(
       throw new Error(Errors.DestinationMissing);
     }
 
-    total = total.add(targetItem.amount);
-    ledgerItem.amount = ledgerItem.amount.sub(targetItem.amount);
+    total = BigNumber.add(total, targetItem.amount);
+    ledgerItem.amount = BigNumber.sub(ledgerItem.amount, targetItem.amount);
 
-    if (ledgerItem.amount.lt(0)) throw new Error(Errors.InsufficientFunds);
+    if (BigNumber.lt(ledgerItem.amount, 0)) throw new Error(Errors.InsufficientFunds);
   });
 
   currentItems.push({destination: makeDestination(targetChannelId), amount: total});
-  currentItems = currentItems.filter(i => i.amount.gt(0));
+  currentItems = currentItems.filter(i => BigNumber.gt(i.amount, 0));
 
   currentOutcome.allocationItems = currentItems;
   return currentOutcome;


### PR DESCRIPTION
Amounts cannot be safely stored in a Javascript number.

There is some contention over whether amounts should be stored in a string, or in a BigNumber class. Things
like storing and fetching amounts from the database, and serializing and deserializing are more complicated
with BigNumber classes. Constructing test data requires constantly importing BigNumber, and calling
`BigNumber.from(1)`, etc.

These problems are certainly not impossible to overcome, but they do add complexity, and can possibly add
bugs. Furthermore, saying that the type of an amount is BigNumber means your project has to commit to
using ethers, which is opinionated. Storing big numbers in string Javascript values is less opinionated.

This changeset is quite small, even after adding the (somewhat opinionated) Uint256 type.

Strings are not assignable to Uint256. The programmer must assert that strings are of type Uint256.
I claim that this is less mental overhead than importing BigNumber from ethers, than calling
`BigNumber.from(1)` If preferred, you may import BigNumber from `'./bignumber'`, and call
`BigNumber.from(1)` -- it will return a value of type `Uint256`.

