### PR TITLE
[nitro-docs] Clarify note 

### DIFF
--- a/packages/nitro-protocol/docs/dapp-devs/quick-start.md
+++ b/packages/nitro-protocol/docs/dapp-devs/quick-start.md
@@ -42,5 +42,5 @@ contract CountingApp is ForceMoveApp {
 Other examples exist: such as games of [Rock Paper Scissors](https://github.com/statechannels/monorepo/blob/master/packages/rps/contracts/RockPaperScissors.sol) and [Tic Tac Toe](https://github.com/magmo/apps/blob/master/packages/tictactoe/contracts/TicTacToeGame.sol).
 
 :::note
-The linked examples conform to a legacy ForceMoveApp interface.
+The Tic Tac Toe example conforms to a legacy ForceMoveApp interface.
 :::

--- a/packages/nitro-protocol/docs/dapp-devs/quick-start.md
+++ b/packages/nitro-protocol/docs/dapp-devs/quick-start.md
@@ -39,8 +39,4 @@ contract CountingApp is ForceMoveApp {
 }
 ```
 
-Other examples exist: such as games of [Rock Paper Scissors](https://github.com/statechannels/monorepo/blob/master/packages/rps/contracts/RockPaperScissors.sol) and [Tic Tac Toe](https://github.com/magmo/apps/blob/master/packages/tictactoe/contracts/TicTacToeGame.sol).
-
-:::note
-The Tic Tac Toe example conforms to a legacy ForceMoveApp interface.
-:::
+Other examples exist: such as games of [Rock Paper Scissors](https://github.com/statechannels/monorepo/blob/master/packages/rps/contracts/RockPaperScissors.sol) and [Tic Tac Toe](https://github.com/statechannels/monorepo/blob/master/packages/tic-tac-toe/contracts/TicTacToe.sol).


### PR DESCRIPTION
We have migrated Rock Paper Scissors, so the warning non longer applies. 