### PR TITLE
[channel-client] Include entire tests directory in published package

### DIFF
--- a/packages/channel-client/package.json
+++ b/packages/channel-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@statechannels/channel-client",
   "description": "Browser-compatible JS client implementing the State Channels Client API",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "author": "snario <liam@l4v.io>",
   "dependencies": {
     "@statechannels/channel-provider": "*",
@@ -28,7 +28,7 @@
   },
   "files": [
     "lib/src",
-    "lib/tests/fakes/fake-channel-provider.js"
+    "lib/tests"
   ],
   "keywords": [
     "ethereum",


### PR DESCRIPTION
Entry point `channel-client` ends up indirectly importing more from the `tests` directory than initially thought. For example:
https://github.com/statechannels/monorepo/blob/c032fbcc8521dad43a6fd9952bb39650118cad24/packages/channel-client/src/channel-client.ts#L18