### PR TITLE
client-api-schema: bump version and publish tag

### DIFF
--- a/packages/channel-client/package.json
+++ b/packages/channel-client/package.json
@@ -5,7 +5,7 @@
   "author": "snario <liam@l4v.io>",
   "dependencies": {
     "@statechannels/channel-provider": "*",
-    "@statechannels/client-api-schema": "0.0.1",
+    "@statechannels/client-api-schema": "0.0.3",
     "ethers": "4.0.45",
     "eventemitter3": "4.0.0"
   },

--- a/packages/channel-provider/package.json
+++ b/packages/channel-provider/package.json
@@ -20,7 +20,7 @@
     "pino": "6.2.0"
   },
   "devDependencies": {
-    "@statechannels/client-api-schema": "0.0.1",
+    "@statechannels/client-api-schema": "0.0.3",
     "@types/debug": "4.1.5",
     "@types/eslint": "6.1.7",
     "@types/eslint-plugin-prettier": "2.2.0",

--- a/packages/client-api-schema/package.json
+++ b/packages/client-api-schema/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@statechannels/client-api-schema",
   "description": "JSON-RPC Schema and TypeScript typings for the State Channels Client API",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "author": "snario <liam@l4v.io>",
   "contributors": [
     "Alex Gap <alex.gap@consensys.net>",

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -5,7 +5,7 @@
   "author": "snario <liam@l4v.io>",
   "devDependencies": {
     "@statechannels/channel-provider": "*",
-    "@statechannels/client-api-schema": "0.0.1",
+    "@statechannels/client-api-schema": "0.0.3",
     "@statechannels/devtools": "0.1.4",
     "@types/eslint": "6.1.7",
     "@types/eslint-plugin-prettier": "2.2.0",

--- a/packages/persistent-seeder/package.json
+++ b/packages/persistent-seeder/package.json
@@ -5,7 +5,7 @@
   "author": "snario <liam@l4v.io>",
   "devDependencies": {
     "@statechannels/channel-provider": "*",
-    "@statechannels/client-api-schema": "0.0.1",
+    "@statechannels/client-api-schema": "0.0.3",
     "@statechannels/devtools": "0.1.4",
     "@types/eslint": "6.1.7",
     "@types/eslint-plugin-prettier": "2.2.0",

--- a/packages/rps/package.json
+++ b/packages/rps/package.json
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@babel/runtime": "7.8.3",
     "@statechannels/channel-provider": "*",
-    "@statechannels/client-api-schema": "0.0.1",
+    "@statechannels/client-api-schema": "0.0.3",
     "@statechannels/devtools": "0.1.4",
     "@statechannels/jest-gas-reporter": "0.0.2",
     "@storybook/react": "5.3.9",

--- a/packages/tic-tac-toe/package.json
+++ b/packages/tic-tac-toe/package.json
@@ -51,7 +51,7 @@
     "@fullhuman/postcss-purgecss": "2.1.0",
     "@glimmer/component": "1.0.0",
     "@glimmer/tracking": "1.0.0",
-    "@statechannels/client-api-schema": "0.0.1",
+    "@statechannels/client-api-schema": "0.0.3",
     "@statechannels/devtools": "0.1.4",
     "@statechannels/jest-gas-reporter": "0.0.2",
     "@types/autoprefixer": "9.6.1",

--- a/packages/xstate-wallet/package.json
+++ b/packages/xstate-wallet/package.json
@@ -25,7 +25,7 @@
     "@rimble/connection-banner": "1.2.3",
     "@rimble/utils": "1.2.3",
     "@sentry/browser": "5.15.5",
-    "@statechannels/client-api-schema": "0.0.1",
+    "@statechannels/client-api-schema": "0.0.3",
     "@statechannels/nitro-protocol": "0.1.4",
     "@statechannels/wallet-core": "0.0.8",
     "@statechannels/wire-format": "0.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4034,6 +4034,13 @@
   dependencies:
     type-detect "4.0.8"
 
+"@statechannels/client-api-schema@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/@statechannels/client-api-schema/-/client-api-schema-0.0.1.tgz#fa6bc51b9fa411981100eeddd771334aa4a0c682"
+  integrity sha512-IXx/gLfs7jEOkMo8azWRkuyN1u1Wt6+xmJcE9spqKZ1Owh2rTicJn9MkxMqUGm3Nyi+plaumq3tVuwFgXLM4fQ==
+  dependencies:
+    ajv "6.11.0"
+
 "@statechannels/wallet-core@0.0.8":
   version "0.0.8"
   resolved "https://registry.npmjs.org/@statechannels/wallet-core/-/wallet-core-0.0.8.tgz#c224418875ee68df0b7855f2c7bd3c4ed54a5718"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4034,13 +4034,6 @@
   dependencies:
     type-detect "4.0.8"
 
-"@statechannels/client-api-schema@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/@statechannels/client-api-schema/-/client-api-schema-0.0.1.tgz#fa6bc51b9fa411981100eeddd771334aa4a0c682"
-  integrity sha512-IXx/gLfs7jEOkMo8azWRkuyN1u1Wt6+xmJcE9spqKZ1Owh2rTicJn9MkxMqUGm3Nyi+plaumq3tVuwFgXLM4fQ==
-  dependencies:
-    ajv "6.11.0"
-
 "@statechannels/wallet-core@0.0.8":
   version "0.0.8"
   resolved "https://registry.npmjs.org/@statechannels/wallet-core/-/wallet-core-0.0.8.tgz#c224418875ee68df0b7855f2c7bd3c4ed54a5718"


### PR DESCRIPTION
https://github.com/statechannels/monorepo/releases/tag/client-api-schema%400.0.3

The new version mainly includes changes from https://github.com/statechannels/monorepo/pull/2296. 