### PR TITLE
Publish @statechannels/channel-provider 0.0.5

### DIFF
--- a/packages/channel-provider/package.json
+++ b/packages/channel-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statechannels/channel-provider",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "browser": "dist/channel-provider.min.js",
   "browserslist": {
     "production": [


### PR DESCRIPTION
The previous version did not include the required types files.
