### PR TITLE
Remove import/order in .eslintrc of sub-packages

### DIFF
--- a/packages/nitro-protocol/.eslintrc.js
+++ b/packages/nitro-protocol/.eslintrc.js
@@ -16,23 +16,9 @@ module.exports = {
     browser: true,
     es6: true,
   },
-  plugins: ['jest', 'import'],
-  extends: [
-    '../../.eslintrc.js',
-    'plugin:jest/recommended',
-    'plugin:jest/style',
-    'plugin:import/errors',
-    'plugin:import/warnings',
-    'plugin:import/typescript',
-  ],
+  plugins: ['jest'],
+  extends: ['../../.eslintrc.js', 'plugin:jest/recommended', 'plugin:jest/style'],
   rules: {
-    'import/order': [
-      1,
-      {
-        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
-        'newlines-between': 'always',
-      },
-    ],
     ...leftoverTsLintRules,
   },
 };

--- a/packages/wallet-core/.eslintrc.js
+++ b/packages/wallet-core/.eslintrc.js
@@ -6,13 +6,6 @@ module.exports = {
   plugins: ['jest'],
   extends: ['../../.eslintrc.js', 'plugin:jest/recommended', 'plugin:jest/style'],
   rules: {
-    'import/order': [
-      1,
-      {
-        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
-        'newlines-between': 'always'
-      }
-    ],
     'no-process-env': 'error',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',


### PR DESCRIPTION
Top level has them so we don't need them
